### PR TITLE
Add elastic ssl support

### DIFF
--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -18,7 +18,7 @@ class ElasticSearchServerArgumentsHelper(server_config.ServerArgumentsHelper):
   """Elastic Search server CLI arguments helper."""
 
   _DEFAULT_SERVER = '127.0.0.1'
-  _DEFAULT_PORT = None
+  _DEFAULT_PORT = 9200
 
 
 class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):

--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -33,7 +33,6 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
   _DEFAULT_FLUSH_INTERVAL = 1000
   _DEFAULT_RAW_FIELDS = False
   _DEFAULT_ELASTIC_USER = None
-  _DEFAULT_USE_SSL = False
   _DEFAULT_CA_CERTS = None
   _DEFAULT_URL_PREFIX = None
 
@@ -69,13 +68,12 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
         default=cls._DEFAULT_ELASTIC_USER, help=(
             'Username to use for Elasticsearch authentication.'))
     argument_group.add_argument(
-        '--use_ssl', dest='use_ssl', action='store',
-        default=cls._DEFAULT_USE_SSL, help=(
-            'Enforces use of ssl.'))
+        '--use_ssl', dest='use_ssl', action='store_true',
+        help='Enforces use of ssl.')
     argument_group.add_argument(
-        '--ca_certs', dest='ca_certs', action='store',
-        default=cls._DEFAULT_CA_CERTS, help=(
-            'Path to a file containing a list of root certificates.'))
+        '--ca_certificates_file_path', dest='ca_certificates_file_path',
+        action='store', type=str, default=cls._DEFAULT_CA_CERTS, help=(
+            'Path to a file containing a list of root certificates to trust.'))
     argument_group.add_argument(
         '--elastic_url_prefix', dest='elastic_url_prefix', type=str,
         action='store', default=cls._DEFAULT_URL_PREFIX, help=(
@@ -112,10 +110,12 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
         options, 'raw_fields', cls._DEFAULT_RAW_FIELDS)
     elastic_user = cls._ParseStringOption(
         options, 'elastic_user', default_value=cls._DEFAULT_ELASTIC_USER)
-    use_ssl = cls._ParseStringOption(
-        options, 'use_ssl', default_value=cls._DEFAULT_USE_SSL)
-    ca_certs = cls._ParseStringOption(
-        options, 'ca_certs', default_value=cls._DEFAULT_CA_CERTS)
+
+    use_ssl = getattr(options, 'use_ssl', False)
+
+    ca_certificates_path = cls._ParseStringOption(
+        options, 'ca_certificates_file_path',
+        default_value=cls._DEFAULT_CA_CERTS)
     elastic_url_prefix = cls._ParseStringOption(
         options, 'elastic_url_prefix', default_value=cls._DEFAULT_URL_PREFIX)
 
@@ -133,7 +133,7 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
     output_module.SetUsername(elastic_user)
     output_module.SetPassword(elastic_password)
     output_module.SetUseSSL(use_ssl)
-    output_module.SetCACerts(ca_certs)
+    output_module.SetCACertificatesPath(ca_certificates_path)
     output_module.SetURLPrefix(elastic_url_prefix)
 
 

--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -18,7 +18,7 @@ class ElasticSearchServerArgumentsHelper(server_config.ServerArgumentsHelper):
   """Elastic Search server CLI arguments helper."""
 
   _DEFAULT_SERVER = '127.0.0.1'
-  _DEFAULT_PORT = 9200
+  _DEFAULT_PORT = None
 
 
 class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
@@ -33,6 +33,7 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
   _DEFAULT_FLUSH_INTERVAL = 1000
   _DEFAULT_RAW_FIELDS = False
   _DEFAULT_ELASTIC_USER = None
+  _DEFAULT_CA_CERTS = None
 
   @classmethod
   def AddArguments(cls, argument_group):
@@ -65,6 +66,10 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
         '--elastic_user', dest='elastic_user', action='store',
         default=cls._DEFAULT_ELASTIC_USER, help=(
             'Username to use for Elasticsearch authentication.'))
+    argument_group.add_argument(
+        '--ca_certs', dest='ca_certs', action='store',
+        default=cls._DEFAULT_CA_CERTS, help=(
+            'Path to a file containing a list of root certificates.'))
 
     ElasticSearchServerArgumentsHelper.AddArguments(argument_group)
 
@@ -104,6 +109,9 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
     else:
       elastic_password = None
 
+    ca_certs = cls._ParseStringOption(
+        options, 'ca_certs', default_value=cls._DEFAULT_CA_CERTS)
+
     ElasticSearchServerArgumentsHelper.ParseOptions(options, output_module)
     output_module.SetIndexName(index_name)
     output_module.SetDocumentType(document_type)
@@ -111,6 +119,7 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
     output_module.SetRawFields(raw_fields)
     output_module.SetUsername(elastic_user)
     output_module.SetPassword(elastic_password)
