### PR TITLE
Fix issue 2059. Correct timestamp description.

### DIFF
--- a/plaso/parsers/amcache.py
+++ b/plaso/parsers/amcache.py
@@ -307,7 +307,7 @@ class AmcacheParser(interface.FileObjectParser):
 
     event = time_events.DateTimeValuesEvent(
         filetime.Filetime(amcache_datetime),
-        definitions.TIME_DESCRIPTION_LAST_RUN)
+        definitions.TIME_DESCRIPTION_MODIFICATION)
     parser_mediator.ProduceEventWithEventData(event, event_data)
 
     if event_data.createdts:


### PR DESCRIPTION
## One line description of pull request
Fix issue 2059.


## Description:
Corrects the timestamp of one of the extracted fields from 'last run' to 'content modification'


**Related issue (if applicable):** fixes #2059 

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://github.com/log2timeline/plaso/wiki/Style-guide).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [x] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://github.com/log2timeline/plaso/wiki/Adding-a-new-dependency) are required or l2tdevtools has been updated
  - [x] Reviewer assigned
