### PR TITLE
build_dependencies: added libsigscan to LIBYAL_LIBRARIES

### DIFF
--- a/utils/build_dependencies.py
+++ b/utils/build_dependencies.py
@@ -2896,7 +2896,7 @@ class DependencyBuilder(object):
 
   _LIBYAL_LIBRARIES = frozenset([
       'libbde', 'libesedb', 'libevt', 'libevtx', 'libewf', 'libfwsi', 'liblnk',
-      'libmsiecf', 'libolecf', 'libqcow', 'libregf', 'libsmdev', 'libsmraw',
+      'libmsiecf', 'libolecf', 'libqcow', 'libregf', 'libsigscan', 'libsmdev', 'libsmraw',
       'libvhdi', 'libvmdk', 'libvshadow'])
 
   _PATCHES_URL = (


### PR DESCRIPTION
This adds libsigscan to the libraries that are built by build_dependencies, to fulfil dfvfs' requirements.