+    output_module.SetCACerts(ca_certs)
 
 
 manager.ArgumentHelperManager.RegisterHelper(ElasticSearchOutputArgumentsHelper)

--- a/plaso/output/shared_elastic.py
+++ b/plaso/output/shared_elastic.py
@@ -65,20 +65,27 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     self._password = None
     self._port = None
     self._username = None
+    self._ca_certs = None
 
   def _Connect(self):
     """Connects to an Elasticsearch server."""
-    elastic_hosts = [{'host': self._host, 'port': self._port}]
+    if self._port is not None:
+      elastic_hosts = [{'host': self._host, 'port': self._port}]
+    else:
+      elastic_hosts = [self._host]
 
     elastic_http_auth = None
     if self._username is not None:
       elastic_http_auth = (self._username, self._password)
 
     self._client = elasticsearch.Elasticsearch(
-        elastic_hosts, http_auth=elastic_http_auth)
+        elastic_hosts,
+        http_auth=elastic_http_auth,
+        ca_certs=self._ca_certs
+    )
 
     logger.debug('Connected to Elasticsearch server: {0:s} port: {1:d}.'.format(
-        self._host, self._port))
+        self._host, self._port or 9200))
 
   def _CreateIndexIfNotExists(self, index_name, mappings):
     """Creates an Elasticsearch index if it not already exists.
@@ -272,7 +279,7 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     """
     self._host = server
     self._port = port
-    logger.debug('Elasticsearch server: {0!s} port: {1:d}'.format(server, port))
+    logger.debug('Elasticsearch server: {0!s} port: {1:d}'.format(server, port or 9200))
 
   def SetUsername(self, username):
     """Sets the username.
@@ -282,6 +289,15 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     """
     self._username = username
     logger.debug('Elasticsearch username: {0!s}'.format(username))
+
+  def SetCACerts(self, ca_certs):
+    """Sets the certificates.
+
+    Args:
+      ca_certs (str): file containing a list of root certificates.
+    """
+    self._ca_certs = ca_certs
+    logger.debug('Elasticsearch ca_certs: {0!s}'.format(ca_certs))
 
   def WriteEventBody(self, event):
     """Writes an event to the output.
@@ -297,14 +313,20 @@ class SharedElasticsearch5OutputModule(SharedElasticsearchOutputModule):
 
   def _Connect(self):
     """Connects to an Elasticsearch server."""
-    elastic_hosts = [{'host': self._host, 'port': self._port}]
+    if self._port is not None:
+      elastic_hosts = [{'host': self._host, 'port': self._port}]
+    else:
+      elastic_hosts = [self._host]
 
     elastic_http_auth = None
     if self._username is not None:
       elastic_http_auth = (self._username, self._password)
 
     self._client = elasticsearch5.Elasticsearch(
-        elastic_hosts, http_auth=elastic_http_auth)
+        elastic_hosts,
+        http_auth=elastic_http_auth,
+        ca_certs=self._ca_certs
+    )
 
     logger.debug('Connected to Elasticsearch server: {0:s} port: {1:d}.'.format(
         self._host, self._port))

--- a/plaso/output/shared_elastic.py
+++ b/plaso/output/shared_elastic.py
@@ -3,6 +3,7 @@
 
 from __future__ import unicode_literals
 
+import os
 import logging
 
 from dfvfs.serializer.json_serializer import JsonPathSpecSerializer
@@ -90,7 +91,6 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     logger.debug(
         ('Connected to Elasticsearch server: {0:s} port: {1:d}'
          'URL prefix {2!s}.').format(self._host, self._port, self._url_prefix))
-
 
   def _CreateIndexIfNotExists(self, index_name, mappings):
     """Creates an Elasticsearch index if it does not exist.
@@ -305,14 +305,25 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     self._use_ssl = use_ssl
     logger.debug('Elasticsearch use_ssl: {0!s}'.format(use_ssl))
 
-  def SetCACerts(self, ca_certs):
-    """Sets the certificates.
+  def SetCACertificatesPath(self, ca_certificates_path):
+    """Sets the path to the CA certificates.
 
     Args:
-      ca_certs (str): file containing a list of root certificates.
+      ca_certificates_path (str): path to file containing a list of root
+        certificates to trust.
+
+    Raises:
+      BadConfigOption: if the CA certificates file does not exist.
     """
-    self._ca_certs = ca_certs
-    logger.debug('Elasticsearch ca_certs: {0!s}'.format(ca_certs))
+    if not ca_certificates_path:
+      return
+
+    if not os.path.exists(ca_certificates_path):
+      raise errors.BadConfigOption(
+          'No such certificate file: {0:s}.'.format(ca_certificates_path))
+
+    self._ca_certs = ca_certificates_path
+    logger.debug('Elasticsearch ca_certs: {0!s}'.format(ca_certificates_path))
 
   def SetURLPrefix(self, url_prefix):
     """Sets the URL prefix.

