### PR TITLE
330570043: Made Unicode strings the default in bencode, cookie, ESEDB, OLECF, plist and syslog parser plugins tests #1268

### DIFF
--- a/tests/parsers/bencode_plugins/test_lib.py
+++ b/tests/parsers/bencode_plugins/test_lib.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Bencode plugin related functions and classes for testing."""
 
+from __future__ import unicode_literals
+
 from tests.parsers import test_lib
 
 

--- a/tests/parsers/bencode_plugins/transmission.py
+++ b/tests/parsers/bencode_plugins/transmission.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 
 import unittest
 
-from plaso.formatters import bencode_parser  # pylint: disable=unused-import
+from plaso.formatters import bencode_parser as _  # pylint: disable=unused-import
 from plaso.lib import definitions
 from plaso.lib import timelib
 from plaso.parsers import bencode_parser

--- a/tests/parsers/bencode_plugins/transmission.py
+++ b/tests/parsers/bencode_plugins/transmission.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the bencode parser plugin for Transmission BitTorrent files."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import bencode_parser  # pylint: disable=unused-import
@@ -16,11 +18,11 @@ from tests.parsers.bencode_plugins import test_lib
 class BencodeTest(test_lib.BencodePluginTestCase):
   """Tests for bencode parser plugin for Transmission BitTorrent files."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'bencode_transmission'])
+  @shared_test_lib.skipUnlessHasTestFile(['bencode_transmission'])
   def testProcess(self):
     """Tests the Process function."""
     parser = bencode_parser.BencodeParser()
-    storage_writer = self._ParseFile([u'bencode_transmission'], parser)
+    storage_writer = self._ParseFile(['bencode_transmission'], parser)
 
     self.assertEqual(storage_writer.number_of_events, 3)
 
@@ -30,7 +32,7 @@ class BencodeTest(test_lib.BencodePluginTestCase):
 
     event = events[0]
 
-    expected_destination = u'/Users/brian/Downloads'
+    expected_destination = '/Users/brian/Downloads'
     self.assertEqual(event.destination, expected_destination)
 
     self.assertEqual(event.seedtime, 4)
@@ -39,7 +41,7 @@ class BencodeTest(test_lib.BencodePluginTestCase):
     self.assertEqual(event.timestamp_desc, expected_description)
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2013-11-08 15:31:20')
+        '2013-11-08 15:31:20')
     self.assertEqual(event.timestamp, expected_timestamp)
 
     # Test on second event of first torrent.
@@ -51,7 +53,7 @@ class BencodeTest(test_lib.BencodePluginTestCase):
     self.assertEqual(event.timestamp_desc, expected_description)
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2013-11-08 18:24:24')
+        '2013-11-08 18:24:24')
     self.assertEqual(event.timestamp, expected_timestamp)
 
 

--- a/tests/parsers/bencode_plugins/utorrent.py
+++ b/tests/parsers/bencode_plugins/utorrent.py
@@ -6,7 +6,8 @@ from __future__ import unicode_literals
 
 import unittest
 
-from plaso.formatters import bencode_parser  # pylint: disable=unused-import
+# pylint: disable=unused-import
+from plaso.formatters import bencode_parser as _
 from plaso.lib import definitions
 from plaso.lib import timelib
 from plaso.parsers import bencode_parser

--- a/tests/parsers/bencode_plugins/utorrent.py
+++ b/tests/parsers/bencode_plugins/utorrent.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the bencode parser plugin for uTorrent files."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import bencode_parser  # pylint: disable=unused-import
@@ -16,11 +18,11 @@ from tests.parsers.bencode_plugins import test_lib
 class UTorrentPluginTest(test_lib.BencodePluginTestCase):
   """Tests for bencode parser plugin for uTorrent files."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'bencode_utorrent'])
+  @shared_test_lib.skipUnlessHasTestFile(['bencode_utorrent'])
   def testProcess(self):
     """Tests the Process function."""
     parser = bencode_parser.BencodeParser()
-    storage_writer = self._ParseFile([u'bencode_utorrent'], parser)
+    storage_writer = self._ParseFile(['bencode_utorrent'], parser)
 
     self.assertEqual(storage_writer.number_of_events, 4)
 
@@ -28,8 +30,8 @@ class UTorrentPluginTest(test_lib.BencodePluginTestCase):
     # hence we sort the events.
     events = list(storage_writer.GetSortedEvents())
 
-    expected_caption = u'plaso test'
-    expected_path = u'e:\\torrent\\files\\plaso test'
+    expected_caption = 'plaso test'
+    expected_path = 'e:\\torrent\\files\\plaso test'
 
     # First test on when the torrent was added to the client.
     event = events[0]
@@ -42,7 +44,7 @@ class UTorrentPluginTest(test_lib.BencodePluginTestCase):
     self.assertEqual(event.timestamp_desc, expected_description)
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2013-08-03 14:52:12')
+        '2013-08-03 14:52:12')
     self.assertEqual(event.timestamp, expected_timestamp)
 
     # Second test on when the torrent file was completely downloaded.
@@ -56,7 +58,7 @@ class UTorrentPluginTest(test_lib.BencodePluginTestCase):
     self.assertEqual(event.timestamp_desc, expected_description)
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2013-08-03 18:11:35')
+        '2013-08-03 18:11:35')
     self.assertEqual(event.timestamp, expected_timestamp)
 
     # Third test on when the torrent was first modified.
@@ -70,7 +72,7 @@ class UTorrentPluginTest(test_lib.BencodePluginTestCase):
     self.assertEqual(event.timestamp_desc, expected_description)
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2013-08-03 18:11:34')
+        '2013-08-03 18:11:34')
     self.assertEqual(event.timestamp, expected_timestamp)
 
     # Fourth test on when the torrent was again modified.
@@ -84,7 +86,7 @@ class UTorrentPluginTest(test_lib.BencodePluginTestCase):
     self.assertEqual(event.timestamp_desc, expected_description)
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2013-08-03 16:27:59')
+        '2013-08-03 16:27:59')
     self.assertEqual(event.timestamp, expected_timestamp)
 
 

--- a/tests/parsers/cookie_plugins/ganalytics.py
+++ b/tests/parsers/cookie_plugins/ganalytics.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 
 import unittest
 
-from plaso.formatters import ganalytics  # pylint: disable=unused-import
+from plaso.formatters import ganalytics as _  # pylint: disable=unused-import
 from plaso.lib import definitions
 from plaso.lib import timelib
 from plaso.parsers.cookie_plugins import ganalytics

--- a/tests/parsers/cookie_plugins/ganalytics.py
+++ b/tests/parsers/cookie_plugins/ganalytics.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the Google Analytics cookies."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import ganalytics  # pylint: disable=unused-import
@@ -26,16 +28,16 @@ class GoogleAnalyticsPluginTest(sqlite_plugins_test_lib.SQLitePluginTestCase):
     """
     cookies = []
     for event in storage_writer.GetEvents():
-      if event.data_type.startswith(u'cookie:google:analytics'):
+      if event.data_type.startswith('cookie:google:analytics'):
         cookies.append(event)
     return cookies
 
-  @shared_test_lib.skipUnlessHasTestFile([u'firefox_cookies.sqlite'])
+  @shared_test_lib.skipUnlessHasTestFile(['firefox_cookies.sqlite'])
   def testParsingFirefox29CookieDatabase(self):
     """Tests the Process function on a Firefox 29 cookie database file."""
     plugin = firefox_cookies.FirefoxCookiePlugin()
     storage_writer = self._ParseDatabaseFileWithPlugin(
-        [u'firefox_cookies.sqlite'], plugin)
+        ['firefox_cookies.sqlite'], plugin)
     events = self._GetAnalyticsCookieEvents(storage_writer)
 
     self.assertEqual(len(events), 25)
@@ -44,29 +46,29 @@ class GoogleAnalyticsPluginTest(sqlite_plugins_test_lib.SQLitePluginTestCase):
 
     self.assertEqual(
         event.utmcct,
-        u'/frettir/erlent/2013/10/30/maelt_med_kerfisbundnum_hydingum/')
+        '/frettir/erlent/2013/10/30/maelt_med_kerfisbundnum_hydingum/')
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2013-10-30 21:56:06')
+        '2013-10-30 21:56:06')
     self.assertEqual(event.timestamp, expected_timestamp)
-    self.assertEqual(event.url, u'http://ads.aha.is/')
-    self.assertEqual(event.utmcsr, u'mbl.is')
+    self.assertEqual(event.url, 'http://ads.aha.is/')
+    self.assertEqual(event.utmcsr, 'mbl.is')
 
     expected_message = (
-        u'http://ads.aha.is/ (__utmz) Sessions: 1 Domain Hash: 137167072 '
-        u'Sources: 1 Last source used to access: mbl.is Ad campaign '
-        u'information: (referral) Last type of visit: referral Path to '
-        u'the page of referring link: /frettir/erlent/2013/10/30/'
-        u'maelt_med_kerfisbundnum_hydingum/')
-    expected_short_message = u'http://ads.aha.is/ (__utmz)'
+        'http://ads.aha.is/ (__utmz) Sessions: 1 Domain Hash: 137167072 '
+        'Sources: 1 Last source used to access: mbl.is Ad campaign '
+        'information: (referral) Last type of visit: referral Path to '
+        'the page of referring link: /frettir/erlent/2013/10/30/'
+        'maelt_med_kerfisbundnum_hydingum/')
+    expected_short_message = 'http://ads.aha.is/ (__utmz)'
 
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
-  @shared_test_lib.skipUnlessHasTestFile([u'cookies.db'])
+  @shared_test_lib.skipUnlessHasTestFile(['cookies.db'])
   def testParsingChromeCookieDatabase(self):
     """Test the process function on a Chrome cookie database."""
     plugin = chrome_cookies.ChromeCookiePlugin()
     storage_writer = self._ParseDatabaseFileWithPlugin(
-        [u'cookies.db'], plugin)
+        ['cookies.db'], plugin)
     events = self._GetAnalyticsCookieEvents(storage_writer)
 
     # The cookie database contains 560 entries in total. Out of them
@@ -76,36 +78,36 @@ class GoogleAnalyticsPluginTest(sqlite_plugins_test_lib.SQLitePluginTestCase):
 
     # Check an UTMZ Google Analytics event.
     event = events[39]
