### PR TITLE
Add ARTIFACT_GROUP support for image_export.py

### DIFF
--- a/plaso/engine/artifact_filters.py
+++ b/plaso/engine/artifact_filters.py
@@ -122,7 +122,7 @@ class ArtifactDefinitionsFilterHelper(object):
                       find_specs)
 
         elif (source.type_indicator ==
-             artifact_types.TYPE_INDICATOR_ARTIFACT_GROUP):
+              artifact_types.TYPE_INDICATOR_ARTIFACT_GROUP):
           self._artifacts.remove(name)
           for name_entry in set(source.names):
             self._artifacts.append(name_entry)

--- a/plaso/engine/artifact_filters.py
+++ b/plaso/engine/artifact_filters.py
@@ -120,8 +120,9 @@ class ArtifactDefinitionsFilterHelper(object):
               self.find_specs_per_source_type[
                   artifact_types.TYPE_INDICATOR_WINDOWS_REGISTRY_KEY].extend(
                       find_specs)
-        
-        elif source.type_indicator == artifact_types.TYPE_INDICATOR_ARTIFACT_GROUP:
+
+        elif (source.type_indicator ==
+             artifact_types.TYPE_INDICATOR_ARTIFACT_GROUP):
           self._artifacts.remove(name)
           for name_entry in set(source.names):
             self._artifacts.append(name_entry)

--- a/plaso/engine/artifact_filters.py
+++ b/plaso/engine/artifact_filters.py
@@ -2,6 +2,7 @@
 """Helper to create filters based on forensic artifact definitions."""
 
 from __future__ import unicode_literals
+from collections import defaultdict
 
 from artifacts import definitions as artifact_types
 
@@ -43,9 +44,7 @@ class ArtifactDefinitionsFilterHelper(object):
     self._artifacts = artifact_filters
     self._artifacts_registry = artifacts_registry
     self._knowledge_base = knowledge_base
-    self.find_specs_per_source_type = {
-        artifact_types.TYPE_INDICATOR_FILE: [],
-        artifact_types.TYPE_INDICATOR_WINDOWS_REGISTRY_KEY: []}
+    self._find_specs_per_source_type = defaultdict(list)
 
   @staticmethod
   def CheckKeyCompatibility(key_path):
@@ -89,8 +88,9 @@ class ArtifactDefinitionsFilterHelper(object):
             find_specs = self.BuildFindSpecsFromFileArtifact(
                 path_entry, source.separator, environment_variables,
                 self._knowledge_base.user_accounts)
-            self.find_specs_per_source_type[
-                artifact_types.TYPE_INDICATOR_FILE].extend(find_specs)
+            artifact_group = self._find_specs_per_source_type[
+                artifact_types.TYPE_INDICATOR_FILE]
+            artifact_group.extend(find_specs)
 
         elif (source.type_indicator ==
               artifact_types.TYPE_INDICATOR_WINDOWS_REGISTRY_KEY):
@@ -99,9 +99,9 @@ class ArtifactDefinitionsFilterHelper(object):
           for key_path in set(source.keys):
             if self.CheckKeyCompatibility(key_path):
               find_specs = self.BuildFindSpecsFromRegistryArtifact(key_path)
-              self.find_specs_per_source_type[
-                  artifact_types.TYPE_INDICATOR_WINDOWS_REGISTRY_KEY].extend(
-                      find_specs)
+              artifact_group = self._find_specs_per_source_type[
+                  artifact_types.TYPE_INDICATOR_WINDOWS_REGISTRY_KEY]
+              artifact_group.extend(find_specs)
 
         elif (source.type_indicator ==
               artifact_types.TYPE_INDICATOR_WINDOWS_REGISTRY_VALUE):
@@ -117,9 +117,9 @@ class ArtifactDefinitionsFilterHelper(object):
               key_value['key'] for key_value in source.key_value_pairs]):
             if self.CheckKeyCompatibility(key_path):
               find_specs = self.BuildFindSpecsFromRegistryArtifact(key_path)
