### PR TITLE
348840043: Migrated Safari cookies construct-based parser to use dtfabric #1893

### DIFF
--- a/plaso/parsers/safari_cookies.py
+++ b/plaso/parsers/safari_cookies.py
@@ -93,12 +93,11 @@ class BinaryCookieParser(data_formats.DataFormatParser):
     self._cookie_plugins = (
         cookie_plugins_manager.CookiePluginsManager.GetPlugins())
 
-  def _ParsePage(self, parser_mediator, page_number, page_data):
+  def _ParsePage(self, parser_mediator, page_data):
     """Parses a page.
 
     Args:
       parser_mediator (ParserMediator): parser mediator.
-      page_number (int): page number.
       page_data (bytes): page data.
 
     Raises:
@@ -110,8 +109,6 @@ class BinaryCookieParser(data_formats.DataFormatParser):
       raise errors.ParseError((
           'Unable to map page header data at offset: 0x{0:08x} with error: '
           '{1!s}').format(file_offset, exception))
-
-    page_header_data_size = 8 + (4 * page_header.number_of_records)
 
     for record_offset in page_header.offsets:
       if parser_mediator.abort:
@@ -266,17 +263,17 @@ class BinaryCookieParser(data_formats.DataFormatParser):
           'Unable to map page sizes data at offset: 0x{0:08x} with error: '
           '{1!s}').format(file_offset, exception))
 
-    for index, page_size in enumerate(page_sizes_array):
+    for page_number, page_size in enumerate(page_sizes_array):
       if parser_mediator.abort:
         break
 
       page_data = file_object.read(page_size)
       if len(page_data) != page_size:
         parser_mediator.ProduceExtractionError(
-            'unable to read page: {0:d}'.format(index))
+            'unable to read page: {0:d}'.format(page_number))
         break
 
-      self._ParsePage(parser_mediator, index, page_data)
+      self._ParsePage(parser_mediator, page_data)
 
     # TODO: check file footer.
 

--- a/plaso/parsers/safari_cookies.yaml
+++ b/plaso/parsers/safari_cookies.yaml
@@ -46,7 +46,8 @@ attributes:
   units: bytes
 ---
 name: cstring
-type: stream
+type: string
+encoding: ascii
 element_data_type: byte
 elements_terminator: "\x00"
 ---

--- a/plaso/parsers/safari_cookies.yaml
+++ b/plaso/parsers/safari_cookies.yaml
@@ -68,16 +68,6 @@ type: sequence
 element_data_type: uint32be
 number_of_elements: binarycookies_file_header.number_of_pages
 ---
-name: binarycookies_file_footer
-type: structure
-attributes:
-  byte_order: big-endian
-members:
-- name: unknown1
-  type: stream
-  element_data_type: byte
-  number_of_elements: 8
----
 name: binarycookies_page_header
 type: structure
 attributes:

--- a/plaso/parsers/safari_cookies.yaml
+++ b/plaso/parsers/safari_cookies.yaml
@@ -1,0 +1,120 @@
+name: binarycookies
+type: format
+description: Safari cookies file format
+urls: ["https://github.com/libyal/dtformats/blob/master/documentation/Safari%20Cookies.asciidoc"]
+---
+name: byte
+type: integer
+attributes:
+  format: unsigned
+  size: 1
+  units: bytes
+---
+name: uint16
+type: integer
+attributes:
+  format: unsigned
+  size: 2
+  units: bytes
+---
+name: uint32
+type: integer
+attributes:
+  format: unsigned
+  size: 4
+  units: bytes
+---
+name: uint32be
+type: integer
+attributes:
+  byte_order: big-endian
+  format: unsigned
+  size: 4
+  units: bytes
+---
+name: uint64
+type: integer
+attributes:
+  format: unsigned
+  size: 8
+  units: bytes
+---
+name: float64
+type: floating-point
+attributes:
+  size: 8
+  units: bytes
+---
+name: cstring
+type: stream
+element_data_type: byte
+elements_terminator: "\x00"
+---
+name: binarycookies_file_header
+type: structure
+attributes:
+  byte_order: big-endian
+members:
+- name: signature
+  type: stream
+  element_data_type: byte
+  number_of_elements: 4
+- name: number_of_pages
+  data_type: uint32
+---
+name: binarycookies_page_sizes
+type: sequence
+element_data_type: uint32be
+number_of_elements: binarycookies_file_header.number_of_pages
+---
+name: binarycookies_file_footer
+type: structure
+attributes:
+  byte_order: big-endian
+members:
+- name: unknown1
+  type: stream
+  element_data_type: byte
+  number_of_elements: 8
+---
+name: binarycookies_page_header
+type: structure
+attributes:
+  byte_order: little-endian
+members:
+- name: signature
+  data_type: uint32
+- name: number_of_records
+  data_type: uint32
+- name: offsets
+  type: sequence
+  element_data_type: uint32
+  number_of_elements: binarycookies_page_header.number_of_records
+---
+name: binarycookies_record_header
+type: structure
+attributes:
+  byte_order: little-endian
+members:
+- name: size
+  data_type: uint32
+- name: unknown1
+  data_type: uint32
+- name: flags
+  data_type: uint32
+- name: unknown2
+  data_type: uint32
+- name: url_offset
+  data_type: uint32
+- name: name_offset
+  data_type: uint32
+- name: path_offset
+  data_type: uint32
+- name: value_offset
+  data_type: uint32
+- name: unknown3
+  data_type: uint64
+- name: expiration_time
+  data_type: float64
+- name: creation_time
+  data_type: float64


### PR DESCRIPTION
[Code review: 348840043: Migrated Safari cookies construct-based parser to use dtfabric #1893](https://codereview.appspot.com/348840043/)