-    self.assertEqual(event.utmctr, u'enders game')
-    self.assertEqual(event.domain_hash, u'68898382')
+    self.assertEqual(event.utmctr, 'enders game')
+    self.assertEqual(event.domain_hash, '68898382')
     self.assertEqual(event.sessions, 1)
 
     expected_message = (
-        u'http://imdb.com/ (__utmz) Sessions: 1 Domain Hash: 68898382 '
-        u'Sources: 1 Last source used to access: google Ad campaign '
-        u'information: (organic) Last type of visit: organic Keywords '
-        u'used to find site: enders game')
-    expected_short_message = u'http://imdb.com/ (__utmz)'
+        'http://imdb.com/ (__utmz) Sessions: 1 Domain Hash: 68898382 '
+        'Sources: 1 Last source used to access: google Ad campaign '
+        'information: (organic) Last type of visit: organic Keywords '
+        'used to find site: enders game')
+    expected_short_message = 'http://imdb.com/ (__utmz)'
 
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
     # Check the UTMA Google Analytics event.
     event = events[41]
-    self.assertEqual(event.timestamp_desc, u'Analytics Previous Time')
-    self.assertEqual(event.cookie_name, u'__utma')
-    self.assertEqual(event.visitor_id, u'1827102436')
+    self.assertEqual(event.timestamp_desc, 'Analytics Previous Time')
+    self.assertEqual(event.cookie_name, '__utma')
+    self.assertEqual(event.visitor_id, '1827102436')
     self.assertEqual(event.sessions, 2)
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2012-03-22 01:55:29')
+        '2012-03-22 01:55:29')
     self.assertEqual(event.timestamp, expected_timestamp)
 
     expected_message = (
-        u'http://assets.tumblr.com/ (__utma) '
-        u'Sessions: 2 '
-        u'Domain Hash: 151488169 '
-        u'Visitor ID: 1827102436')
-    expected_short_message = u'http://assets.tumblr.com/ (__utma)'
+        'http://assets.tumblr.com/ (__utma) '
+        'Sessions: 2 '
+        'Domain Hash: 151488169 '
+        'Visitor ID: 1827102436')
+    expected_short_message = 'http://assets.tumblr.com/ (__utma)'
 
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
@@ -113,18 +115,18 @@ class GoogleAnalyticsPluginTest(sqlite_plugins_test_lib.SQLitePluginTestCase):
     event = events[34]
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_LAST_VISITED)
-    self.assertEqual(event.cookie_name, u'__utmb')
-    self.assertEqual(event.domain_hash, u'154523900')
+    self.assertEqual(event.cookie_name, '__utmb')
+    self.assertEqual(event.domain_hash, '154523900')
     self.assertEqual(event.pages_viewed, 1)
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2012-03-22 01:48:30')
+        '2012-03-22 01:48:30')
     self.assertEqual(event.timestamp, expected_timestamp)
 
     expected_message = (
-        u'http://upressonline.com/ (__utmb) Pages Viewed: 1 Domain Hash: '
-        u'154523900')
-    expected_short_message = u'http://upressonline.com/ (__utmb)'
+        'http://upressonline.com/ (__utmb) Pages Viewed: 1 Domain Hash: '
+        '154523900')
+    expected_short_message = 'http://upressonline.com/ (__utmb)'
 
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 

--- a/tests/parsers/cookie_plugins/manager.py
+++ b/tests/parsers/cookie_plugins/manager.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the cookie plugins manager."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.parsers.cookie_plugins import interface
@@ -11,8 +13,8 @@ from plaso.parsers.cookie_plugins import manager
 class TestCookiePlugin(interface.BaseCookiePlugin):
   """Test cookie plugin."""
 
-  NAME = u'test_cookie_plugin'
-  DESCRIPTION = u'Test cookie plugin.'
+  NAME = 'test_cookie_plugin'
+  DESCRIPTION = 'Test cookie plugin.'
 
   def GetEntries(
       self, unused_parser_mediator, cookie_data=None, url=None, **kwargs):

--- a/tests/parsers/cookie_plugins/test_lib.py
+++ b/tests/parsers/cookie_plugins/test_lib.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Browser cookie plugin related functions and classes for testing."""
 
+from __future__ import unicode_literals
+
 from tests.parsers import test_lib
 
 

--- a/tests/parsers/esedb_plugins/file_history.py
+++ b/tests/parsers/esedb_plugins/file_history.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 
 import unittest
 
-from plaso.formatters import file_history  # pylint: disable=unused-import
+from plaso.formatters import file_history as _  # pylint: disable=unused-import
 from plaso.lib import definitions
 from plaso.lib import timelib
 from plaso.parsers.esedb_plugins import file_history

--- a/tests/parsers/esedb_plugins/file_history.py
+++ b/tests/parsers/esedb_plugins/file_history.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the File History ESE database file."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import file_history  # pylint: disable=unused-import
@@ -16,12 +18,12 @@ from tests.parsers.esedb_plugins import test_lib
 class FileHistoryESEDBPluginTest(test_lib.ESEDBPluginTestCase):
   """Tests for the File History ESE database plugin."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'Catalog1.edb'])
+  @shared_test_lib.skipUnlessHasTestFile(['Catalog1.edb'])
   def testProcess(self):
     """Tests the Process function."""
     plugin = file_history.FileHistoryESEDBPlugin()
     storage_writer = self._ParseESEDBFileWithPlugin(
-        [u'Catalog1.edb'], plugin)
+        ['Catalog1.edb'], plugin)
 
     self.assertEqual(storage_writer.number_of_events, 2713)
 
@@ -33,23 +35,23 @@ class FileHistoryESEDBPluginTest(test_lib.ESEDBPluginTestCase):
     self.assertEqual(event.identifier, 356)
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2013-10-12 17:34:36.688580')
+        '2013-10-12 17:34:36.688580')
 
     self.assertEqual(event.timestamp, expected_timestamp)
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_MODIFICATION)
 
-    filename = u'?UP\\Favorites\\Links\\Lenovo'
+    filename = '?UP\\Favorites\\Links\\Lenovo'
     self.assertEqual(event.original_filename, filename)
 
     expected_message = (
-        u'Filename: {0:s} '
-        u'Identifier: 356 '
-        u'Parent Identifier: 230 '
-        u'Attributes: 16 '
-        u'USN number: 9251162904').format(filename)
+        'Filename: {0:s} '
+        'Identifier: 356 '
+        'Parent Identifier: 230 '
+        'Attributes: 16 '
+        'USN number: 9251162904').format(filename)
 
-    expected_short_message = u'Filename: {0:s}'.format(filename)
+    expected_short_message = 'Filename: {0:s}'.format(filename)
 
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 

--- a/tests/parsers/esedb_plugins/msie_webcache.py
+++ b/tests/parsers/esedb_plugins/msie_webcache.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 
 import unittest
 
-from plaso.formatters import msie_webcache  # pylint: disable=unused-import
+from plaso.formatters import msie_webcache as _  # pylint: disable=unused-import
 from plaso.lib import definitions
 from plaso.lib import timelib
 from plaso.parsers.esedb_plugins import msie_webcache

--- a/tests/parsers/esedb_plugins/msie_webcache.py
+++ b/tests/parsers/esedb_plugins/msie_webcache.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the Microsoft Internet Explorer WebCache database."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import msie_webcache  # pylint: disable=unused-import
@@ -16,12 +18,12 @@ from tests.parsers.esedb_plugins import test_lib
 class MsieWebCacheESEDBPluginTest(test_lib.ESEDBPluginTestCase):
   """Tests for the MSIE WebCache ESE database plugin."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'WebCacheV01.dat'])
+  @shared_test_lib.skipUnlessHasTestFile(['WebCacheV01.dat'])
   def testProcess(self):
     """Tests the Process function."""
     plugin = msie_webcache.MsieWebCacheESEDBPlugin()
     storage_writer = self._ParseESEDBFileWithPlugin(
-        [u'WebCacheV01.dat'], plugin)
+        ['WebCacheV01.dat'], plugin)
 
     self.assertEqual(storage_writer.number_of_events, 1354)
 
@@ -34,21 +36,21 @@ class MsieWebCacheESEDBPluginTest(test_lib.ESEDBPluginTestCase):
     self.assertEqual(event.container_identifier, 1)
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2014-05-12 07:30:25.486198')
+        '2014-05-12 07:30:25.486198')
     self.assertEqual(event.timestamp, expected_timestamp)
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_LAST_ACCESS)
 
     expected_message = (
-        u'Container identifier: 1 '
-        u'Set identifier: 0 '
-        u'Name: Content '
-        u'Directory: C:\\Users\\test\\AppData\\Local\\Microsoft\\Windows\\'
-        u'INetCache\\IE\\ '
-        u'Table: Container_1')
+        'Container identifier: 1 '
+        'Set identifier: 0 '
+        'Name: Content '
+        'Directory: C:\\Users\\test\\AppData\\Local\\Microsoft\\Windows\\'
+        'INetCache\\IE\\ '
+        'Table: Container_1')
     expected_short_message = (
-        u'Directory: C:\\Users\\test\\AppData\\Local\\Microsoft\\Windows\\'
-        u'INetCache\\IE\\')
+        'Directory: C:\\Users\\test\\AppData\\Local\\Microsoft\\Windows\\'
+        'INetCache\\IE\\')
 
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 

--- a/tests/parsers/esedb_plugins/test_lib.py
+++ b/tests/parsers/esedb_plugins/test_lib.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """ESEDB plugin related functions and classes for testing."""
 
+from __future__ import unicode_literals
+
 import pyesedb
 
 from plaso.containers import sessions
@@ -11,21 +13,20 @@ from tests.parsers import test_lib
 
 
 class ESEDBPluginTestCase(test_lib.ParserTestCase):
-  """The unit test case for ESE database based plugins."""
+  """ESE database-based plugin test case."""
 
   def _ParseESEDBFileWithPlugin(
       self, path_segments, plugin, knowledge_base_values=None):
     """Parses a file as an ESE database file and returns an event generator.
 
     Args:
-      path_segments: a list of strings containinge the path segments inside
-                     the test data directory.
-      plugin: an ESE database plugin object (instance of ESEDBPlugin).
-      knowledge_base_values: optional dictionary containing the knowledge base
-                             values.
+      path_segments (list[str]): path segments inside the test data directory.
+      plugin (ESEDBPlugin): ESE database plugin.
+      knowledge_base_values (Optional[dict[str, object]]): knowledge base
+          values.
 
     Returns:
