### PR TITLE
Fixed some bugs with the new artifact filter processing

### DIFF
--- a/plaso/cli/extraction_tool.py
+++ b/plaso/cli/extraction_tool.py
@@ -16,6 +16,7 @@ from plaso.cli import storage_media_tool
 from plaso.cli import tool_options
 from plaso.cli.helpers import manager as helpers_manager
 from plaso.engine import configurations
+from plaso.engine import engine
 from plaso.lib import definitions
 from plaso.lib import errors
 from plaso.parsers import manager as parsers_manager
@@ -167,8 +168,10 @@ class ExtractionTool(
     logger.debug('Starting preprocessing.')
 
     try:
+      artifacts_registry = engine.BaseEngine.BuildArtifactsRegistry(
+          self._artifact_definitions_path, self._custom_artifacts_path)
       extraction_engine.PreprocessSources(
-          self._artifacts_registry, self._source_path_specs,
+          artifacts_registry, self._source_path_specs,
           resolver_context=self._resolver_context)
 
     except IOError as exception:

--- a/plaso/cli/helpers/artifact_definitions.py
+++ b/plaso/cli/helpers/artifact_definitions.py
@@ -127,7 +127,6 @@ class ArtifactDefinitionsArgumentsHelper(interface.ArgumentsHelper):
             'Unable to read artifact definitions from: {0:s} with error: '
             '{1!s}').format(custom_artifacts_path, exception))
 
-    setattr(configuration_object, '_artifacts_registry', registry)
     setattr(configuration_object, '_artifact_definitions_path', artifacts_path)
     setattr(
         configuration_object, '_custom_artifacts_path', custom_artifacts_path)

--- a/plaso/cli/helpers/artifact_definitions.py
+++ b/plaso/cli/helpers/artifact_definitions.py
@@ -127,6 +127,7 @@ class ArtifactDefinitionsArgumentsHelper(interface.ArgumentsHelper):
             'Unable to read artifact definitions from: {0:s} with error: '
             '{1!s}').format(custom_artifacts_path, exception))
 
+    setattr(configuration_object, '_artifacts_registry', registry)
     setattr(configuration_object, '_artifact_definitions_path', artifacts_path)
     setattr(
         configuration_object, '_custom_artifacts_path', custom_artifacts_path)