-              self.find_specs_per_source_type[
-                  artifact_types.TYPE_INDICATOR_WINDOWS_REGISTRY_KEY].extend(
-                      find_specs)
+              artifact_group = self._find_specs_per_source_type[
+                  artifact_types.TYPE_INDICATOR_WINDOWS_REGISTRY_KEY]
+              artifact_group.extend(find_specs)
 
         elif (source.type_indicator ==
               artifact_types.TYPE_INDICATOR_ARTIFACT_GROUP):
@@ -134,7 +134,7 @@ class ArtifactDefinitionsFilterHelper(object):
                   source.type_indicator))
 
     self._knowledge_base.SetValue(
-        self.KNOWLEDGE_BASE_VALUE, self.find_specs_per_source_type)
+        self.KNOWLEDGE_BASE_VALUE, self._find_specs_per_source_type)
 
   def BuildFindSpecsFromFileArtifact(
       self, source_path, path_separator, environment_variables, user_accounts):

--- a/test_data/artifacts/artifacts_filters.yaml
+++ b/test_data/artifacts/artifacts_filters.yaml
@@ -5,7 +5,7 @@ doc: Test Group
 sources:
 - type: ARTIFACT_GROUP
   attributes:
-    names: 
+    names:
      - 'TestFiles3'
      - 'TestFiles4'
 labels: [System]
@@ -42,7 +42,7 @@ doc: Test Doc3
 sources:
 - type: FILE
   attributes:
-    paths: 
+    paths:
       - '\a_directory\'
       - '\a_directory\a_file'
     separator: '\'
@@ -54,7 +54,7 @@ doc: Test Doc4
 sources:
 - type: FILE
   attributes:
-    paths: 
+    paths:
       - '\a_directory\another_file'
       - '\passwords.txt'
     separator: '\'

--- a/test_data/artifacts/artifacts_filters.yaml
+++ b/test_data/artifacts/artifacts_filters.yaml
@@ -1,5 +1,16 @@
 # Artifact definitions.
 
+name: TestGroupExport
+doc: Test Group
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names: 
+     - 'TestFiles3'
+     - 'TestFiles4'
+labels: [System]
+supported_os: [Windows]
+---
 name: TestFiles
 doc: Test Doc
 sources:
@@ -22,6 +33,30 @@ sources:
       - '\does_not_exist\some_file_*.txt'
       - '\globbed\test\path\**\'
       - 'failing'
+    separator: '\'
+labels: [System]
+supported_os: [Windows]
+---
+name: TestFiles3
+doc: Test Doc3
+sources:
+- type: FILE
+  attributes:
+    paths: 
+      - '\a_directory\'
+      - '\a_directory\a_file'
+    separator: '\'
+labels: [System]
+supported_os: [Windows]
+---
+name: TestFiles4
+doc: Test Doc4
+sources:
+- type: FILE
+  attributes:
+    paths: 
+      - '\a_directory\another_file'
+      - '\passwords.txt'
     separator: '\'
 labels: [System]
 supported_os: [Windows]

--- a/tests/cli/image_export_tool.py
+++ b/tests/cli/image_export_tool.py
@@ -402,7 +402,7 @@ class ImageExportToolTest(test_lib.CLIToolTestCase):
   @shared_test_lib.skipUnlessHasTestFile(['artifacts'])
   @shared_test_lib.skipUnlessHasTestFile(['image.qcow2'])
   def testProcessSourcesExtractWithArtifactsFilter(self):
-    """Tests the ProcessSources function with a filter file."""
+    """Tests the ProcessSources function with a artifacts filter file."""
     output_writer = test_lib.TestOutputWriter(encoding='utf-8')
     test_tool = image_export_tool.ImageExportTool(output_writer=output_writer)
 
@@ -411,7 +411,7 @@ class ImageExportToolTest(test_lib.CLIToolTestCase):
     options.image = self._GetTestFilePath(['image.qcow2'])
     options.quiet = True
     options.artifact_filters = 'TestFilesImageExport'
-    
+
     with shared_test_lib.TempDirectory() as temp_directory:
       options.path = temp_directory
 