-      A storage writer object (instance of FakeStorageWriter).
+      FakeStorageWriter: storage writer.
     """
     session = sessions.Session()
     storage_writer = fake_storage.FakeStorageWriter(session)

--- a/tests/parsers/olecf_plugins/automatic_destinations.py
+++ b/tests/parsers/olecf_plugins/automatic_destinations.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the .automaticDestinations-ms OLECF parser plugin."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import olecf  # pylint: disable=unused-import
@@ -17,12 +19,12 @@ class TestAutomaticDestinationsOLECFPlugin(test_lib.OLECFPluginTestCase):
   """Tests for the .automaticDestinations-ms OLECF parser plugin."""
 
   @shared_test_lib.skipUnlessHasTestFile([
-      u'1b4dd67f29cb1962.automaticDestinations-ms'])
+      '1b4dd67f29cb1962.automaticDestinations-ms'])
   def testProcessVersion1(self):
     """Tests the Process function on version 1 .automaticDestinations-ms."""
     plugin = automatic_destinations.AutomaticDestinationsOLECFPlugin()
     storage_writer = self._ParseOLECFFileWithPlugin(
-        [u'1b4dd67f29cb1962.automaticDestinations-ms'], plugin)
+        ['1b4dd67f29cb1962.automaticDestinations-ms'], plugin)
 
     self.assertEqual(storage_writer.number_of_events, 88)
 
@@ -32,30 +34,30 @@ class TestAutomaticDestinationsOLECFPlugin(test_lib.OLECFPluginTestCase):
     event = events[7]
 
     self.assertEqual(event.offset, 32)
-    self.assertEqual(event.data_type, u'olecf:dest_list:entry')
+    self.assertEqual(event.data_type, 'olecf:dest_list:entry')
 
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_MODIFICATION)
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2012-04-01 13:52:38.997538')
+        '2012-04-01 13:52:38.997538')
     self.assertEqual(event.timestamp, expected_timestamp)
 
     expected_message = (
-        u'Entry: 11 '
-        u'Pin status: Unpinned '
-        u'Hostname: wks-win764bitb '
-        u'Path: C:\\Users\\nfury\\Pictures\\The SHIELD '
-        u'Droid volume identifier: {cf6619c2-66a8-44a6-8849-1582fcd3a338} '
-        u'Droid file identifier: {63eea867-7b85-11e1-8950-005056a50b40} '
-        u'Birth droid volume identifier: '
-        u'{cf6619c2-66a8-44a6-8849-1582fcd3a338} '
-        u'Birth droid file identifier: {63eea867-7b85-11e1-8950-005056a50b40}')
+        'Entry: 11 '
+        'Pin status: Unpinned '
+        'Hostname: wks-win764bitb '
+        'Path: C:\\Users\\nfury\\Pictures\\The SHIELD '
+        'Droid volume identifier: {cf6619c2-66a8-44a6-8849-1582fcd3a338} '
+        'Droid file identifier: {63eea867-7b85-11e1-8950-005056a50b40} '
+        'Birth droid volume identifier: '
+        '{cf6619c2-66a8-44a6-8849-1582fcd3a338} '
+        'Birth droid file identifier: {63eea867-7b85-11e1-8950-005056a50b40}')
 
     expected_short_message = (
-        u'Entry: 11 '
-        u'Pin status: Unpinned '
-        u'Path: C:\\Users\\nfury\\Pictures\\The SHIELD')
+        'Entry: 11 '
+        'Pin status: Unpinned '
+        'Path: C:\\Users\\nfury\\Pictures\\The SHIELD')
 
     self._TestGetMessageStrings(
         event, expected_message, expected_short_message)
@@ -63,25 +65,25 @@ class TestAutomaticDestinationsOLECFPlugin(test_lib.OLECFPluginTestCase):
     # Check a WinLnkLinkEvent.
     event = events[1]
 
-    self.assertEqual(event.data_type, u'windows:lnk:link')
+    self.assertEqual(event.data_type, 'windows:lnk:link')
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2010-11-10 07:51:16.749125')
+        '2010-11-10 07:51:16.749125')
     self.assertEqual(event.timestamp, expected_timestamp)
 
     expected_message = (
-        u'[Empty description] '
-        u'File size: 3545 '
-        u'File attribute flags: 0x00002020 '
-        u'Drive type: 3 '
-        u'Drive serial number: 0x24ba718b '
-        u'Local path: C:\\Users\\nfury\\AppData\\Roaming\\Microsoft\\Windows\\'
-        u'Libraries\\Documents.library-ms '
-        u'Link target: <Users Libraries> <UNKNOWN: 0x00>')
+        '[Empty description] '
+        'File size: 3545 '
+        'File attribute flags: 0x00002020 '
+        'Drive type: 3 '
+        'Drive serial number: 0x24ba718b '
+        'Local path: C:\\Users\\nfury\\AppData\\Roaming\\Microsoft\\Windows\\'
+        'Libraries\\Documents.library-ms '
+        'Link target: <Users Libraries> <UNKNOWN: 0x00>')
 
     expected_short_message = (
-        u'[Empty description] '
-        u'C:\\Users\\nfury\\AppData\\Roaming\\Microsoft\\Windows\\Librarie...')
+        '[Empty description] '
+        'C:\\Users\\nfury\\AppData\\Roaming\\Microsoft\\Windows\\Librarie...')
 
     self._TestGetMessageStrings(
         event, expected_message, expected_short_message)
@@ -90,31 +92,31 @@ class TestAutomaticDestinationsOLECFPlugin(test_lib.OLECFPluginTestCase):
     event = events[5]
 
     self.assertEqual(
-        event.data_type, u'windows:distributed_link_tracking:creation')
+        event.data_type, 'windows:distributed_link_tracking:creation')
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2012-03-31 23:01:03.527741')
+        '2012-03-31 23:01:03.527741')
     self.assertEqual(event.timestamp, expected_timestamp)
 
     expected_message = (
-        u'63eea867-7b85-11e1-8950-005056a50b40 '
-        u'MAC address: 00:50:56:a5:0b:40 '
-        u'Origin: DestList entry at offset: 0x00000020')
+        '63eea867-7b85-11e1-8950-005056a50b40 '
+        'MAC address: 00:50:56:a5:0b:40 '
+        'Origin: DestList entry at offset: 0x00000020')
 
     expected_short_message = (
-        u'63eea867-7b85-11e1-8950-005056a50b40 '
-        u'Origin: DestList entry at offset: 0x0000...')
+        '63eea867-7b85-11e1-8950-005056a50b40 '
+        'Origin: DestList entry at offset: 0x0000...')
 
     self._TestGetMessageStrings(
         event, expected_message, expected_short_message)
 
   @shared_test_lib.skipUnlessHasTestFile([
-      u'9d1f905ce5044aee.automaticDestinations-ms'])
+      '9d1f905ce5044aee.automaticDestinations-ms'])
   def testProcessVersion3(self):
     """Tests the Process function on version 3 .automaticDestinations-ms."""
     plugin = automatic_destinations.AutomaticDestinationsOLECFPlugin()
     storage_writer = self._ParseOLECFFileWithPlugin(
-        [u'9d1f905ce5044aee.automaticDestinations-ms'], plugin)
+        ['9d1f905ce5044aee.automaticDestinations-ms'], plugin)
 
     self.assertEqual(storage_writer.number_of_events, 4)
 
@@ -126,36 +128,36 @@ class TestAutomaticDestinationsOLECFPlugin(test_lib.OLECFPluginTestCase):
     event = events[1]
 
     self.assertEqual(event.offset, 32)
-    self.assertEqual(event.data_type, u'olecf:dest_list:entry')
+    self.assertEqual(event.data_type, 'olecf:dest_list:entry')
 
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_MODIFICATION)
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2016-01-17 13:08:08.247504')
+        '2016-01-17 13:08:08.247504')
     self.assertEqual(event.timestamp, expected_timestamp)
 
     expected_message = (
-        u'Entry: 2 '
-        u'Pin status: Unpinned '
-        u'Path: http://support.microsoft.com/kb/3124263 '
-        u'Droid volume identifier: {00000000-0000-0000-0000-000000000000} '
-        u'Droid file identifier: {00000000-0000-0000-0000-000000000000} '
-        u'Birth droid volume identifier: '
-        u'{00000000-0000-0000-0000-000000000000} '
-        u'Birth droid file identifier: {00000000-0000-0000-0000-000000000000}')
+        'Entry: 2 '
+        'Pin status: Unpinned '
+        'Path: http://support.microsoft.com/kb/3124263 '
+        'Droid volume identifier: {00000000-0000-0000-0000-000000000000} '
+        'Droid file identifier: {00000000-0000-0000-0000-000000000000} '
+        'Birth droid volume identifier: '
+        '{00000000-0000-0000-0000-000000000000} '
+        'Birth droid file identifier: {00000000-0000-0000-0000-000000000000}')
 
     expected_short_message = (
-        u'Entry: 2 '
-        u'Pin status: Unpinned '
-        u'Path: http://support.microsoft.com/kb/3124263')
+        'Entry: 2 '
+        'Pin status: Unpinned '
+        'Path: http://support.microsoft.com/kb/3124263')
 
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
     # Check a WinLnkLinkEvent.
     event = events[0]
 
-    self.assertEqual(event.data_type, u'windows:lnk:link')
+    self.assertEqual(event.data_type, 'windows:lnk:link')
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_NOT_A_TIME)
 

--- a/tests/parsers/olecf_plugins/default.py
+++ b/tests/parsers/olecf_plugins/default.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the OLE Compound File (OLECF) default plugin."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import olecf  # pylint: disable=unused-import
@@ -16,12 +18,12 @@ from tests.parsers.olecf_plugins import test_lib
 class TestDefaultPluginOLECF(test_lib.OLECFPluginTestCase):
   """Tests for the OLECF default plugin."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'Document.doc'])
+  @shared_test_lib.skipUnlessHasTestFile(['Document.doc'])
   def testProcess(self):
     """Tests the Process function."""
     plugin = default.DefaultOLECFPlugin()
     storage_writer = self._ParseOLECFFileWithPlugin(
-        [u'Document.doc'], plugin)
+        ['Document.doc'], plugin)
 
     self.assertEqual(storage_writer.number_of_events, 5)
 
@@ -30,28 +32,28 @@ class TestDefaultPluginOLECF(test_lib.OLECFPluginTestCase):
     # Check the Root Entry event.
     event = events[0]
 
-    self.assertEqual(event.name, u'Root Entry')
+    self.assertEqual(event.name, 'Root Entry')
 
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_MODIFICATION)
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2013-05-16 02:29:49.795')
+        '2013-05-16 02:29:49.795')
     self.assertEqual(event.timestamp, expected_timestamp)
 
     expected_string = (
-        u'Name: Root Entry')
+        'Name: Root Entry')
 
     self._TestGetMessageStrings(event, expected_string, expected_string)
 
     # Check one other entry.
     event = events[1]
 
-    expected_string = u'Name: MsoDataStore'
+    expected_string = 'Name: MsoDataStore'
     self._TestGetMessageStrings(event, expected_string, expected_string)
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2013-05-16 02:29:49.704')
+        '2013-05-16 02:29:49.704')
     self.assertEqual(event.timestamp, expected_timestamp)
 
 