--- a/plaso/output/shared_elastic.py
+++ b/plaso/output/shared_elastic.py
@@ -279,7 +279,8 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     """
     self._host = server
     self._port = port
-    logger.debug('Elasticsearch server: {0!s} port: {1:d}'.format(server, port or 9200))
+    logger.debug('Elasticsearch server: {0!s} port: {1:d}'.format(
+        server, port or 9200))
 
   def SetUsername(self, username):
     """Sets the username.

--- a/tests/cli/helpers/elastic_output.py
+++ b/tests/cli/helpers/elastic_output.py
@@ -24,12 +24,13 @@ class ElasticSearchOutputArgumentsHelperTest(
   _EXPECTED_OUTPUT = """\
 usage: cli_helper.py [--index_name INDEX_NAME] [--doc_type DOCUMENT_TYPE]
                      [--flush_interval FLUSH_INTERVAL] [--raw_fields]
-                     [--elastic_user ELASTIC_USER] [--server HOSTNAME]
-                     [--port PORT]
+                     [--elastic_user ELASTIC_USER] [--ca_certs CA_CERTS]
+                     [--server HOSTNAME] [--port PORT]
 
 Test argument parser.
 
 optional arguments:
+  --ca_certs CA_CERTS   Path to a file containing a list of root certificates.
   --doc_type DOCUMENT_TYPE
                         Name of the document type that will be used in
                         ElasticSearch.

--- a/tests/cli/helpers/elastic_output.py
+++ b/tests/cli/helpers/elastic_output.py
@@ -24,15 +24,17 @@ class ElasticSearchOutputArgumentsHelperTest(
   _EXPECTED_OUTPUT = """\
 usage: cli_helper.py [--index_name INDEX_NAME] [--doc_type DOCUMENT_TYPE]
                      [--flush_interval FLUSH_INTERVAL] [--raw_fields]
-                     [--elastic_user ELASTIC_USER] [--use_ssl USE_SSL]
-                     [--ca_certs CA_CERTS]
+                     [--elastic_user ELASTIC_USER] [--use_ssl]
+                     [--ca_certificates_file_path CA_CERTIFICATES_FILE_PATH]
                      [--elastic_url_prefix ELASTIC_URL_PREFIX]
                      [--server HOSTNAME] [--port PORT]
 
 Test argument parser.
 
 optional arguments:
-  --ca_certs CA_CERTS   Path to a file containing a list of root certificates.
+  --ca_certificates_file_path CA_CERTIFICATES_FILE_PATH
+                        Path to a file containing a list of root certificates
+                        to trust.
   --doc_type DOCUMENT_TYPE
                         Name of the document type that will be used in
                         ElasticSearch.
@@ -49,7 +51,7 @@ optional arguments:
   --raw_fields          Export string fields that will not be analyzed by
                         Lucene.
   --server HOSTNAME     The hostname or server IP address of the server.
-  --use_ssl USE_SSL     Enforces use of ssl.
+  --use_ssl             Enforces use of ssl.
 """
 
   def testAddArguments(self):

--- a/tests/cli/helpers/elastic_output.py
+++ b/tests/cli/helpers/elastic_output.py
@@ -24,7 +24,8 @@ class ElasticSearchOutputArgumentsHelperTest(
   _EXPECTED_OUTPUT = """\
 usage: cli_helper.py [--index_name INDEX_NAME] [--doc_type DOCUMENT_TYPE]
                      [--flush_interval FLUSH_INTERVAL] [--raw_fields]
-                     [--elastic_user ELASTIC_USER] [--ca_certs CA_CERTS]
+                     [--elastic_user ELASTIC_USER] [--use_ssl USE_SSL]
+                     [--ca_certs CA_CERTS]
                      [--elastic_url_prefix ELASTIC_URL_PREFIX]
                      [--server HOSTNAME] [--port PORT]
 
@@ -48,6 +49,7 @@ optional arguments:
   --raw_fields          Export string fields that will not be analyzed by
                         Lucene.
   --server HOSTNAME     The hostname or server IP address of the server.
+  --use_ssl USE_SSL     Enforces use of ssl.
 """
 
   def testAddArguments(self):


### PR DESCRIPTION
## One line description of pull request

Add ssl support (with custom certificates) for elastic search

## Description:

- Remove default elasticsearch  port from plaso, it is still the 9200 by default from the elasticsearch python package. This way hosts can be defined by urls like `https://example.com:1234/var`
- Add ca_cert command line option for elasticsearch. This enables usage of custom certificates.

**Related issue (if applicable):** fixes #2047

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://github.com/log2timeline/plaso/wiki/Style-guide).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [x] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://github.com/log2timeline/plaso/wiki/Adding-a-new-dependency) are required or l2tdevtools has been updated
  - [x] Reviewer assigned
