### PR TITLE
343950043: Migrated utmp construct-based parsers to use dtfabric #1893

### DIFF
--- a/plaso/formatters/utmp.py
+++ b/plaso/formatters/utmp.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 from plaso.formatters import interface
 from plaso.formatters import manager
+from plaso.lib import errors
 
 
 class UtmpSessionFormatter(interface.ConditionalEventFormatter):
@@ -13,19 +14,62 @@ class UtmpSessionFormatter(interface.ConditionalEventFormatter):
   DATA_TYPE = 'linux:utmp:event'
 
   FORMAT_STRING_PIECES = [
-      'User: {user}',
+      'User: {username}',
       'Computer Name: {computer_name}',
       'Terminal: {terminal}',
       'PID: {pid}',
-      'Terminal_ID: {terminal_id}',
+      'Terminal identifier: {terminal_identifier}',
       'Status: {status}',
       'IP Address: {ip_address}',
-      'Exit: {exit}']
+      'Exit status: {exit_status}']
 
-  FORMAT_STRING_SHORT_PIECES = ['User: {user}']
+  FORMAT_STRING_SHORT_PIECES = ['User: {username}']
 
   SOURCE_LONG = 'UTMP session'
   SOURCE_SHORT = 'LOG'
+
+  _STATUS_TYPES = {
+      0: 'EMPTY',
+      1: 'RUN_LVL',
+      2: 'BOOT_TIME',
+      3: 'NEW_TIME',
+      4: 'OLD_TIME',
+      5: 'INIT_PROCESS',
+      6: 'LOGIN_PROCESS',
+      7: 'USER_PROCESS',
+      8: 'DEAD_PROCESS',
+      9: 'ACCOUNTING'}
+
+  def GetMessages(self, unused_formatter_mediator, event):
+    """Determines the formatted message strings for an event object.
+
+    Args:
+      formatter_mediator (FormatterMediator): mediates the interactions between
+          formatters and other components, such as storage and Windows EventLog
+          resources.
+      event (EventObject): event.
+
+    Returns:
+      tuple(str, str): formatted message string and short message string.
+
+    Raises:
+      WrongFormatter: if the event object cannot be formatted by the formatter.
+    """
+    if self.DATA_TYPE != event.data_type:
+      raise errors.WrongFormatter('Unsupported data type: {0:s}.'.format(
+          event.data_type))
+
+    event_values = event.CopyToDict()
+
+    login_type = event_values.get('type', None)
+    if login_type is None:
+      status = 'N/A'
+    else:
+      status = self._STATUS_TYPES.get(login_type, 'UNKNOWN')
+
+    event_values['status'] = status
+
+    return self._ConditionalFormatMessages(event_values)
 
 
 manager.FormattersManager.RegisterFormatter(UtmpSessionFormatter)

--- a/plaso/parsers/dtfabric_parser.py
+++ b/plaso/parsers/dtfabric_parser.py
@@ -80,6 +80,33 @@ class DtFabricBaseParser(interface.FileObjectParser):
     self._data_type_maps = {}
     self._fabric = self._ReadDefinitionFile(self._DEFINITION_FILE)
 
+  def _FormatPackedIPv4Address(self, packed_ip_address):
+    """Formats a packed IPv4 address as a human readable string.
+
+    Args:
+      packed_ip_address (list[int]): packed IPv4 address.
+
+    Returns:
+      str: human readable IPv4 address.
+    """
+    return '.'.join(['{0:d}'.format(octet) for octet in packed_ip_address[:4]])
+
+  def _FormatPackedIPv6Address(self, packed_ip_address):
+    """Formats a packed IPv6 address as a human readable string.
+
+    Args:
+      packed_ip_address (list[int]): packed IPv6 address.
+
+    Returns:
+      str: human readable IPv6 address.
+    """
+    # Note that socket.inet_ntop() is not supported on Windows.
+    octet_pairs = zip(packed_ip_address[0::2], packed_ip_address[1::2])
+    octet_pairs = [octet1 << 8 | octet2 for octet1, octet2 in octet_pairs]
+    # TODO: omit ":0000" from the string.
+    return ':'.join([
+        '{0:04x}'.format(octet_pair) for octet_pair in octet_pairs])
+
   def _GetDataTypeMap(self, name):
     """Retrieves a data type map defined by the definition file.
 

--- a/plaso/parsers/utmp.py
+++ b/plaso/parsers/utmp.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Parser for Linux UTMP files."""
+"""Parser for Linux utmp files."""
 
 from __future__ import unicode_literals
 
