### PR TITLE
ELK 6 does not support `string` anymore

### DIFF
--- a/plaso/output/elastic.py
+++ b/plaso/output/elastic.py
@@ -301,7 +301,7 @@ class ElasticSearchOutputModule(interface.OutputModule):
               'mapping': {
                   'fields': {
                       'raw': {
-                          'type': 'string',
+                          'type': 'text',
                           'index': 'not_analyzed',
                           'ignore_above': self._ELASTIC_ANALYZER_STRING_LIMIT
                       }


### PR DESCRIPTION
## One line description of pull request

As of Elasticsearch version 6, the datatype `string` is not supported anymore (and has been deprecated long before). 

## Description:

I simply changed the type mapping from `string` to `text`, which is the intended replacement. Using this, I can import timelines without problems.

**Related issue (if applicable):** fixes #1717 

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/plaso/wiki/Codereview). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://github.com/log2timeline/plaso/wiki/Style-guide).

One of the maintainers will examine your code, and may request changes.

## Checklist:
  - [ ] Local tests pass
  - [ ] Tests on TravisCI pass
  - [ ] Codacy passes (or flags issues that you think are acceptable)
  - [ ] Coveralls indicates test coverage is sufficient

If [new dependencies](https://github.com/log2timeline/plaso/wiki/Adding-a-new-dependency) are required:
 - [ ] l2tdevtools has been updated
