### PR TITLE
326030043: Generate an error in mediator instead of raising ParseError on 'dirty' journal files.

### DIFF
--- a/plaso/parsers/systemd_journal.py
+++ b/plaso/parsers/systemd_journal.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 """Parser for Systemd journal files."""
 
+import os
 try:
   import lzma
 except ImportError:
   lzma = None
-
-import os
 
 import construct
 

--- a/plaso/parsers/systemd_journal.py
+++ b/plaso/parsers/systemd_journal.py
@@ -324,6 +324,11 @@ class SystemdJournalParser(interface.FileObjectParser):
     for entry_offset in entries_offsets:
       try:
         self._ParseJournalEntry(parser_mediator, file_object, entry_offset)
+      except errors.ParseError as exception:
+        parser_mediator.ProduceExtractionError((
+            u'Unable to complete parsing journal file: {0:s} at offset '
+            u'0x{1:08x}').format(exception, entry_offset))
+        return
       except construct.ConstructError as exception:
         raise errors.UnableToParseFile((
             u'Unable to parse journal header at offset: 0x{0:08x} with '

--- a/tests/parsers/systemd_journal.py
+++ b/tests/parsers/systemd_journal.py
@@ -9,7 +9,6 @@ except ImportError:
 
 import unittest
 
-from plaso.lib import errors
 from plaso.lib import timelib
 from plaso.parsers import systemd_journal
 

--- a/tests/parsers/systemd_journal.py
+++ b/tests/parsers/systemd_journal.py
@@ -67,10 +67,7 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
     file_entry = self._GetTestFileEntry(path_segments)
     file_object = file_entry.GetFileObject()
 
-    with self.assertRaisesRegexp(
-        errors.ParseError,
-        ur'object offset should be after hash tables \([0-9]+ < [0-9]+\)'):
-      parser.ParseFileObject(parser_mediator, file_object)
+    parser.ParseFileObject(parser_mediator, file_object)
 
     self.assertEqual(storage_writer.number_of_events, 2211)
 
@@ -89,6 +86,15 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
     expected_short_message = u'{0:s}...'.format(expected_message[:77])
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
+    self.assertEqual(storage_writer.number_of_errors, 1)
+
+    errors = list(storage_writer.GetErrors())
+    error = errors[0]
+    expected_error_message = (
+        u'Unable to complete parsing journal file: '
+        u'object offset should be after hash tables (4308912 < 2527472) at '
+        u'offset 0x0041bfb0')
+    self.assertEqual(error.message, expected_error_message)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/parsers/systemd_journal.py
+++ b/tests/parsers/systemd_journal.py
@@ -2,12 +2,12 @@
 # -*- coding: utf-8 -*-
 """Tests for the Systemd Journal parser."""
 
+import unittest
+
 try:
   import lzma
 except ImportError:
   lzma = None
-
-import unittest
 
 from plaso.lib import timelib
 from plaso.parsers import systemd_journal


### PR DESCRIPTION
[Code review: 326030043: Generate an error in mediator instead of raising ParseError on 'dirty' journal files.](https://codereview.appspot.com/326030043/)