@@ -14,7 +14,7 @@ from plaso.parsers import manager
 
 
 class UtmpEventData(events.EventData):
-  """UTMP event data.
+  """utmp event data.
 
   Attributes:
     computer_name (str): name of the computer.
@@ -43,10 +43,10 @@ class UtmpEventData(events.EventData):
 
 
 class UtmpParser(dtfabric_parser.DtFabricBaseParser):
-  """Parser for Linux/Unix UTMP files."""
+  """Parser for Linux/Unix utmp files."""
 
   NAME = 'utmp'
-  DESCRIPTION = 'Parser for Linux/Unix UTMP files.'
+  DESCRIPTION = 'Parser for Linux/Unix utmp files.'
 
   _DEFINITION_FILE = 'utmp.yaml'
 
@@ -55,13 +55,13 @@ class UtmpParser(dtfabric_parser.DtFabricBaseParser):
   _SUPPORTED_TYPES = frozenset(range(0, 10))
 
   def _ReadEntry(self, parser_mediator, file_object, file_offset):
-    """Reads an UTMP entry.
+    """Reads an utmp entry.
 
     Args:
       parser_mediator (ParserMediator): mediates interactions between parsers
           and other components, such as storage and dfvfs.
       file_object (dfvfs.FileIO): a file-like object.
-      file_offset (int): offset of the data relative from the start of
+      file_offset (int): offset of the data relative to the start of
           the file-like object.
 
     Returns:
@@ -69,7 +69,7 @@ class UtmpParser(dtfabric_parser.DtFabricBaseParser):
 
         int: timestamp, which contains the number of microseconds
             since January 1, 1970, 00:00:00 UTC.
-        UtmpEventData: event data of the UTMP entry read.
+        UtmpEventData: event data of the utmp entry read.
 
     Raises:
       ParseError: if the entry cannot be parsed.
@@ -81,14 +81,14 @@ class UtmpParser(dtfabric_parser.DtFabricBaseParser):
           file_object, file_offset, entry_map)
     except (ValueError, errors.ParseError) as exception:
       raise errors.ParseError((
-          'Unable to parse UTMP entry at offset: 0x{0:08x} with error: '
+          'Unable to parse utmp entry at offset: 0x{0:08x} with error: '
           '{1!s}.').format(file_offset, exception))
 
     if entry.type not in self._SUPPORTED_TYPES:
       raise errors.UnableToParseFile('Unsupported type: {0:d}'.format(
           entry.type))
 
-    encoding = parser_mediator.codepage or 'utf8'
+    encoding = parser_mediator.codepage or 'utf-8'
 
     try:
       username = entry.username.rstrip(b'\x00')
@@ -139,7 +139,7 @@ class UtmpParser(dtfabric_parser.DtFabricBaseParser):
     return timestamp, event_data
 
   def ParseFileObject(self, parser_mediator, file_object, **kwargs):
-    """Parses an UTMP file-like object.
+    """Parses an utmp file-like object.
 
     Args:
       parser_mediator (ParserMediator): mediates interactions between parsers
@@ -156,15 +156,15 @@ class UtmpParser(dtfabric_parser.DtFabricBaseParser):
           parser_mediator, file_object, file_offset)
     except errors.ParseError as exception:
       raise errors.UnableToParseFile(
-          'Unable to parse UTMP header with error: {0!s}'.format(exception))
+          'Unable to parse utmp header with error: {0!s}'.format(exception))
 
     if not event_data.username:
       raise errors.UnableToParseFile(
-          'Unable to parse UTMP header with error: missing username')
+          'Unable to parse utmp header with error: missing username')
 
     if not timestamp:
       raise errors.UnableToParseFile(
-          'Unable to parse UTMP header with error: missing timestamp')
+          'Unable to parse utmp header with error: missing timestamp')
 
     date_time = dfdatetime_posix_time.PosixTimeInMicroseconds(
         timestamp=timestamp)