@@ -427,11 +427,11 @@ class ImageExportToolTest(test_lib.CLIToolTestCase):
       extracted_files = self._RecursiveList(temp_directory)
 
     self.assertEqual(sorted(extracted_files), expected_extracted_files)
-  
+
   @shared_test_lib.skipUnlessHasTestFile(['artifacts'])
   @shared_test_lib.skipUnlessHasTestFile(['image.qcow2'])
   def testProcessSourcesExtractWithArtifactsGroupFilter(self):
-    """Tests the ProcessSources function with a filter file."""
+    """Tests the ProcessSources function with a group artifacts filter file."""
     output_writer = test_lib.TestOutputWriter(encoding='utf-8')
     test_tool = image_export_tool.ImageExportTool(output_writer=output_writer)
 

--- a/tests/cli/image_export_tool.py
+++ b/tests/cli/image_export_tool.py
@@ -455,7 +455,6 @@ class ImageExportToolTest(test_lib.CLIToolTestCase):
           os.path.join(temp_directory, 'passwords.txt')])
 
       extracted_files = self._RecursiveList(temp_directory)
-      print  extracted_files
 
     self.assertEqual(sorted(extracted_files), expected_extracted_files)
 

--- a/tests/cli/image_export_tool.py
+++ b/tests/cli/image_export_tool.py
@@ -411,7 +411,7 @@ class ImageExportToolTest(test_lib.CLIToolTestCase):
     options.image = self._GetTestFilePath(['image.qcow2'])
     options.quiet = True
     options.artifact_filters = 'TestFilesImageExport'
-
+    
     with shared_test_lib.TempDirectory() as temp_directory:
       options.path = temp_directory
 
@@ -425,6 +425,37 @@ class ImageExportToolTest(test_lib.CLIToolTestCase):
           os.path.join(temp_directory, 'a_directory', 'a_file')])
 
       extracted_files = self._RecursiveList(temp_directory)
+
+    self.assertEqual(sorted(extracted_files), expected_extracted_files)
+  
+  @shared_test_lib.skipUnlessHasTestFile(['artifacts'])
+  @shared_test_lib.skipUnlessHasTestFile(['image.qcow2'])
+  def testProcessSourcesExtractWithArtifactsGroupFilter(self):
+    """Tests the ProcessSources function with a filter file."""
+    output_writer = test_lib.TestOutputWriter(encoding='utf-8')
+    test_tool = image_export_tool.ImageExportTool(output_writer=output_writer)
+
+    options = test_lib.TestOptions()
+    options.artifact_definitions_path = self._GetTestFilePath(['artifacts'])
+    options.image = self._GetTestFilePath(['image.qcow2'])
+    options.quiet = True
+    options.artifact_filters = 'TestGroupExport'
+
+    with shared_test_lib.TempDirectory() as temp_directory:
+      options.path = temp_directory
+
+      test_tool.ParseOptions(options)
+
+      test_tool.ProcessSources()
+
+      expected_extracted_files = sorted([
+          os.path.join(temp_directory, 'a_directory'),
+          os.path.join(temp_directory, 'a_directory', 'another_file'),
+          os.path.join(temp_directory, 'a_directory', 'a_file'),
+          os.path.join(temp_directory, 'passwords.txt')])
+
+      extracted_files = self._RecursiveList(temp_directory)
+      print  extracted_files
 
     self.assertEqual(sorted(extracted_files), expected_extracted_files)
 


### PR DESCRIPTION
## One line description of pull request
Adds support to export ARTIFACT_GROUP artifacts to image_export.py



## Description:
Adds support to export ARTIFACT_GROUP artifacts to image_export.py. Please pay attention as I moved
the 'find_specs_per_source_type' from function local to class variable!

**Related issue (if applicable):** fixes #2015

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://github.com/log2timeline/plaso/wiki/Style-guide).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [x] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://github.com/log2timeline/plaso/wiki/Adding-a-new-dependency) are required or l2tdevtools has been updated
  - [x] Reviewer assigned
