### PR TITLE
Registry Files Open Error Bug Fix

### DIFF
--- a/plaso/engine/extractors.py
+++ b/plaso/engine/extractors.py
@@ -169,7 +169,10 @@ class EventExtractor(object):
           parser_mediator, parser, file_entry, file_object=file_object)
 
     finally:
-      file_object.close()
+      # Check if file_object is open as dfwinreg will have closed file_object.
+      # TODO: Fix once Issue #306 addressed in DFVFS
+      if file_object._is_open:  # pylint: disable=protected-access
+        file_object.close()
 
   def _ParseFileEntryWithParser(
       self, parser_mediator, parser, file_entry, file_object=None):
@@ -322,7 +325,10 @@ class EventExtractor(object):
             file_object=file_object)
 
     finally:
-      file_object.close()
+      # Check if file_object is open as dfwinreg will have closed file_object.
+      # TODO: Fix once Issue #306 addressed in DFVFS
+      if file_object._is_open:  # pylint: disable=protected-access
+        file_object.close()
 
   def ParseFileEntryMetadata(self, parser_mediator, file_entry):
     """Parses the file entry metadata e.g. file system data.


### PR DESCRIPTION
## One line description of pull request
Fix registry file parsing errors.


## Description:
Fix file closure errors as winreg and dfvfs will try to close the same file. 

**Related issue (if applicable):** Helps fix #2007 

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://github.com/log2timeline/plaso/wiki/Style-guide).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [ ] No new [new dependencies](https://github.com/log2timeline/plaso/wiki/Adding-a-new-dependency) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