--- a/plaso/cli/helpers/artifact_filters.py
+++ b/plaso/cli/helpers/artifact_filters.py
@@ -42,7 +42,7 @@ class ArtifactFiltersArgumentsHelper(interface.ArgumentsHelper):
 
     argument_group.add_argument(
         '--artifact_filters_file', '--artifact-filters_file',
-        dest='artifact_filters', type=str, default=None,
+        dest='artifact_filters_file', type=str, default=None,
         action='store', help=(
             'Names of forensic artifact definitions, provided in a file with '
             'one artifact name per line. Forensic artifacts are stored in '

--- a/plaso/cli/helpers/artifact_filters.py
+++ b/plaso/cli/helpers/artifact_filters.py
@@ -42,7 +42,7 @@ class ArtifactFiltersArgumentsHelper(interface.ArgumentsHelper):
 
     argument_group.add_argument(
         '--artifact_filters_file', '--artifact-filters_file',
-        dest='artifact_filters_file', type=str, default=None,
+        dest='artifact_filters_file_path', type=str, default=None,
         action='store', help=(
             'Names of forensic artifact definitions, provided in a file with '
             'one artifact name per line. Forensic artifacts are stored in '

--- a/plaso/cli/helpers/artifact_filters.py
+++ b/plaso/cli/helpers/artifact_filters.py
@@ -43,7 +43,7 @@ class ArtifactFiltersArgumentsHelper(interface.ArgumentsHelper):
     argument_group.add_argument(
         '--artifact_filters_file', '--artifact-filters_file',
         dest='artifact_filters_file_path', type=str, default=None,
-        action='store', help=(
+        metavar='PATH', action='store', help=(
             'Names of forensic artifact definitions, provided in a file with '
             'one artifact name per line. Forensic artifacts are stored in '
             '.yaml files that are directly pulled from the artifact '

--- a/plaso/cli/log2timeline_tool.py
+++ b/plaso/cli/log2timeline_tool.py
@@ -419,15 +419,10 @@ class Log2TimelineTool(extraction_tool.ExtractionTool):
     self._SetExtractionParsersAndPlugins(configuration, session)
     self._SetExtractionPreferredTimeZone(extraction_engine.knowledge_base)
 
-    artifact_filters = getattr(configuration, '_artifact_filters', None)
-    artifact_definitions_path = getattr(
-        configuration, '_artifact_definitions_path', None)
-    custom_artifacts_path = getattr(
-        configuration, '_custom_artifacts_path', None)
     filter_find_specs = engine.BaseEngine.BuildFilterFindSpecs(
-        artifact_definitions_path, custom_artifacts_path,
-        extraction_engine.knowledge_base, artifact_filters,
-        configuration.filter_file)
+        self._artifact_definitions_path, self._custom_artifacts_path,
+        extraction_engine.knowledge_base, self._artifact_filters,
+        self._filter_file)
 
     processing_status = None
     if single_process_mode:

--- a/plaso/cli/psteal_tool.py
+++ b/plaso/cli/psteal_tool.py
@@ -319,15 +319,10 @@ class PstealTool(
     self._SetExtractionParsersAndPlugins(configuration, session)
     self._SetExtractionPreferredTimeZone(extraction_engine.knowledge_base)
 
-    artifact_filters = getattr(configuration, '_artifact_filters', None)
-    artifact_definitions_path = getattr(
-        configuration, '_artifact_definitions_path', None)
-    custom_artifacts_path = getattr(
-        configuration, '_custom_artifacts_path', None)
     filter_find_specs = engine.BaseEngine.BuildFilterFindSpecs(
-        artifact_definitions_path, custom_artifacts_path,
-        extraction_engine.knowledge_base, artifact_filters,
-        configuration.filter_file)
+        self._artifact_definitions_path, self._custom_artifacts_path,
+        extraction_engine.knowledge_base, self._artifact_filters,
+        self._filter_file)
 
     processing_status = None
     if single_process_mode:
@@ -454,8 +449,7 @@ class PstealTool(
     self._ParseTimezoneOption(options)
 
     argument_helper_names = [
-        'artifact_definitions', 'custom_artifact_definitions',
-        'hashers', 'language', 'parsers']
+        'artifact_definitions', 'hashers', 'language', 'parsers']
     helpers_manager.ArgumentHelperManager.ParseOptions(
         options, self, names=argument_helper_names)
 

--- a/plaso/cli/storage_media_tool.py
+++ b/plaso/cli/storage_media_tool.py
@@ -63,6 +63,8 @@ class StorageMediaTool(tools.CLITool):
     """
     super(StorageMediaTool, self).__init__(
         input_reader=input_reader, output_writer=output_writer)
+    self._custom_artifacts_path = None
+    self._artifact_definitions_path = None
     self._artifact_filters = None
     self._credentials = []
     self._credential_configurations = []

--- a/tests/cli/helpers/artifact_filters.py
+++ b/tests/cli/helpers/artifact_filters.py
@@ -21,7 +21,7 @@ class ArtifactFiltersArgumentsHelperTest(cli_test_lib.CLIToolTestCase):
 
   _EXPECTED_OUTPUT = """\
 usage: cli_helper.py [--artifact_filters ARTIFACT_FILTERS]
-                     [--artifact_filters_file ARTIFACT_FILTERS_FILE_PATH]
+                     [--artifact_filters_file PATH]
 
 Test argument parser.
 
@@ -36,7 +36,7 @@ optional arguments:
                         can be used to describe and quickly collect data of
                         interest, such as specific files or Windows Registry
                         keys.
-  --artifact_filters_file ARTIFACT_FILTERS_FILE_PATH, --artifact-filters_file ARTIFACT_FILTERS_FILE_PATH
+  --artifact_filters_file PATH, --artifact-filters_file PATH
                         Names of forensic artifact definitions, provided in a
                         file with one artifact name per line. Forensic
                         artifacts are stored in .yaml files that are directly

--- a/tests/cli/helpers/artifact_filters.py
+++ b/tests/cli/helpers/artifact_filters.py
@@ -21,7 +21,7 @@ class ArtifactFiltersArgumentsHelperTest(cli_test_lib.CLIToolTestCase):
 
   _EXPECTED_OUTPUT = """\
 usage: cli_helper.py [--artifact_filters ARTIFACT_FILTERS]
-                     [--artifact_filters_file ARTIFACT_FILTERS]
+                     [--artifact_filters_file ARTIFACT_FILTERS_FILE]
 
 Test argument parser.
 
@@ -36,7 +36,7 @@ optional arguments:
                         can be used to describe and quickly collect data of
                         interest, such as specific files or Windows Registry
                         keys.
-  --artifact_filters_file ARTIFACT_FILTERS, --artifact-filters_file ARTIFACT_FILTERS
+  --artifact_filters_file ARTIFACT_FILTERS_FILE, --artifact-filters_file ARTIFACT_FILTERS_FILE
                         Names of forensic artifact definitions, provided in a
                         file with one artifact name per line. Forensic
                         artifacts are stored in .yaml files that are directly

--- a/tests/cli/helpers/artifact_filters.py
+++ b/tests/cli/helpers/artifact_filters.py
@@ -21,7 +21,7 @@ class ArtifactFiltersArgumentsHelperTest(cli_test_lib.CLIToolTestCase):
 
   _EXPECTED_OUTPUT = """\
 usage: cli_helper.py [--artifact_filters ARTIFACT_FILTERS]
-                     [--artifact_filters_file ARTIFACT_FILTERS_FILE]
+                     [--artifact_filters_file ARTIFACT_FILTERS_FILE_PATH]
 
 Test argument parser.
 
@@ -36,7 +36,7 @@ optional arguments:
                         can be used to describe and quickly collect data of
                         interest, such as specific files or Windows Registry
                         keys.
-  --artifact_filters_file ARTIFACT_FILTERS_FILE, --artifact-filters_file ARTIFACT_FILTERS_FILE
+  --artifact_filters_file ARTIFACT_FILTERS_FILE_PATH, --artifact-filters_file ARTIFACT_FILTERS_FILE_PATH
                         Names of forensic artifact definitions, provided in a
                         file with one artifact name per line. Forensic
                         artifacts are stored in .yaml files that are directly


### PR DESCRIPTION
## One line description of pull request
Fixing some bugs when processing from log2timeline.py


## Description:
There were some errors while processing from log2timeline.py, fixing these by refactoring passing of filter arguments.

**Related issue (if applicable):** fixes #<plaso issue number here>
Related to #1313

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/plaso/wiki/Codereview). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://github.com/log2timeline/plaso/wiki/Style-guide).

One of the maintainers will examine your code, and may request changes.

## Checklist:
  - [ ] Local tests pass
  - [ ] Tests on TravisCI pass
  - [ ] Codacy passes (or flags issues that you think are acceptable)
  - [ ] Coveralls indicates test coverage is sufficient

If [new dependencies](https://github.com/log2timeline/plaso/wiki/Adding-a-new-dependency) are required:
 - [ ] l2tdevtools has been updated
