### PR TITLE
266050043: Fix to get Timesketch output to deal with tagged events correctly.

### DIFF
--- a/plaso/output/timesketch_out.py
+++ b/plaso/output/timesketch_out.py
@@ -98,7 +98,7 @@ class TimesketchOutputModule(interface.OutputModule):
     event_values[u'message'] = message
 
     try:
-      tags = [tag for tag in event_values[u'tag'].tags]
+      tags = list(event_values[u'tag'].tags)
     except (KeyError, AttributeError):
       tags = []
     event_values[u'tag'] = tags

--- a/plaso/output/timesketch_out.py
+++ b/plaso/output/timesketch_out.py
@@ -97,6 +97,12 @@ class TimesketchOutputModule(interface.OutputModule):
 
     event_values[u'message'] = message
 
+    try:
+      tags = [tag for tag in event_values[u'tag'].tags]
+    except (KeyError, AttributeError):
+      tags = []
+    event_values[u'tag'] = tags
+
     source_short, source = self._output_mediator.GetFormattedSources(
         event_object)
     if source is None or source_short is None:

--- a/tests/output/timesketch_out.py
+++ b/tests/output/timesketch_out.py
@@ -69,6 +69,10 @@ class TimesketchOutputModuleTest(test_lib.OutputModuleTestCase):
     self._event_timestamp = plaso_timestamp.CopyFromString(
         u'2012-06-27 18:17:01+00:00')
     self._event_object = TimesketchTestEvent(self._event_timestamp)
+    self._event_tag = event.EventTag()
+    self._event_tag.uuid = self._event_object.uuid
+    self._event_tag.tags = [u'Test tag']
+    self._event_object.tag = self._event_tag
 
     output_mediator = self._CreateOutputMediator()
     self._timesketch_output = timesketch_out.TimesketchOutputModule(
@@ -87,6 +91,7 @@ class TimesketchOutputModuleTest(test_lib.OutputModuleTestCase):
         u'data_type': u'syslog:line',
         u'source_long': u'Log File',
         u'source_short': u'LOG',
+        u'tag': [u'Test tag'],
         u'text': u'Reporter <CRON> PID: 8442 (pam_unix(cron:session): '
                  u'session\n closed for user root)',
         u'message': u'[',

--- a/tests/output/timesketch_out.py
+++ b/tests/output/timesketch_out.py
@@ -93,7 +93,7 @@ class TimesketchOutputModuleTest(test_lib.OutputModuleTestCase):
         u'source_short': u'LOG',
         u'tag': [u'Test tag'],
         u'text': (u'Reporter <CRON> PID: 8442 (pam_unix(cron:session): '
-                 u'session\n closed for user root)'),
+                  u'session\n closed for user root)'),
         u'message': u'[',
         u'datetime': u'2012-06-27T18:17:01+00:00'
     }

--- a/tests/output/timesketch_out.py
+++ b/tests/output/timesketch_out.py
@@ -92,8 +92,8 @@ class TimesketchOutputModuleTest(test_lib.OutputModuleTestCase):
         u'source_long': u'Log File',
         u'source_short': u'LOG',
         u'tag': [u'Test tag'],
-        u'text': u'Reporter <CRON> PID: 8442 (pam_unix(cron:session): '
-                 u'session\n closed for user root)',
+        u'text': (u'Reporter <CRON> PID: 8442 (pam_unix(cron:session): '
+                 u'session\n closed for user root)'),
         u'message': u'[',
         u'datetime': u'2012-06-27T18:17:01+00:00'
     }


### PR DESCRIPTION
[Code review: 266050043: Fix to get Timesketch output to deal with tagged events correctly.](https://codereview.appspot.com/266050043/)