@@ -182,7 +182,7 @@ class UtmpParser(dtfabric_parser.DtFabricBaseParser):
       try:
         timestamp, event_data = self._ReadEntry(
             parser_mediator, file_object, file_offset)
-      except errors.ParseError as exception:
+      except errors.ParseError:
         # Note that the utmp file can contain trailing data.
         break
 

--- a/plaso/parsers/utmp.py
+++ b/plaso/parsers/utmp.py
@@ -3,8 +3,6 @@
 
 from __future__ import unicode_literals
 
-import os
-
 from dfdatetime import posix_time as dfdatetime_posix_time
 
 from plaso.containers import events

--- a/plaso/parsers/utmp.py
+++ b/plaso/parsers/utmp.py
@@ -15,7 +15,6 @@ from plaso.containers import time_events
 from plaso.lib import errors
 from plaso.lib import definitions
 from plaso.parsers import data_formats
-from plaso.parsers import logger
 from plaso.parsers import manager
 
 
@@ -159,7 +158,7 @@ class UtmpParser(data_formats.DataFormatParser):
       parser_mediator.ProduceExtractionError('unable to unpack IP address')
       ip_address = None
 
-    # TODO: add termination status. 
+    # TODO: add termination status.
     # TODO: rename event data attributes to match data definition.
     event_data = UtmpEventData()
     event_data.computer_name = hostname

--- a/plaso/parsers/utmp.py
+++ b/plaso/parsers/utmp.py
@@ -190,6 +190,9 @@ class UtmpParser(data_formats.DataFormatParser):
     file_size = file_object.get_size()
 
     while file_offset < file_size:
+      if parser_mediator.abort:
+        break
+
       try:
         timestamp, event_data = self._ReadEntry(
             parser_mediator, file_object, file_offset)

--- a/plaso/parsers/utmp.py
+++ b/plaso/parsers/utmp.py
@@ -174,7 +174,7 @@ class UtmpParser(dtfabric_parser.DtFabricBaseParser):
         date_time, definitions.TIME_DESCRIPTION_START)
     parser_mediator.ProduceEventWithEventData(event, event_data)
 
-    file_offset += self._UTMP_ENTRY_SIZE
+    file_offset = file_object.tell()
     file_size = file_object.get_size()
 
     while file_offset < file_size:
@@ -194,7 +194,7 @@ class UtmpParser(dtfabric_parser.DtFabricBaseParser):
           date_time, definitions.TIME_DESCRIPTION_START)
       parser_mediator.ProduceEventWithEventData(event, event_data)
 
-      file_offset += self._UTMP_ENTRY_SIZE
+      file_offset = file_object.tell()
 
 
 manager.ParsersManager.RegisterParser(UtmpParser)

--- a/plaso/parsers/utmp.yaml
+++ b/plaso/parsers/utmp.yaml
@@ -1,0 +1,74 @@
+name: utmp
+type: format
+description: Utmp login records format
+urls: ["https://github.com/libyal/dtformats/blob/master/documentation/Utmp%20login%20records%20format.asciidoc"]
+---
+name: byte
+type: integer
+attributes:
+  format: unsigned
+  size: 1
+  units: bytes
+---
+name: int16
+type: integer
+attributes:
+  format: signed
+  size: 2
+  units: bytes
+---
+name: int32
+type: integer
+attributes:
+  format: signed
+  size: 4
+  units: bytes
+---
+name: uint32
+type: integer
+attributes:
+  format: unsigned
+  size: 4
+  units: bytes
+---
+name: utmp_entry
+type: structure
+attributes:
+  byte_order: little-endian
+members:
+- name: type
+  data_type: int32
+- name: pid
+  data_type: uint32
+- name: terminal
+  type: stream
+  element_data_type: byte
+  number_of_elements: 32
+- name: terminal_identifier
+  data_type: uint32
+- name: username
+  type: stream
+  element_data_type: byte
+  number_of_elements: 32
+- name: hostname
+  type: stream
+  element_data_type: byte
+  number_of_elements: 256
+- name: termination_status
+  data_type: int16
+- name: exit_status
+  data_type: int16
+- name: session
+  data_type: int32
+- name: timestamp
+  data_type: int32
+- name: microseconds
+  data_type: int32
+- name: ip_address
+  type: stream
+  element_data_type: byte
+  number_of_elements: 16
+- name: unknown1
+  type: stream
+  element_data_type: byte
+  number_of_elements: 20