--- a/tests/parsers/olecf_plugins/summary.py
+++ b/tests/parsers/olecf_plugins/summary.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the OLE Compound File summary and document summary plugins."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import olecf  # pylint: disable=unused-import
@@ -15,12 +17,12 @@ from tests.parsers.olecf_plugins import test_lib
 class TestSummaryInformationOLECFPlugin(test_lib.OLECFPluginTestCase):
   """Tests for the OLECF summary information plugin."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'Document.doc'])
+  @shared_test_lib.skipUnlessHasTestFile(['Document.doc'])
   def testProcess(self):
     """Tests the Process function on a Summary Information stream."""
     plugin = summary.SummaryInformationOLECFPlugin()
     storage_writer = self._ParseOLECFFileWithPlugin(
-        [u'Document.doc'], plugin)
+        ['Document.doc'], plugin)
 
     # There is one summary info stream with three event objects.
     self.assertEqual(storage_writer.number_of_events, 3)
@@ -28,41 +30,41 @@ class TestSummaryInformationOLECFPlugin(test_lib.OLECFPluginTestCase):
     events = list(storage_writer.GetSortedEvents())
 
     event = events[0]
-    self.assertEqual(event.name, u'Summary Information')
+    self.assertEqual(event.name, 'Summary Information')
 
-    self.assertEqual(event.title, u'Table of Context')
-    self.assertEqual(event.author, u'DAVID NIDES')
-    self.assertEqual(event.template, u'Normal.dotm')
-    self.assertEqual(event.last_saved_by, u'Nides')
-    self.assertEqual(event.revision_number, u'4')
+    self.assertEqual(event.title, 'Table of Context')
+    self.assertEqual(event.author, 'DAVID NIDES')
+    self.assertEqual(event.template, 'Normal.dotm')
+    self.assertEqual(event.last_saved_by, 'Nides')
+    self.assertEqual(event.revision_number, '4')
     self.assertEqual(event.number_of_characters, 18)
-    self.assertEqual(event.application, u'Microsoft Office Word')
+    self.assertEqual(event.application, 'Microsoft Office Word')
     self.assertEqual(event.security, 0)
 
-    self.assertEqual(event.timestamp_desc, u'Document Creation Time')
+    self.assertEqual(event.timestamp_desc, 'Document Creation Time')
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2012-12-10 18:38:00')
+        '2012-12-10 18:38:00')
     self.assertEqual(event.timestamp, expected_timestamp)
 
     expected_message = (
-        u'Title: Table of Context '
-        u'Author: DAVID NIDES '
-        u'Template: Normal.dotm '
-        u'Revision number: 4 '
-        u'Last saved by: Nides '
-        u'Number of pages: 1 '
-        u'Number of words: 3 '
-        u'Number of characters: 18 '
-        u'Application: Microsoft Office Word '
-        u'Security: 0')
+        'Title: Table of Context '
+        'Author: DAVID NIDES '
+        'Template: Normal.dotm '
+        'Revision number: 4 '
+        'Last saved by: Nides '
+        'Number of pages: 1 '
+        'Number of words: 3 '
+        'Number of characters: 18 '
+        'Application: Microsoft Office Word '
+        'Security: 0')
 
     expected_short_message = (
-        u'Title: Table of Context '
-        u'Author: DAVID NIDES '
-        u'Revision number: 4')
+        'Title: Table of Context '
+        'Author: DAVID NIDES '
+        'Revision number: 4')
 
     # TODO: add support for:
-    #    u'Total edit time (secs): 0 '
+    #    'Total edit time (secs): 0 '
 
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
@@ -70,12 +72,12 @@ class TestSummaryInformationOLECFPlugin(test_lib.OLECFPluginTestCase):
 class TestDocumentSummaryInformationOLECFPlugin(test_lib.OLECFPluginTestCase):
   """Tests for the OLECF document summary information plugin."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'Document.doc'])
+  @shared_test_lib.skipUnlessHasTestFile(['Document.doc'])
   def testProcess(self):
     """Tests the Process function on a Document Summary Information stream."""
     plugin = summary.DocumentSummaryInformationOLECFPlugin()
     storage_writer = self._ParseOLECFFileWithPlugin(
-        [u'Document.doc'], plugin)
+        ['Document.doc'], plugin)
 
     # There should only be one summary info stream with one event.
     self.assertEqual(storage_writer.number_of_events, 1)
@@ -83,26 +85,26 @@ class TestDocumentSummaryInformationOLECFPlugin(test_lib.OLECFPluginTestCase):
     events = list(storage_writer.GetSortedEvents())
 
     event = events[0]
-    self.assertEqual(event.name, u'Document Summary Information')
+    self.assertEqual(event.name, 'Document Summary Information')
 
     self.assertEqual(event.number_of_lines, 1)
     self.assertEqual(event.number_of_paragraphs, 1)
-    self.assertEqual(event.company, u'KPMG')
+    self.assertEqual(event.company, 'KPMG')
     self.assertFalse(event.shared_document)
-    self.assertEqual(event.application_version, u'14.0')
+    self.assertEqual(event.application_version, '14.0')
 
     # TODO: add support for:
     # self.assertEqual(event.is_shared, False)
 
     expected_message = (
-        u'Number of lines: 1 '
-        u'Number of paragraphs: 1 '
-        u'Company: KPMG '
-        u'Shared document: False '
-        u'Application version: 14.0')
+        'Number of lines: 1 '
+        'Number of paragraphs: 1 '
+        'Company: KPMG '
+        'Shared document: False '
+        'Application version: 14.0')
 
     expected_short_message = (
-        u'Company: KPMG')
+        'Company: KPMG')
 
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 

--- a/tests/parsers/olecf_plugins/test_lib.py
+++ b/tests/parsers/olecf_plugins/test_lib.py
@@ -14,6 +14,8 @@ from tests.parsers import test_lib
 class OLECFPluginTestCase(test_lib.ParserTestCase):
   """OLE CF-based plugin test case."""
 
+  # pylint: disable=no-member
+
   def _ParseOLECFFileWithPlugin(
       self, path_segments, plugin, codepage='cp1252',
       knowledge_base_values=None):

--- a/tests/parsers/olecf_plugins/test_lib.py
+++ b/tests/parsers/olecf_plugins/test_lib.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """OLECF plugin related functions and classes for testing."""
 
+from __future__ import unicode_literals
+
 import pyolecf
 
 from plaso.containers import sessions
@@ -10,22 +12,22 @@ from tests.parsers import test_lib
 
 
 class OLECFPluginTestCase(test_lib.ParserTestCase):
-  """The unit test case for OLE CF based plugins."""
+  """OLE CF-based plugin test case."""
 
   def _ParseOLECFFileWithPlugin(
-      self, path_segments, plugin, codepage=u'cp1252',
+      self, path_segments, plugin, codepage='cp1252',
       knowledge_base_values=None):
     """Parses a file as an OLE compound file and returns an event generator.
 
     Args:
-      path_segments: a list of strings containinge the path segments inside
-      plugin: an OLE CF plugin object (instance of OLECFPlugin).
-      codepage: optional string containing the codepage.
-      knowledge_base_values: optional dictionary containing the knowledge base
-                             values.
+      path_segments (list[str]): path segments inside the test data directory.
+      plugin (OLECFPlugin): OLE CF plugin.
+      codepage (Optional[str]): codepage.
+      knowledge_base_values (Optional[dict[str, object]]): knowledge base
+          values.
 
     Returns:
-      A storage writer object (instance of FakeStorageWriter).
+      FakeStorageWriter: storage writer.
     """
     session = sessions.Session()
     storage_writer = fake_storage.FakeStorageWriter(session)

--- a/tests/parsers/plist_plugins/airport.py
+++ b/tests/parsers/plist_plugins/airport.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the airport plist plugin."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import plist  # pylint: disable=unused-import
@@ -15,10 +17,10 @@ class AirportPluginTest(test_lib.PlistPluginTestCase):
   """Tests for the airport plist plugin."""
 
   @shared_test_lib.skipUnlessHasTestFile([
-      u'com.apple.airport.preferences.plist'])
+      'com.apple.airport.preferences.plist'])
   def testProcess(self):
     """Tests the Process function."""
-    plist_name = u'com.apple.airport.preferences.plist'
+    plist_name = 'com.apple.airport.preferences.plist'
 
     plugin = airport.AirportPlugin()
     storage_writer = self._ParsePlistFileWithPlugin(
@@ -36,17 +38,17 @@ class AirportPluginTest(test_lib.PlistPluginTestCase):
     self.assertEqual(timestamps, expected_timestamps)
 
     event = events[0]
-    self.assertEqual(event.key, u'item')
-    self.assertEqual(event.root, u'/RememberedNetworks')
+    self.assertEqual(event.key, 'item')
+    self.assertEqual(event.root, '/RememberedNetworks')
 
     expecte_description = (
-        u'[WiFi] Connected to network: <europa> using security '
-        u'WPA/WPA2 Personal')
+        '[WiFi] Connected to network: <europa> using security '
+        'WPA/WPA2 Personal')
     self.assertEqual(event.desc, expecte_description)
 
-    expected_message = u'/RememberedNetworks/item {0:s}'.format(
+    expected_message = '/RememberedNetworks/item {0:s}'.format(
         expecte_description)
-    expected_short_message = u'{0:s}...'.format(expected_message[:77])
+    expected_short_message = '{0:s}...'.format(expected_message[:77])
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
 

--- a/tests/parsers/plist_plugins/appleaccount.py
+++ b/tests/parsers/plist_plugins/appleaccount.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the Apple account plist plugin."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import plist  # pylint: disable=unused-import
@@ -15,13 +17,13 @@ class AppleAccountPluginTest(test_lib.PlistPluginTestCase):
   """Tests for the Apple account plist plugin."""
 
   @shared_test_lib.skipUnlessHasTestFile([
-      u'com.apple.coreservices.appleidauthenticationinfo.'
-      u'ABC0ABC1-ABC0-ABC0-ABC0-ABC0ABC1ABC2.plist'])
+      'com.apple.coreservices.appleidauthenticationinfo.'
+      'ABC0ABC1-ABC0-ABC0-ABC0-ABC0ABC1ABC2.plist'])
   def testProcess(self):
     """Tests the Process function."""
     plist_file = (
-        u'com.apple.coreservices.appleidauthenticationinfo.'
-        u'ABC0ABC1-ABC0-ABC0-ABC0-ABC0ABC1ABC2.plist')
+        'com.apple.coreservices.appleidauthenticationinfo.'
+        'ABC0ABC1-ABC0-ABC0-ABC0-ABC0ABC1ABC2.plist')
     plist_name = plist_file
 
     plugin = appleaccount.AppleAccountPlugin()
