### PR TITLE
293750043: Set terminal locale to UTF-8 in Docker. Fixes #625.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@
 /.review
 ._code_review_number
 
+# Pycharm files
+/.idea
+
 # Test files
 .coverage
 tests-coverage.txt

--- a/config/docker/plaso-from-ppa.dockerfile
+++ b/config/docker/plaso-from-ppa.dockerfile
@@ -16,6 +16,12 @@ RUN apt-get update && apt-get -y upgrade
 RUN apt-get -y install python-plaso
 RUN apt-get clean &&  rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
+# Set terminal to UTF-8 by default
+RUN locale-gen en_US.UTF-8
+RUN update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
 WORKDIR /usr/local/bin
 COPY "plaso-switch.sh" "plaso-switch.sh"
 RUN chmod a+x plaso-switch.sh


### PR DESCRIPTION
[Code review: 293750043: Set terminal locale to UTF-8 in Docker. Fixes #625.](https://codereview.appspot.com/293750043/)