--- a/plaso/parsers/utmp.yaml
+++ b/plaso/parsers/utmp.yaml
@@ -65,7 +65,7 @@ members:
 - name: microseconds
   data_type: int32
 - name: ip_address
-  type: stream
+  type: sequence
   element_data_type: byte
   number_of_elements: 16
 - name: unknown1

--- a/tests/formatters/utmp.py
+++ b/tests/formatters/utmp.py
@@ -24,14 +24,14 @@ class UtmpSessionFormatterTest(test_lib.EventFormatterTestCase):
     event_formatter = utmp.UtmpSessionFormatter()
 
     expected_attribute_names = [
-        'user',
+        'username',
         'computer_name',
         'terminal',
         'pid',
-        'terminal_id',
+        'terminal_identifier',
         'status',
         'ip_address',
-        'exit']
+        'exit_status']
 
     self._TestGetFormatStringAttributeNames(
         event_formatter, expected_attribute_names)

--- a/tests/parsers/dtfabric_parser.py
+++ b/tests/parsers/dtfabric_parser.py
@@ -121,6 +121,22 @@ members:
 
   _SHAPE3D = _DATA_TYPE_FABRIC.CreateDataTypeMap('shape3d')
 
+  def testFormatPackedIPv4Address(self):
+    """Tests the _FormatPackedIPv4Address function."""
+    parser = data_formats.DataFormatParser()
+
+    ip_address = parser._FormatPackedIPv4Address([0xc0, 0xa8, 0xcc, 0x62])
+    self.assertEqual(ip_address, '192.168.204.98')
+
+  def testFormatPackedIPv6Address(self):
+    """Tests the _FormatPackedIPv6Address function."""
+    parser = data_formats.DataFormatParser()
+
+    ip_address = parser._FormatPackedIPv6Address([
+        0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x00,
+        0x00, 0x42, 0x83, 0x29])
+    self.assertEqual(ip_address, '2001:0db8:0000:0000:0000:ff00:0042:8329')
+
   # TODO: add tests for _GetDataTypeMap
 
   def testReadData(self):

--- a/tests/parsers/dtfabric_parser.py
+++ b/tests/parsers/dtfabric_parser.py
@@ -123,14 +123,14 @@ members:
 
   def testFormatPackedIPv4Address(self):
     """Tests the _FormatPackedIPv4Address function."""
-    parser = data_formats.DataFormatParser()
+    parser = dtfabric_parser.DtFabricBaseParser()
 
     ip_address = parser._FormatPackedIPv4Address([0xc0, 0xa8, 0xcc, 0x62])
     self.assertEqual(ip_address, '192.168.204.98')
 
   def testFormatPackedIPv6Address(self):
     """Tests the _FormatPackedIPv6Address function."""
