### PR TITLE
334550043: Handle event timestamp of None in output modules #1680

### DIFF
--- a/plaso/output/dynamic.py
+++ b/plaso/output/dynamic.py
@@ -64,7 +64,7 @@ class DynamicFieldsHelper(object):
           raise_error=True)
     except (OverflowError, ValueError) as exception:
       self._ReportEventError(event, (
-          'unable to copy timestamp: {0:d} to a human readable date '
+          'unable to copy timestamp: {0!s} to a human readable date '
           'with error: {1!s}. Defaulting to: "0000-00-00"').format(
               event.timestamp, exception))
 
@@ -89,7 +89,7 @@ class DynamicFieldsHelper(object):
 
     except (OverflowError, ValueError) as exception:
       self._ReportEventError(event, (
-          'unable to copy timestamp: {0:d} to a human readable date and time '
+          'unable to copy timestamp: {0!s} to a human readable date and time '
           'with error: {1!s}. Defaulting to: "0000-00-00T00:00:00"').format(
               event.timestamp, exception))
 
@@ -250,7 +250,7 @@ class DynamicFieldsHelper(object):
           raise_error=True)
     except (OverflowError, ValueError) as exception:
       self._ReportEventError(event, (
-          'unable to copy timestamp: {0:d} to a human readable time '
+          'unable to copy timestamp: {0!s} to a human readable time '
           'with error: {1!s}. Defaulting to: "00:00:00"').format(
               event.timestamp, exception))
 

--- a/plaso/output/elastic.py
+++ b/plaso/output/elastic.py
@@ -132,9 +132,9 @@ class ElasticSearchHelper(object):
       attribute_value = timelib.Timestamp.RoundToSeconds(event_object.timestamp)
     except TypeError as exception:
       logging.warning(
-          'Unable to round timestamp {0!s}. error: {1!s}. '
-          'Defaulting to 0'.format(
-              event_object.timestamp, exception))
+          ('Unable to round timestamp {0!s}. error: {1!s}. '
+           'Defaulting to 0').format(
+               event_object.timestamp, exception))
       attribute_value = 0
 
     attribute_value = timelib.Timestamp.CopyToIsoFormat(

--- a/plaso/output/elastic.py
+++ b/plaso/output/elastic.py
@@ -128,7 +128,15 @@ class ElasticSearchHelper(object):
       event_values[attribute_name] = attribute_value
 
     # Add string representation of the timestamp
-    attribute_value = timelib.Timestamp.RoundToSeconds(event_object.timestamp)
+    try:
+      attribute_value = timelib.Timestamp.RoundToSeconds(event_object.timestamp)
+    except TypeError as exception:
+      logging.warning(
+          'Unable to round timestamp {0!s}. error: {1!s}. '
+          'Defaulting to 0'.format(
+              event_object.timestamp, exception))
+      attribute_value = 0
+
     attribute_value = timelib.Timestamp.CopyToIsoFormat(
         attribute_value, timezone=self._output_mediator.timezone)
     event_values['datetime'] = attribute_value

--- a/plaso/output/tln.py
+++ b/plaso/output/tln.py
@@ -132,7 +132,15 @@ class TLNOutputModule(TLNBaseOutputModule):
     if not hasattr(event, 'timestamp'):
       return
 
-    posix_timestamp = timelib.Timestamp.CopyToPosix(event.timestamp)
+    try:
+      posix_timestamp = timelib.Timestamp.CopyToPosix(event.timestamp)
+    except (OverflowError, ValueError) as exception:
+      self._ReportEventError(event, (
+          'unable to copy timestamp: {0!s} to a posix value '
+          'with error: {1!s}. Defaulting to: "0"').format(
+              event.timestamp, exception))
+      posix_timestamp = 0
+
     source = self._FormatSource(event)
     hostname = self._FormatHostname(event)
     username = self._FormatUsername(event)
@@ -190,7 +198,15 @@ class L2TTLNOutputModule(TLNBaseOutputModule):
     if not hasattr(event, 'timestamp'):
       return
 
-    posix_timestamp = timelib.Timestamp.CopyToPosix(event.timestamp)
+    try:
+      posix_timestamp = timelib.Timestamp.CopyToPosix(event.timestamp)
+    except (OverflowError, ValueError) as exception:
+      self._ReportEventError(event, (
+          'unable to copy timestamp: {0!s} to a posix value '
+          'with error: {1!s}. Defaulting to: "0"').format(
+              event.timestamp, exception))
+      posix_timestamp = 0
+
     source = self._FormatSource(event)
     hostname = self._FormatHostname(event)
     username = self._FormatUsername(event)

--- a/plaso/output/xlsx.py
+++ b/plaso/output/xlsx.py
@@ -76,7 +76,7 @@ class XLSXOutputModule(interface.OutputModule):
 
     except (OverflowError, ValueError) as exception:
       self._ReportEventError(event, (
-          'unable to copy timestamp: {0:d} to a human readable date and time '
+          'unable to copy timestamp: {0!s} to a human readable date and time '
           'with error: {1!s}. Defaulting to: "ERROR"').format(
               event.timestamp, exception))
       return 'ERROR'


### PR DESCRIPTION
[Code review: 334550043: Fix crashes in output when timestamp is None. #1680](https://codereview.appspot.com/334550043/)