### PR TITLE
322370043: Changed to setup.py to exclude non-script files from bdist_rpm #1299

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,8 +110,29 @@ else:
           in_description = True
 
         elif line.startswith('%files'):
-          line = '%files -f INSTALLED_FILES -n {0:s}-%{{name}}'.format(
-              python_package)
+          # Cannot use %{_libdir} here since it can expand to "lib64".
+          lines = [
+              '%files',
+              '%defattr(644,root,root,755)',
+              '%doc ACKNOWLEDGEMENTS AUTHORS LICENSE README',
+              '%{_prefix}/bin/*.py',
+              '%{_prefix}/lib/python*/site-packages/plaso/*.py',
+              '%{_prefix}/lib/python*/site-packages/plaso/*/*.py',
+              '%{_prefix}/lib/python*/site-packages/plaso/*/*/*.py',
+              '%{_prefix}/lib/python*/site-packages/plaso*.egg-info/*',
+              '%{_prefix}/share/plaso/*',
+              '%exclude %{_prefix}/lib/python*/site-packages/plaso/*.pyc',
+              '%exclude %{_prefix}/lib/python*/site-packages/plaso/*.pyo',
+              '%exclude %{_prefix}/lib/python*/site-packages/plaso/__pycache__/*',
+              '%exclude %{_prefix}/lib/python*/site-packages/plaso/*/*.pyc',
+              '%exclude %{_prefix}/lib/python*/site-packages/plaso/*/*.pyo',
+              '%exclude %{_prefix}/lib/python*/site-packages/plaso/*/__pycache__/*',
+              '%exclude %{_prefix}/lib/python*/site-packages/plaso/*/*/*.pyc',
+              '%exclude %{_prefix}/lib/python*/site-packages/plaso/*/*/*.pyo',
+              '%exclude %{_prefix}/lib/python*/site-packages/plaso/*/*/__pycache__/*']
+
+          python_spec_file.extend(lines)
+          break
 
         elif line.startswith('%prep'):
           in_description = False


### PR DESCRIPTION
[Code review: 322370043: Changed to setup.py to exclude non-script files from bdist_rpm #1299](https://codereview.appspot.com/322370043/)