@@ -40,28 +42,28 @@ class AppleAccountPluginTest(test_lib.PlistPluginTestCase):
     self.assertEqual(timestamps, expected_timestamps)
 
     event = events[0]
-    self.assertEqual(event.root, u'/Accounts')
-    self.assertEqual(event.key, u'email@domain.com')
+    self.assertEqual(event.root, '/Accounts')
+    self.assertEqual(event.key, 'email@domain.com')
 
     expected_description = (
-        u'Configured Apple account email@domain.com (Joaquin Moreno Garijo)')
+        'Configured Apple account email@domain.com (Joaquin Moreno Garijo)')
     self.assertEqual(event.desc, expected_description)
 
-    expected_message = u'/Accounts/email@domain.com {0:s}'.format(
+    expected_message = '/Accounts/email@domain.com {0:s}'.format(
         expected_description)
-    expected_short_message = u'{0:s}...'.format(expected_message[:77])
+    expected_short_message = '{0:s}...'.format(expected_message[:77])
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
     event = events[1]
     expected_description = (
-        u'Connected Apple account '
-        u'email@domain.com (Joaquin Moreno Garijo)')
+        'Connected Apple account '
+        'email@domain.com (Joaquin Moreno Garijo)')
     self.assertEqual(event.desc, expected_description)
 
     event = events[2]
     expected_description = (
-        u'Last validation Apple account '
-        u'email@domain.com (Joaquin Moreno Garijo)')
+        'Last validation Apple account '
+        'email@domain.com (Joaquin Moreno Garijo)')
     self.assertEqual(event.desc, expected_description)
 
 

--- a/tests/parsers/plist_plugins/bluetooth.py
+++ b/tests/parsers/plist_plugins/bluetooth.py
@@ -55,11 +55,12 @@ class TestBtPlugin(test_lib.PlistPluginTestCase):
 
     # One of the paired event descriptions should contain the string:
     # Paired:True Name:Apple Magic Trackpad 2.
-    paired_descriptions = [
-        event.desc for event in paired_events]
+    paired_descriptions = [event.desc for event in paired_events]
 
     self.assertTrue(
         'Paired:True Name:Apple Magic Trackpad 2' in paired_descriptions)
+
+    event = events[10]
 
     expected_string = (
         '/DeviceCache/44-00-00-00-00-04 '

--- a/tests/parsers/plist_plugins/bluetooth.py
+++ b/tests/parsers/plist_plugins/bluetooth.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the Bluetooth plist plugin."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import plist  # pylint: disable=unused-import
@@ -14,11 +16,11 @@ from tests.parsers.plist_plugins import test_lib
 class TestBtPlugin(test_lib.PlistPluginTestCase):
   """Tests for the Bluetooth plist plugin."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'plist_binary'])
+  @shared_test_lib.skipUnlessHasTestFile(['plist_binary'])
   def testProcess(self):
     """Tests the Process function."""
-    test_file_name = u'plist_binary'
-    plist_name = u'com.apple.bluetooth.plist'
+    test_file_name = 'plist_binary'
+    plist_name = 'com.apple.bluetooth.plist'
 
     plugin = bluetooth.BluetoothPlugin()
     storage_writer = self._ParsePlistFileWithPlugin(
@@ -34,7 +36,7 @@ class TestBtPlugin(test_lib.PlistPluginTestCase):
     timestamps = []
     for event in events:
       timestamps.append(event.timestamp)
-      if event.desc.startswith(u'Paired'):
+      if event.desc.startswith('Paired'):
         paired_events.append(event)
 
     # Ensure all 14 events and times from the plist are parsed correctly.
@@ -57,12 +59,12 @@ class TestBtPlugin(test_lib.PlistPluginTestCase):
         event.desc for event in paired_events]
 
     self.assertTrue(
-        u'Paired:True Name:Apple Magic Trackpad 2' in paired_descriptions)
+        'Paired:True Name:Apple Magic Trackpad 2' in paired_descriptions)
 
     expected_string = (
-        u'/DeviceCache/44-00-00-00-00-04 '
-        u'Paired:True '
-        u'Name:Apple Magic Trackpad 2')
+        '/DeviceCache/44-00-00-00-00-04 '
+        'Paired:True '
+        'Name:Apple Magic Trackpad 2')
 
     self._TestGetMessageStrings(event, expected_string, expected_string)
 

--- a/tests/parsers/plist_plugins/default.py
+++ b/tests/parsers/plist_plugins/default.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the default plist plugin."""
 
+from __future__ import unicode_literals
+
 import datetime
 import unittest
 
@@ -20,14 +22,14 @@ class TestDefaultPlist(test_lib.PlistPluginTestCase):
   def testProcessSingle(self):
     """Tests Process on a plist containing a root, value and timestamp."""
     top_level_dict_single = {
-        u'DE-00-AD-00-BE-EF': {
-            u'Name': u'DBF Industries Slideshow Lazer', u'LastUsed':
+        'DE-00-AD-00-BE-EF': {
+            'Name': 'DBF Industries Slideshow Lazer', 'LastUsed':
             datetime.datetime(
                 2012, 11, 2, 1, 21, 38, 997672, tzinfo=pytz.UTC)}}
 
     plugin = default.DefaultPlugin()
     storage_writer = self._ParsePlistWithPlugin(
-        plugin, u'single', top_level_dict_single)
+        plugin, 'single', top_level_dict_single)
 
     self.assertEqual(storage_writer.number_of_events, 1)
 
@@ -38,46 +40,46 @@ class TestDefaultPlist(test_lib.PlistPluginTestCase):
     event = events[0]
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2012-11-02 01:21:38.997672')
+        '2012-11-02 01:21:38.997672')
     self.assertEqual(event.timestamp, expected_timestamp)
