### PR TITLE
Update winevt_rc.py

### DIFF
--- a/plaso/formatters/winevt_rc.py
+++ b/plaso/formatters/winevt_rc.py
@@ -87,7 +87,13 @@ class Sqlite3DatabaseFile(object):
     sql_query = u'SELECT {1:s} FROM {0:s}{2:s}'.format(
         u', '.join(table_names), u', '.join(column_names), condition)
 
-    self._cursor.execute(sql_query)
+    # TODO: Current code errors out when condition contains unicode char
+    # Added Try/Except to keep it running - It should report the error to user
+    try:
+      self._cursor.execute(sql_query)
+    except sqlite3.OperationalError:
+      return False
+    
 
     # TODO: have a look at https://docs.python.org/2/library/
     # sqlite3.html#sqlite3.Row.


### PR DESCRIPTION
To fix crash issue related to line 90. When a condition uses a unicode character a sqlite3.OperationalError is raised crashing psort.py. I added the try/except block to keep things moving. In my version i printed the sql query to the terminal, however I think the gurus can come up with a more graceful error mechanism.