-    parser = data_formats.DataFormatParser()
+    parser = dtfabric_parser.DtFabricBaseParser()
 
     ip_address = parser._FormatPackedIPv6Address([
         0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x00,

--- a/tests/parsers/utmp.py
+++ b/tests/parsers/utmp.py
@@ -14,11 +14,11 @@ from tests.parsers import test_lib
 
 
 class UtmpParserTest(test_lib.ParserTestCase):
-  """The unit test for UTMP parser."""
+  """The unit test for utmp parser."""
 
   @shared_test_lib.skipUnlessHasTestFile(['utmp'])
   def testParseUtmpFile(self):
-    """Tests the Parse function on an UTMP file."""
+    """Tests the Parse function on a utmp file."""
     parser = utmp.UtmpParser()
     storage_writer = self._ParseFile(['utmp'], parser)
 
@@ -83,7 +83,7 @@ class UtmpParserTest(test_lib.ParserTestCase):
 
   @shared_test_lib.skipUnlessHasTestFile(['wtmp.1'])
   def testParseWtmpFile(self):
-    """Tests the Parse function on a WTMP file."""
+    """Tests the Parse function on a wtmp file."""
     parser = utmp.UtmpParser()
     storage_writer = self._ParseFile(['wtmp.1'], parser)
 

--- a/tests/parsers/utmp.py
+++ b/tests/parsers/utmp.py
@@ -28,32 +28,32 @@ class UtmpParserTest(test_lib.ParserTestCase):
 
     event = events[0]
     self.assertEqual(event.terminal, 'system boot')
-    self.assertEqual(event.status, 'BOOT_TIME')
+    self.assertEqual(event.type, 2)
 
     event = events[1]
-    self.assertEqual(event.status, 'RUN_LVL')
+    self.assertEqual(event.type, 1)
 
     event = events[2]
 
     self.CheckTimestamp(event.timestamp, '2013-12-13 14:45:09.000000')
 
-    self.assertEqual(event.user, 'LOGIN')
+    self.assertEqual(event.username, 'LOGIN')
     self.assertEqual(event.computer_name, 'localhost')
     self.assertEqual(event.terminal, 'tty4')
-    self.assertEqual(event.status, 'LOGIN_PROCESS')
-    self.assertEqual(event.exit, 0)
+    self.assertEqual(event.type, 6)
+    self.assertEqual(event.exit_status, 0)
     self.assertEqual(event.pid, 1115)
-    self.assertEqual(event.terminal_id, 52)
+    self.assertEqual(event.terminal_identifier, 52)
 
     expected_message = (
         'User: LOGIN '
         'Computer Name: localhost '
         'Terminal: tty4 '
         'PID: 1115 '
-        'Terminal_ID: 52 '
+        'Terminal identifier: 52 '
         'Status: LOGIN_PROCESS '
         'IP Address: 0.0.0.0 '
-        'Exit: 0')
+        'Exit status: 0')
     expected_short_message = 'User: LOGIN'
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
@@ -61,23 +61,23 @@ class UtmpParserTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2013-12-18 22:46:56.305504')
 
-    self.assertEqual(event.user, 'moxilo')
+    self.assertEqual(event.username, 'moxilo')
     self.assertEqual(event.computer_name, 'localhost')
     self.assertEqual(event.terminal, 'pts/4')
-    self.assertEqual(event.status, 'USER_PROCESS')
-    self.assertEqual(event.exit, 0)
+    self.assertEqual(event.type, 7)
+    self.assertEqual(event.exit_status, 0)
     self.assertEqual(event.pid, 2684)
-    self.assertEqual(event.terminal_id, 13359)
+    self.assertEqual(event.terminal_identifier, 13359)
 
     expected_message = (
         'User: moxilo '
         'Computer Name: localhost '
         'Terminal: pts/4 '
         'PID: 2684 '
-        'Terminal_ID: 13359 '
+        'Terminal identifier: 13359 '
         'Status: USER_PROCESS '
         'IP Address: 0.0.0.0 '
-        'Exit: 0')
+        'Exit status: 0')
     expected_short_message = 'User: moxilo'
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
@@ -95,24 +95,24 @@ class UtmpParserTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2011-12-01 17:36:38.432935')
 
-    self.assertEqual(event.user, 'userA')
+    self.assertEqual(event.username, 'userA')
     self.assertEqual(event.computer_name, '10.10.122.1')
     self.assertEqual(event.terminal, 'pts/32')