-    self.assertEqual(event.root, u'/DE-00-AD-00-BE-EF')
-    self.assertEqual(event.key, u'LastUsed')
+    self.assertEqual(event.root, '/DE-00-AD-00-BE-EF')
+    self.assertEqual(event.key, 'LastUsed')
 
     expected_string = (
-        u'/DE-00-AD-00-BE-EF/LastUsed')
+        '/DE-00-AD-00-BE-EF/LastUsed')
 
     self._TestGetMessageStrings(event, expected_string, expected_string)
 
   def testProcessMulti(self):
     """Tests Process on a plist containing five keys with date values."""
     top_level_dict_many_keys = {
-        u'DeviceCache': {
-            u'44-00-00-00-00-04': {
-                u'Name': u'Apple Magic Trackpad 2', u'LMPSubversion': 796,
-                u'LMPVersion': 3, u'PageScanMode': 0, u'ClassOfDevice': 9620,
-                u'SupportedFeatures': b'\x00\x00\x00\x00', u'Manufacturer': 76,
-                u'PageScanPeriod': 0, u'ClockOffset': 17981, u'LastNameUpdate':
+        'DeviceCache': {
+            '44-00-00-00-00-04': {
+                'Name': 'Apple Magic Trackpad 2', 'LMPSubversion': 796,
+                'LMPVersion': 3, 'PageScanMode': 0, 'ClassOfDevice': 9620,
+                'SupportedFeatures': b'\x00\x00\x00\x00', 'Manufacturer': 76,
+                'PageScanPeriod': 0, 'ClockOffset': 17981, 'LastNameUpdate':
                 datetime.datetime(
                     2012, 11, 2, 1, 21, 38, 997672, tzinfo=pytz.UTC),
-                u'InquiryRSSI': 198, u'PageScanRepetitionMode': 1,
-                u'LastServicesUpdate':
+                'InquiryRSSI': 198, 'PageScanRepetitionMode': 1,
+                'LastServicesUpdate':
                 datetime.datetime(2012, 11, 2, 1, 13, 23, tzinfo=pytz.UTC),
-                u'displayName': u'Apple Magic Trackpad 2', u'LastInquiryUpdate':
+                'displayName': 'Apple Magic Trackpad 2', 'LastInquiryUpdate':
                 datetime.datetime(
                     2012, 11, 2, 1, 13, 17, 324095, tzinfo=pytz.UTC),
-                u'Services': u'', u'BatteryPercent': 0.61},
-            u'44-00-00-00-00-02': {
-                u'Name': u'test-macpro', u'ClockOffset': 28180,
-                u'ClassOfDevice': 3670276, u'PageScanMode': 0,
-                u'LastNameUpdate': datetime.datetime(
+                'Services': '', 'BatteryPercent': 0.61},
+            '44-00-00-00-00-02': {
+                'Name': 'test-macpro', 'ClockOffset': 28180,
+                'ClassOfDevice': 3670276, 'PageScanMode': 0,
+                'LastNameUpdate': datetime.datetime(
                     2011, 4, 7, 17, 56, 53, 524275, tzinfo=pytz.UTC),
-                u'PageScanPeriod': 2, u'PageScanRepetitionMode': 1,
-                u'LastInquiryUpdate': datetime.datetime(
+                'PageScanPeriod': 2, 'PageScanRepetitionMode': 1,
+                'LastInquiryUpdate': datetime.datetime(
                     2012, 7, 10, 22, 5, 0, 20116, tzinfo=pytz.UTC)}}}
 
     plugin = default.DefaultPlugin()
     storage_writer = self._ParsePlistWithPlugin(
-        plugin, u'nested', top_level_dict_many_keys)
+        plugin, 'nested', top_level_dict_many_keys)
 
     self.assertEqual(storage_writer.number_of_events, 5)
 
@@ -88,10 +90,10 @@ class TestDefaultPlist(test_lib.PlistPluginTestCase):
     event = events[0]
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2011-04-07 17:56:53.524275')
+        '2011-04-07 17:56:53.524275')
     self.assertEqual(event.timestamp, expected_timestamp)
-    self.assertEqual(event.root, u'/DeviceCache/44-00-00-00-00-02')
-    self.assertEqual(event.key, u'LastNameUpdate')
+    self.assertEqual(event.root, '/DeviceCache/44-00-00-00-00-02')
+    self.assertEqual(event.key, 'LastNameUpdate')
 
 
 if __name__ == '__main__':

--- a/tests/parsers/plist_plugins/install_history.py
+++ b/tests/parsers/plist_plugins/install_history.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the install history plist plugin."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import plist  # pylint: disable=unused-import
@@ -14,10 +16,10 @@ from tests.parsers.plist_plugins import test_lib
 class InstallHistoryPluginTest(test_lib.PlistPluginTestCase):
   """Tests for the install history plist plugin."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'InstallHistory.plist'])
+  @shared_test_lib.skipUnlessHasTestFile(['InstallHistory.plist'])
   def testProcess(self):
     """Tests the Process function."""
-    plist_name = u'InstallHistory.plist'
+    plist_name = 'InstallHistory.plist'
 
     plugin = install_history.InstallHistoryPlugin()
     storage_writer = self._ParsePlistFileWithPlugin(
@@ -37,24 +39,24 @@ class InstallHistoryPluginTest(test_lib.PlistPluginTestCase):
     self.assertEqual(timestamps, expected_timestamps)
 
     event = events[0]
-    self.assertEqual(event.key, u'')
-    self.assertEqual(event.root, u'/item')
+    self.assertEqual(event.key, '')
+    self.assertEqual(event.root, '/item')
 
     expected_description = (
-        u'Installation of [OS X 10.9 (13A603)] using [OS X Installer]. '
-        u'Packages: com.apple.pkg.BaseSystemBinaries, '
-        u'com.apple.pkg.BaseSystemResources, '
-        u'com.apple.pkg.Essentials, com.apple.pkg.BSD, '
-        u'com.apple.pkg.JavaTools, com.apple.pkg.AdditionalEssentials, '
-        u'com.apple.pkg.AdditionalSpeechVoices, '
-        u'com.apple.pkg.AsianLanguagesSupport, com.apple.pkg.MediaFiles, '
-        u'com.apple.pkg.JavaEssentials, com.apple.pkg.OxfordDictionaries, '
-        u'com.apple.pkg.X11redirect, com.apple.pkg.OSInstall, '
-        u'com.apple.pkg.update.compatibility.2013.001.')
+        'Installation of [OS X 10.9 (13A603)] using [OS X Installer]. '
+        'Packages: com.apple.pkg.BaseSystemBinaries, '
+        'com.apple.pkg.BaseSystemResources, '
+        'com.apple.pkg.Essentials, com.apple.pkg.BSD, '
+        'com.apple.pkg.JavaTools, com.apple.pkg.AdditionalEssentials, '
+        'com.apple.pkg.AdditionalSpeechVoices, '
+        'com.apple.pkg.AsianLanguagesSupport, com.apple.pkg.MediaFiles, '
+        'com.apple.pkg.JavaEssentials, com.apple.pkg.OxfordDictionaries, '
+        'com.apple.pkg.X11redirect, com.apple.pkg.OSInstall, '
+        'com.apple.pkg.update.compatibility.2013.001.')
     self.assertEqual(event.desc, expected_description)
 
-    expected_message = u'/item/ {0:s}'.format(expected_description)
-    expected_short_message = u'{0:s}...'.format(expected_message[:77])
+    expected_message = '/item/ {0:s}'.format(expected_description)
+    expected_short_message = '{0:s}...'.format(expected_message[:77])
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
 

--- a/tests/parsers/plist_plugins/interface.py
+++ b/tests/parsers/plist_plugins/interface.py
@@ -26,6 +26,7 @@ class MockPlugin(interface.PlistPlugin):
   PLIST_PATH = 'plist_binary'
   PLIST_KEYS = frozenset(['DeviceCache', 'PairedDevices'])
 
+  # pylint: disable=arguments-differ
   def GetEntries(self, parser_mediator, **unused_kwargs):
     """Extracts entries for testing.
 

--- a/tests/parsers/plist_plugins/interface.py
+++ b/tests/parsers/plist_plugins/interface.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the plist plugin interface."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from dfdatetime import posix_time as dfdatetime_posix_time
@@ -18,11 +20,11 @@ from tests.parsers.plist_plugins import test_lib
 class MockPlugin(interface.PlistPlugin):
   """Mock plugin."""
 
-  NAME = u'mock_plist_plugin'
-  DESCRIPTION = u'Parser for testing parsing plist files.'
+  NAME = 'mock_plist_plugin'
+  DESCRIPTION = 'Parser for testing parsing plist files.'
 
-  PLIST_PATH = u'plist_binary'
-  PLIST_KEYS = frozenset([u'DeviceCache', u'PairedDevices'])
+  PLIST_PATH = 'plist_binary'
+  PLIST_KEYS = frozenset(['DeviceCache', 'PairedDevices'])
 
   def GetEntries(self, parser_mediator, **unused_kwargs):
     """Extracts entries for testing.
@@ -32,8 +34,8 @@ class MockPlugin(interface.PlistPlugin):
           and other components, such as storage and dfvfs.
     """
     event_data = plist_event.PlistTimeEventData()
-    event_data.key = u'LastInquiryUpdate'
-    event_data.root = u'/DeviceCache/44-00-00-00-00-00'
+    event_data.key = 'LastInquiryUpdate'
+    event_data.root = '/DeviceCache/44-00-00-00-00-00'
 
     date_time = dfdatetime_posix_time.PosixTimeInMicroseconds(
         timestamp=1351827808261762)
@@ -50,13 +52,13 @@ class TestPlistPlugin(test_lib.PlistPluginTestCase):
   def setUp(self):
     """Makes preparations before running an individual test."""
     self._top_level_dict = {
-        u'DeviceCache': {
-            u'44-00-00-00-00-04': {
-                u'Name': u'Apple Magic Trackpad 2', u'LMPSubversion': 796,
-                u'Services': u'', u'BatteryPercent': 0.61},
-            u'44-00-00-00-00-02': {
-                u'Name': u'test-macpro', u'ClockOffset': 28180,
-                u'PageScanPeriod': 2, u'PageScanRepetitionMode': 1}}}
+        'DeviceCache': {
+            '44-00-00-00-00-04': {
+                'Name': 'Apple Magic Trackpad 2', 'LMPSubversion': 796,
+                'Services': '', 'BatteryPercent': 0.61},
+            '44-00-00-00-00-02': {
+                'Name': 'test-macpro', 'ClockOffset': 28180,
+                'PageScanPeriod': 2, 'PageScanRepetitionMode': 1}}}
 
   def testGetKeys(self):
     """Tests the _GetKeys function."""
@@ -64,18 +66,18 @@ class TestPlistPlugin(test_lib.PlistPluginTestCase):
     plugin = MockPlugin()
 
     # Match DeviceCache from the root level.
-    key = [u'DeviceCache']
+    key = ['DeviceCache']
     result = plugin._GetKeys(self._top_level_dict, key)
     self.assertEqual(len(result), 1)
 
     # Look for a key nested a layer beneath DeviceCache from root level.
     # Note: overriding the default depth to look deeper.
-    key = [u'44-00-00-00-00-02']
+    key = ['44-00-00-00-00-02']
     result = plugin._GetKeys(self._top_level_dict, key, depth=2)
     self.assertEqual(len(result), 1)
 
     # Check the value of the result was extracted as expected.
-    self.assertEqual(result[key[0]][u'Name'], u'test-macpro')
+    self.assertEqual(result[key[0]]['Name'], 'test-macpro')
 
   def testProcess(self):
     """Tests the Process function."""
@@ -83,30 +85,30 @@ class TestPlistPlugin(test_lib.PlistPluginTestCase):
     plugin = MockPlugin()
 
     # Test correct filename and keys.
-    top_level = {u'DeviceCache': 1, u'PairedDevices': 1}
+    top_level = {'DeviceCache': 1, 'PairedDevices': 1}
     storage_writer = self._ParsePlistWithPlugin(
-        plugin, u'plist_binary', top_level)
+        plugin, 'plist_binary', top_level)
 
     self.assertEqual(storage_writer.number_of_events, 1)
 
     # Correct filename with odd filename cAsinG. Adding an extra useless key.
-    top_level = {u'DeviceCache': 1, u'PairedDevices': 1, u'R@ndomExtraKey': 1}
+    top_level = {'DeviceCache': 1, 'PairedDevices': 1, 'R@ndomExtraKey': 1}
     storage_writer = self._ParsePlistWithPlugin(
-        plugin, u'pLiSt_BinAry', top_level)
+        plugin, 'pLiSt_BinAry', top_level)
 
     self.assertEqual(storage_writer.number_of_events, 1)
 
     # Test wrong filename.
-    top_level = {u'DeviceCache': 1, u'PairedDevices': 1}
+    top_level = {'DeviceCache': 1, 'PairedDevices': 1}
     with self.assertRaises(errors.WrongPlistPlugin):
       _ = self._ParsePlistWithPlugin(
-          plugin, u'wrong_file.plist', top_level)
+          plugin, 'wrong_file.plist', top_level)
 
     # Test not enough required keys.
-    top_level = {u'Useless_Key': 0, u'PairedDevices': 1}
+    top_level = {'Useless_Key': 0, 'PairedDevices': 1}
     with self.assertRaises(errors.WrongPlistPlugin):
       _ = self._ParsePlistWithPlugin(
-          plugin, u'plist_binary.plist', top_level)
+          plugin, 'plist_binary.plist', top_level)
 
   def testRecurseKey(self):
     """Tests the RecurseKey function."""
@@ -122,7 +124,7 @@ class TestPlistPlugin(test_lib.PlistPluginTestCase):
     my_keys = []
     for unused_root, key, unused_value in result:
       my_keys.append(key)
-    expected = {u'DeviceCache', u'44-00-00-00-00-04', u'44-00-00-00-00-02'}
+    expected = {'DeviceCache', '44-00-00-00-00-04', '44-00-00-00-00-02'}
     self.assertTrue(expected == set(my_keys))
 
 

--- a/tests/parsers/plist_plugins/ipod.py
+++ b/tests/parsers/plist_plugins/ipod.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 
 import unittest
 
-from plaso.formatters import ipod  # pylint: disable=unused-import
+from plaso.formatters import ipod as _  # pylint: disable=unused-import
 from plaso.lib import definitions
 from plaso.lib import timelib
 from plaso.parsers.plist_plugins import ipod

