### PR TITLE
preventing listed mistaken error

### DIFF
--- a/plaso/dependencies.py
+++ b/plaso/dependencies.py
@@ -18,7 +18,7 @@ PYTHON_DEPENDENCIES = {
     u'bencode': (u'', u'', None, True),
     u'binplist': (u'__version__', u'0.1.4', None, True),
     u'construct': (u'__version__', u'2.5.2', u'2.5.3', True),
-    u'Crypto': (u'__version__', u'2.6.0', None, True),
+    u'Crypto': (u'__version__', u'2.6', None, True),
     u'dateutil': (u'__version__', u'1.5', None, True),
     u'dfdatetime': (u'__version__', u'20170103', None, True),
     u'dfvfs': (u'__version__', u'20160803', None, True),


### PR DESCRIPTION
root@kali:~/Desktop/log2timeline2/plaso# /usr/local/bin/log2timeline.py --workers 8 /cases/case_name.plaso /mnt/rabbit
Checking availability and versions of dependencies.
[FAILURE]	Crypto version: 2.6 is too old, 2.6.0 or later required.

## This is almost always the wrong way to submit code to Plaso

All contributions to Plaso undergo [code 
review](https://github.com/log2timeline/plaso/wiki/Codereview). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://github.com/log2timeline/plaso/wiki/Style-guide).

Please don't send a pull request without a corresponding code review issue!