-    self.assertEqual(event.status, 'USER_PROCESS')
+    self.assertEqual(event.type, 7)
     self.assertEqual(event.ip_address, '10.10.122.1')
-    self.assertEqual(event.exit, 0)
+    self.assertEqual(event.exit_status, 0)
     self.assertEqual(event.pid, 20060)
-    self.assertEqual(event.terminal_id, 842084211)
+    self.assertEqual(event.terminal_identifier, 842084211)
 
     expected_message = (
         'User: userA '
         'Computer Name: 10.10.122.1 '
         'Terminal: pts/32 '
         'PID: 20060 '
-        'Terminal_ID: 842084211 '
+        'Terminal identifier: 842084211 '
         'Status: USER_PROCESS '
         'IP Address: 10.10.122.1 '
-        'Exit: 0')
+        'Exit status: 0')
     expected_short_message = 'User: userA'
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 

--- a/tests/parsers/utmp.py
+++ b/tests/parsers/utmp.py
@@ -18,7 +18,7 @@ class UtmpParserTest(test_lib.ParserTestCase):
 
   @shared_test_lib.skipUnlessHasTestFile(['utmp'])
   def testParseUtmpFile(self):
-    """Tests the Parse function for an UTMP file."""
+    """Tests the Parse function on an UTMP file."""
     parser = utmp.UtmpParser()
     storage_writer = self._ParseFile(['utmp'], parser)
 
@@ -44,6 +44,7 @@ class UtmpParserTest(test_lib.ParserTestCase):
     self.assertEqual(event.exit, 0)
     self.assertEqual(event.pid, 1115)
     self.assertEqual(event.terminal_id, 52)
+
     expected_message = (
         'User: LOGIN '
         'Computer Name: localhost '
@@ -51,10 +52,9 @@ class UtmpParserTest(test_lib.ParserTestCase):
         'PID: 1115 '
         'Terminal_ID: 52 '
         'Status: LOGIN_PROCESS '
-        'IP Address: localhost '
+        'IP Address: 0.0.0.0 '
         'Exit: 0')
-    expected_short_message = (
-        'User: LOGIN')
+    expected_short_message = 'User: LOGIN'
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
     event = events[12]
@@ -68,6 +68,7 @@ class UtmpParserTest(test_lib.ParserTestCase):
     self.assertEqual(event.exit, 0)
     self.assertEqual(event.pid, 2684)
     self.assertEqual(event.terminal_id, 13359)
+
     expected_message = (
         'User: moxilo '
         'Computer Name: localhost '
@@ -75,15 +76,14 @@ class UtmpParserTest(test_lib.ParserTestCase):
         'PID: 2684 '
         'Terminal_ID: 13359 '
         'Status: USER_PROCESS '
-        'IP Address: localhost '
+        'IP Address: 0.0.0.0 '
         'Exit: 0')
-    expected_short_message = (
-        'User: moxilo')
+    expected_short_message = 'User: moxilo'
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
   @shared_test_lib.skipUnlessHasTestFile(['wtmp.1'])
   def testParseWtmpFile(self):
-    """Tests the Parse function for an WTMP file."""
+    """Tests the Parse function on a WTMP file."""
     parser = utmp.UtmpParser()
     storage_writer = self._ParseFile(['wtmp.1'], parser)
 
@@ -103,6 +103,7 @@ class UtmpParserTest(test_lib.ParserTestCase):
     self.assertEqual(event.exit, 0)
     self.assertEqual(event.pid, 20060)
     self.assertEqual(event.terminal_id, 842084211)
+
     expected_message = (
         'User: userA '
         'Computer Name: 10.10.122.1 '
@@ -112,8 +113,7 @@ class UtmpParserTest(test_lib.ParserTestCase):
         'Status: USER_PROCESS '
         'IP Address: 10.10.122.1 '
         'Exit: 0')
-    expected_short_message = (
-        'User: userA')
+    expected_short_message = 'User: userA'
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
 


### PR DESCRIPTION
[Code review: 343950043: Migrated utmp construct-based parsers to use dtfabric #1893](https://codereview.appspot.com/343950043/)