--- a/tests/parsers/plist_plugins/ipod.py
+++ b/tests/parsers/plist_plugins/ipod.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the iPod plist plugin."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import ipod  # pylint: disable=unused-import
@@ -16,10 +18,10 @@ from tests.parsers.plist_plugins import test_lib
 class TestIPodPlugin(test_lib.PlistPluginTestCase):
   """Tests for the iPod plist plugin."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'com.apple.iPod.plist'])
+  @shared_test_lib.skipUnlessHasTestFile(['com.apple.iPod.plist'])
   def testProcess(self):
     """Tests the Process function."""
-    plist_name = u'com.apple.iPod.plist'
+    plist_name = 'com.apple.iPod.plist'
 
     plugin = ipod.IPodPlugin()
     storage_writer = self._ParsePlistFileWithPlugin(
@@ -33,32 +35,32 @@ class TestIPodPlugin(test_lib.PlistPluginTestCase):
 
     event = events[0]
 
-    timestamp = timelib.Timestamp.CopyFromString(u'1995-11-22 18:25:07')
+    timestamp = timelib.Timestamp.CopyFromString('1995-11-22 18:25:07')
     self.assertEqual(event.timestamp, timestamp)
-    self.assertEqual(event.device_id, u'0000A11300000000')
+    self.assertEqual(event.device_id, '0000A11300000000')
 
     event = events[2]
 
-    timestamp = timelib.Timestamp.CopyFromString(u'2013-10-09 19:27:54')
+    timestamp = timelib.Timestamp.CopyFromString('2013-10-09 19:27:54')
     self.assertEqual(event.timestamp, timestamp)
 
     expected_message = (
-        u'Device ID: 4C6F6F6E65000000 '
-        u'Type: iPhone [10016] '
-        u'Connected 1 times '
-        u'Serial nr: 526F676572 '
-        u'IMEI [012345678901234]')
-    expected_short_message = u'{0:s}...'.format(expected_message[:77])
+        'Device ID: 4C6F6F6E65000000 '
+        'Type: iPhone [10016] '
+        'Connected 1 times '
+        'Serial nr: 526F676572 '
+        'IMEI [012345678901234]')
+    expected_short_message = '{0:s}...'.format(expected_message[:77])
 
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_LAST_CONNECTED)
 
-    self.assertEqual(event.device_class, u'iPhone')
-    self.assertEqual(event.device_id, u'4C6F6F6E65000000')
+    self.assertEqual(event.device_class, 'iPhone')
+    self.assertEqual(event.device_id, '4C6F6F6E65000000')
     self.assertEqual(event.firmware_version, 256)
-    self.assertEqual(event.imei, u'012345678901234')
+    self.assertEqual(event.imei, '012345678901234')
     self.assertEqual(event.use_count, 1)
 
 

--- a/tests/parsers/plist_plugins/macuser.py
+++ b/tests/parsers/plist_plugins/macuser.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the Mac OS X local users plist plugin."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import plist  # pylint: disable=unused-import
@@ -15,10 +17,10 @@ from tests.parsers.plist_plugins import test_lib
 class MacUserPluginTest(test_lib.PlistPluginTestCase):
   """Tests for the Mac OS X local user plist plugin."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'user.plist'])
+  @shared_test_lib.skipUnlessHasTestFile(['user.plist'])
   def testProcess(self):
     """Tests the Process function."""
-    plist_name = u'user.plist'
+    plist_name = 'user.plist'
 
     plugin = macuser.MacUserPlugin()
     storage_writer = self._ParsePlistFileWithPlugin(
@@ -33,24 +35,24 @@ class MacUserPluginTest(test_lib.PlistPluginTestCase):
     event = events[0]
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2013-12-28 04:35:47')
+        '2013-12-28 04:35:47')
     self.assertEqual(event.timestamp, expected_timestamp)
 
-    self.assertEqual(event.key, u'passwordLastSetTime')
-    self.assertEqual(event.root, u'/')
+    self.assertEqual(event.key, 'passwordLastSetTime')
+    self.assertEqual(event.root, '/')
     expected_description = (
-        u'Last time user (501) changed the password: '
-        u'$ml$37313$fa6cac1869263baa85cffc5e77a3d4ee164b7'
-        u'5536cae26ce8547108f60e3f554$a731dbb0e386b169af8'
-        u'9fbb33c255ceafc083c6bc5194853f72f11c550c42e4625'
-        u'ef113b66f3f8b51fc3cd39106bad5067db3f7f1491758ff'
-        u'e0d819a1b0aba20646fd61345d98c0c9a411bfd1144dd4b'
-        u'3c40ec0f148b66d5b9ab014449f9b2e103928ef21db6e25'
-        u'b536a60ff17a84e985be3aa7ba3a4c16b34e0d1d2066ae178')
+        'Last time user (501) changed the password: '
+        '$ml$37313$fa6cac1869263baa85cffc5e77a3d4ee164b7'
+        '5536cae26ce8547108f60e3f554$a731dbb0e386b169af8'
+        '9fbb33c255ceafc083c6bc5194853f72f11c550c42e4625'
+        'ef113b66f3f8b51fc3cd39106bad5067db3f7f1491758ff'
+        'e0d819a1b0aba20646fd61345d98c0c9a411bfd1144dd4b'
+        '3c40ec0f148b66d5b9ab014449f9b2e103928ef21db6e25'
+        'b536a60ff17a84e985be3aa7ba3a4c16b34e0d1d2066ae178')
     self.assertEqual(event.desc, expected_description)
 
-    expected_string = u'//passwordLastSetTime {}'.format(expected_description)
-    expected_short = u'{0:s}...'.format(expected_string[:77])
+    expected_string = '//passwordLastSetTime {}'.format(expected_description)
+    expected_short = '{0:s}...'.format(expected_string[:77])
     self._TestGetMessageStrings(event, expected_string, expected_short)
 
 

--- a/tests/parsers/plist_plugins/safari.py
+++ b/tests/parsers/plist_plugins/safari.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the Safari history plist plugin."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import plist  # pylint: disable=unused-import
@@ -15,10 +17,10 @@ from tests.parsers.plist_plugins import test_lib
 class SafariPluginTest(test_lib.PlistPluginTestCase):
   """Tests for the Safari history plist plugin."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'History.plist'])
+  @shared_test_lib.skipUnlessHasTestFile(['History.plist'])
   def testProcess(self):
     """Tests the Process function."""
-    plist_name = u'History.plist'
+    plist_name = 'History.plist'
 
     plugin = safari.SafariHistoryPlugin()
     storage_writer = self._ParsePlistFileWithPlugin(
@@ -33,17 +35,17 @@ class SafariPluginTest(test_lib.PlistPluginTestCase):
     event = events[7]
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2013-07-08 17:31:00')
+        '2013-07-08 17:31:00')
     self.assertEqual(event.timestamp, expected_timestamp)
 
     event = events[9]
 
-    expected_url = u'http://netverslun.sci-mx.is/aminosyrur'
+    expected_url = 'http://netverslun.sci-mx.is/aminosyrur'
     self.assertEqual(event.url, expected_url)
 
     expected_message = (
-        u'Visited: {0:s} (Am\xedn\xf3s\xfdrur ) '
-        u'Visit Count: 1').format(expected_url)
+        'Visited: {0:s} (Am\xedn\xf3s\xfdrur ) '
+        'Visit Count: 1').format(expected_url)
 
     self._TestGetMessageStrings(event, expected_message, expected_message)
 

--- a/tests/parsers/plist_plugins/softwareupdate.py
+++ b/tests/parsers/plist_plugins/softwareupdate.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the Software Update plist plugin."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import plist  # pylint: disable=unused-import
@@ -14,10 +16,10 @@ from tests.parsers.plist_plugins import test_lib
 class SoftwareUpdatePluginTest(test_lib.PlistPluginTestCase):
   """Tests for the SoftwareUpdate plist plugin."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'com.apple.SoftwareUpdate.plist'])
+  @shared_test_lib.skipUnlessHasTestFile(['com.apple.SoftwareUpdate.plist'])
   def testProcess(self):
     """Tests the Process function."""
-    plist_name = u'com.apple.SoftwareUpdate.plist'
+    plist_name = 'com.apple.SoftwareUpdate.plist'
 
     plugin = softwareupdate.SoftwareUpdatePlugin()
     storage_writer = self._ParsePlistFileWithPlugin(
@@ -31,20 +33,20 @@ class SoftwareUpdatePluginTest(test_lib.PlistPluginTestCase):
 
     event = events[0]
 
-    self.assertEqual(event.key, u'')
-    self.assertEqual(event.root, u'/')
+    self.assertEqual(event.key, '')
+    self.assertEqual(event.root, '/')
     expected_description = (
-        u'Last Mac OS 10.9.1 (13B42) partially '
-        u'update, pending 1: RAWCameraUpdate5.03(031-2664).')
+        'Last Mac OS 10.9.1 (13B42) partially '
+        'update, pending 1: RAWCameraUpdate5.03(031-2664).')
     self.assertEqual(event.desc, expected_description)
 
     event = events[1]
 
-    self.assertEqual(event.key, u'')
-    self.assertEqual(event.root, u'/')
-    expected_description = u'Last Mac OS X 10.9.1 (13B42) full update.'
+    self.assertEqual(event.key, '')
+    self.assertEqual(event.root, '/')
+    expected_description = 'Last Mac OS X 10.9.1 (13B42) full update.'
     self.assertEqual(event.desc, expected_description)
-    expected_string = u'// {0:s}'.format(expected_description)
+    expected_string = '// {0:s}'.format(expected_description)
     self._TestGetMessageStrings(event, expected_string, expected_string)
 
 

--- a/tests/parsers/plist_plugins/spotlight.py
+++ b/tests/parsers/plist_plugins/spotlight.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the spotlight plist plugin."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import plist  # pylint: disable=unused-import
@@ -14,10 +16,10 @@ from tests.parsers.plist_plugins import test_lib
 class SpotlightPluginTest(test_lib.PlistPluginTestCase):
   """Tests for the spotlight plist plugin."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'com.apple.spotlight.plist'])
+  @shared_test_lib.skipUnlessHasTestFile(['com.apple.spotlight.plist'])
   def testProcess(self):
     """Tests the Process function."""
-    plist_name = u'com.apple.spotlight.plist'
+    plist_name = 'com.apple.spotlight.plist'
 
     plugin = spotlight.SpotlightPlugin()
     storage_writer = self._ParsePlistFileWithPlugin(
@@ -38,16 +40,16 @@ class SpotlightPluginTest(test_lib.PlistPluginTestCase):
     self.assertEqual(timestamps, expected_timestamps)
 
     event = events[6]
-    self.assertEqual(event.key, u'gr')
-    self.assertEqual(event.root, u'/UserShortcuts')
+    self.assertEqual(event.key, 'gr')
+    self.assertEqual(event.root, '/UserShortcuts')
 
     expected_description = (
-        u'Spotlight term searched "gr" associate to Grab '
-        u'(/Applications/Utilities/Grab.app)')
+        'Spotlight term searched "gr" associate to Grab '
+        '(/Applications/Utilities/Grab.app)')
     self.assertEqual(event.desc, expected_description)
 
-    expected_message = u'/UserShortcuts/gr {0:s}'.format(expected_description)
-    expected_short_message = u'{0:s}...'.format(expected_message[:77])
+    expected_message = '/UserShortcuts/gr {0:s}'.format(expected_description)
+    expected_short_message = '{0:s}...'.format(expected_message[:77])
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
 

--- a/tests/parsers/plist_plugins/spotlight_volume.py
+++ b/tests/parsers/plist_plugins/spotlight_volume.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the Spotlight Volume configuration plist plugin."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import plist  # pylint: disable=unused-import
@@ -14,10 +16,10 @@ from tests.parsers.plist_plugins import test_lib
 class SpotlightVolumePluginTest(test_lib.PlistPluginTestCase):
   """Tests for the Spotlight Volume configuration plist plugin."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'VolumeConfiguration.plist'])
