### PR TITLE
Replaced PATH variable shadowing original PATH environment variable

### DIFF
--- a/config/macos/uninstall.sh
+++ b/config/macos/uninstall.sh
@@ -63,21 +63,21 @@ then
 
   INSTALLED_FILES=`/usr/sbin/pkgutil --files ${PACKAGE_IDENTIFIER} --only-files`;
 
-  for PATH in ${INSTALLED_FILES};
+  for INSTALLED_FILE in ${INSTALLED_FILES};
   do
-    if test -f ${PATH};
+    if test -f ${INSTALLED_FILE};
     then
-      rm -f ${PATH};
+      rm -f ${INSTALLED_FILE};
     fi
   done
 
   INSTALLED_FILES=`/usr/sbin/pkgutil --files ${PACKAGE_IDENTIFIER} --only-dirs | sort -r`;
 
-  for PATH in ${INSTALLED_FILES};
+  for INSTALLED_FILE in ${INSTALLED_FILES};
   do
-    if test -d ${PATH};
+    if test -d ${INSTALLED_FILE};
     then
-      rmdir ${PATH} 2> /dev/null;
+      rmdir ${INSTALLED_FILE} 2> /dev/null;
     fi
   done
 
@@ -97,21 +97,21 @@ do
 
   INSTALLED_FILES=`/usr/sbin/pkgutil --files ${PACKAGE_IDENTIFIER} --only-files`;
 
-  for PATH in ${INSTALLED_FILES};
+  for INSTALLED_FILE in ${INSTALLED_FILES};
   do
-    if test -f ${PATH};
+    if test -f ${INSTALLED_FILE};
     then
-      rm -f ${PATH};
+      rm -f ${INSTALLED_FILE};
     fi
   done
 
   INSTALLED_FILES=`/usr/sbin/pkgutil --files ${PACKAGE_IDENTIFIER} --only-dirs | sort -r`;
 
-  for PATH in ${INSTALLED_FILES};
+  for INSTALLED_FILE in ${INSTALLED_FILES};
   do
-    if test -d ${PATH};
+    if test -d ${INSTALLED_FILE};
     then
-      rmdir ${PATH} 2> /dev/null;
+      rmdir ${INSTALLED_FILE} 2> /dev/null;
     fi
   done
 


### PR DESCRIPTION
## One line description of pull request
`PATH` was used in macOS's uninstalled.sh, shadowing the original environment variable. I replaced it with a more indicative name.


## Description:
PATH was used in macOS's uninstalled.sh, shadowing the original environment variable. 
I replaced it with `INSTALLED_FILE`, since it's the single instance of INSTALLED_FILES

**Related issue (if applicable):** fixes #<plaso issue number here>

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://github.com/log2timeline/plaso/wiki/Style-guide).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [ ] No new [new dependencies](https://github.com/log2timeline/plaso/wiki/Adding-a-new-dependency) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
