### PR TITLE
336410043: Added work-around for failing OS detection for MacOS #1611

### DIFF
--- a/plaso/cli/extraction_tool.py
+++ b/plaso/cli/extraction_tool.py
@@ -105,6 +105,10 @@ class ExtractionTool(
               operating_system, operating_system_product,
               operating_system_version))
 
+      if not parser_filter_expression:
+        # knowledge_base.platform contains the first result of GuessOS.
+        parser_filter_expression = knowledge_base.platform.lower()
+
       if parser_filter_expression:
         logging.info('Parser filter expression changed to: {0:s}'.format(
             parser_filter_expression))


### PR DESCRIPTION
[Code review: 336410043: Added work-around for failing OS detection for MacOS #1611](https://codereview.appspot.com/336410043/)