+  @shared_test_lib.skipUnlessHasTestFile(['VolumeConfiguration.plist'])
   def testProcess(self):
     """Tests the Process function."""
-    plist_name = u'VolumeConfiguration.plist'
+    plist_name = 'VolumeConfiguration.plist'
 
     plugin = spotlight_volume.SpotlightVolumePlugin()
     storage_writer = self._ParsePlistFileWithPlugin(
@@ -36,16 +38,16 @@ class SpotlightVolumePluginTest(test_lib.PlistPluginTestCase):
 
     event = events[1]
 
-    self.assertEqual(event.key, u'')
-    self.assertEqual(event.root, u'/Stores')
+    self.assertEqual(event.key, '')
+    self.assertEqual(event.root, '/Stores')
 
     expected_description = (
-        u'Spotlight Volume 4D4BFEB5-7FE6-4033-AAAA-AAAABBBBCCCCDDDD '
-        u'(/.MobileBackups) activated.')
+        'Spotlight Volume 4D4BFEB5-7FE6-4033-AAAA-AAAABBBBCCCCDDDD '
+        '(/.MobileBackups) activated.')
     self.assertEqual(event.desc, expected_description)
 
-    expected_message = u'/Stores/ {0:s}'.format(expected_description)
-    expected_short_message = u'{0:s}...'.format(expected_message[:77])
+    expected_message = '/Stores/ {0:s}'.format(expected_description)
+    expected_short_message = '{0:s}...'.format(expected_message[:77])
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
 

--- a/tests/parsers/plist_plugins/test_lib.py
+++ b/tests/parsers/plist_plugins/test_lib.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Plist plugin related functions and classes for testing."""
 
+from __future__ import unicode_literals
+
 from plaso.storage import fake_storage
 
 from plaso.containers import sessions

--- a/tests/parsers/plist_plugins/timemachine.py
+++ b/tests/parsers/plist_plugins/timemachine.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the timemachine plist plugin."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.formatters import plist  # pylint: disable=unused-import
@@ -14,10 +16,10 @@ from tests.parsers.plist_plugins import test_lib
 class TimeMachinePluginTest(test_lib.PlistPluginTestCase):
   """Tests for the timemachine plist plugin."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'com.apple.TimeMachine.plist'])
+  @shared_test_lib.skipUnlessHasTestFile(['com.apple.TimeMachine.plist'])
   def testProcess(self):
     """Tests the Process function."""
-    plist_name = u'com.apple.TimeMachine.plist'
+    plist_name = 'com.apple.TimeMachine.plist'
 
     plugin = timemachine.TimeMachinePlugin()
     storage_writer = self._ParsePlistFileWithPlugin(
@@ -39,17 +41,17 @@ class TimeMachinePluginTest(test_lib.PlistPluginTestCase):
     self.assertEqual(timestamps, expected_timestamps)
 
     event = events[0]
-    self.assertEqual(event.root, u'/Destinations')
-    self.assertEqual(event.key, u'item/SnapshotDates')
+    self.assertEqual(event.root, '/Destinations')
+    self.assertEqual(event.key, 'item/SnapshotDates')
 
     expected_description = (
-        u'TimeMachine Backup in BackUpFast '
-        u'(5B33C22B-A4A1-4024-A2F5-C9979C4AAAAA)')
+        'TimeMachine Backup in BackUpFast '
+        '(5B33C22B-A4A1-4024-A2F5-C9979C4AAAAA)')
     self.assertEqual(event.desc, expected_description)
 
-    expected_message = u'/Destinations/item/SnapshotDates {0:s}'.format(
+    expected_message = '/Destinations/item/SnapshotDates {0:s}'.format(
         expected_description)
-    expected_short_message = u'{0:s}...'.format(expected_message[:77])
+    expected_short_message = '{0:s}...'.format(expected_message[:77])
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
 

--- a/tests/parsers/syslog_plugins/cron.py
+++ b/tests/parsers/syslog_plugins/cron.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the cron syslog plugin."""
 
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.lib import timelib
@@ -13,13 +15,13 @@ from tests.parsers.syslog_plugins import test_lib
 class SyslogCronPluginTest(test_lib.SyslogPluginTestCase):
   """Tests for the cron syslog plugin."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'syslog_cron.log'])
+  @shared_test_lib.skipUnlessHasTestFile(['syslog_cron.log'])
   def testParse(self):
     """Tests the parsing functionality on a sample file."""
-    knowledge_base_values = {u'year': 2015}
+    knowledge_base_values = {'year': 2015}
 
     storage_writer = self._ParseFileWithPlugin(
-        [u'syslog_cron.log'], u'cron',
+        ['syslog_cron.log'], 'cron',
         knowledge_base_values=knowledge_base_values)
 
     self.assertEqual(storage_writer.number_of_events, 9)
@@ -28,19 +30,19 @@ class SyslogCronPluginTest(test_lib.SyslogPluginTestCase):
 
     event = events[1]
 
-    self.assertEqual(event.data_type, u'syslog:cron:task_run')
+    self.assertEqual(event.data_type, 'syslog:cron:task_run')
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2015-03-11 19:26:39')
+        '2015-03-11 19:26:39')
     self.assertEqual(event.timestamp, expected_timestamp)
 
-    expected_command = u'sleep $(( 1 * 60 )); touch /tmp/afile.txt'
+    expected_command = 'sleep $(( 1 * 60 )); touch /tmp/afile.txt'
     self.assertEqual(event.command, expected_command)
 
-    self.assertEqual(event.username, u'root')
+    self.assertEqual(event.username, 'root')
 
     event = events[7]
-    self.assertEqual(event.command, u'/sbin/status.mycheck')
+    self.assertEqual(event.command, '/sbin/status.mycheck')
     self.assertEqual(event.pid, 31067)
 
 

--- a/tests/parsers/syslog_plugins/ssh.py
+++ b/tests/parsers/syslog_plugins/ssh.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """Tests for the SSH syslog plugin."""
+
+from __future__ import unicode_literals
+
 import unittest
 
 from plaso.lib import timelib
@@ -12,13 +15,13 @@ from tests.parsers.syslog_plugins import test_lib
 class SSHSyslogParserTest(test_lib.SyslogPluginTestCase):
   """Tests for the SSH syslog plugin."""
 
-  @shared_test_lib.skipUnlessHasTestFile([u'syslog_ssh.log'])
+  @shared_test_lib.skipUnlessHasTestFile(['syslog_ssh.log'])
   def testParse(self):
     """Tests the Parse function."""
-    knowledge_base_values = {u'year': 2016}
+    knowledge_base_values = {'year': 2016}
 
     storage_writer = self._ParseFileWithPlugin(
-        [u'syslog_ssh.log'], u'ssh',
+        ['syslog_ssh.log'], 'ssh',
         knowledge_base_values=knowledge_base_values)
 
     self.assertEqual(storage_writer.number_of_events, 9)
@@ -26,38 +29,38 @@ class SSHSyslogParserTest(test_lib.SyslogPluginTestCase):
     events = list(storage_writer.GetSortedEvents())
 
     event = events[0]
-    self.assertEqual(event.data_type, u'syslog:line')
+    self.assertEqual(event.data_type, 'syslog:line')
 
     event = events[1]
-    self.assertEqual(event.data_type, u'syslog:ssh:login')
-    self.assertEqual(event.address, u'192.168.0.1')
+    self.assertEqual(event.data_type, 'syslog:ssh:login')
+    self.assertEqual(event.address, '192.168.0.1')
 
     expected_body = (
-        u'Accepted publickey for plaso from 192.168.0.1 port 59229 ssh2: '
-        u'RSA 00:aa:bb:cc:dd:ee:ff:11:22:33:44:55:66:77:88:99')
+        'Accepted publickey for plaso from 192.168.0.1 port 59229 ssh2: '
+        'RSA 00:aa:bb:cc:dd:ee:ff:11:22:33:44:55:66:77:88:99')
     self.assertEqual(expected_body, event.body)
 
     expected_timestamp = timelib.Timestamp.CopyFromString(
-        u'2016-03-11 19:26:39')
+        '2016-03-11 19:26:39')
     self.assertEqual(event.timestamp, expected_timestamp)
 
     expected_fingerprint = (
-        u'RSA 00:aa:bb:cc:dd:ee:ff:11:22:33:44:55:66:77:88:99')
+        'RSA 00:aa:bb:cc:dd:ee:ff:11:22:33:44:55:66:77:88:99')
     self.assertEqual(expected_fingerprint, event.fingerprint)
 
     event = events[2]
-    self.assertEqual(event.data_type, u'syslog:ssh:failed_connection')
-    self.assertEqual(event.address, u'001:db8:a0b:12f0::1')
-    self.assertEqual(event.port, u'8759')
+    self.assertEqual(event.data_type, 'syslog:ssh:failed_connection')
+    self.assertEqual(event.address, '001:db8:a0b:12f0::1')
+    self.assertEqual(event.port, '8759')
 
     event = events[4]
-    self.assertEqual(event.data_type, u'syslog:ssh:opened_connection')
-    self.assertEqual(event.address, u'188.124.3.41')
+    self.assertEqual(event.data_type, 'syslog:ssh:opened_connection')
+    self.assertEqual(event.address, '188.124.3.41')
 
     event = events[7]
-    self.assertEqual(event.address, u'192.0.2.60')
-    self.assertEqual(event.port, u'20042')
-    self.assertEqual(event.username, u'fred')
+    self.assertEqual(event.address, '192.0.2.60')
+    self.assertEqual(event.port, '20042')
+    self.assertEqual(event.username, 'fred')
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/parsers/syslog_plugins/test_lib.py
+++ b/tests/parsers/syslog_plugins/test_lib.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Syslog plugin related functions and classes for testing."""
 
+from __future__ import unicode_literals
+
 from plaso.containers import sessions
 from plaso.parsers import syslog
 from plaso.storage import fake_storage


### PR DESCRIPTION
[Code review: 330570043: Made Unicode strings the default in bencode, cookie, ESEDB, OLECF, plist and syslog parser plugins tests #1268](https://codereview.appspot.com/330570043/)