### PR TITLE
343290043: Changed SQLite storage file schema to use BIGINT for timestamp #1970

### DIFF
--- a/plaso/storage/sqlite/sqlite_file.py
+++ b/plaso/storage/sqlite/sqlite_file.py
@@ -79,7 +79,7 @@ class SQLiteStorageFile(interface.BaseStorageFile):
   _CREATE_EVENT_TABLE_QUERY = (
       'CREATE TABLE {0:s} ('
       '_identifier INTEGER PRIMARY KEY AUTOINCREMENT,'
-      '_timestamp INTEGER,'
+      '_timestamp BIGINT,'
       '_data {1:s});')
 
   _HAS_TABLE_QUERY = (


### PR DESCRIPTION
[Code review: 343290043: Changed SQLite storage file schema to use BIGINT for timestamp #1970](https://codereview.appspot.com/343290043/)