### PR TITLE
prevent versioning error

### DIFF
--- a/dependencies.ini
+++ b/dependencies.ini
@@ -37,7 +37,7 @@ version_property: __version__
 
 [Crypto]
 dpkg_name: python-crypto
-minimum_version: 2.6.0
+minimum_version: 2.6
 l2tbinaries_name: pycrypto
 pypi_name: pycrypto
 rpm_name: python-crypto


### PR DESCRIPTION
root@kali:~/Desktop/log2timeline2/plaso# /usr/local/bin/log2timeline.py --workers 8 /cases/case_name.plaso /mnt/rabbit
Checking availability and versions of dependencies.
[FAILURE]	Crypto version: 2.6 is too old, 2.6.0 or later required.

## This is almost always the wrong way to submit code to Plaso

All contributions to Plaso undergo [code 
review](https://github.com/log2timeline/plaso/wiki/Codereview). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://github.com/log2timeline/plaso/wiki/Style-guide).

Please don't send a pull request without a corresponding code review issue!