### PR TITLE
ignore comments for lsb-release files.

### DIFF
--- a/plaso/preprocessors/linux.py
+++ b/plaso/preprocessors/linux.py
@@ -123,7 +123,8 @@ class LinuxStandardBaseReleasePlugin(interface.FileArtifactPreprocessorPlugin):
 
     product_values = {}
     for line in text_file_object.readlines():
-      if line[0] == '#':
+      line = line.strip()
+      if line.startswith('#'):
         continue
       key, value = line.split('=')
       key = key.strip().upper()

--- a/plaso/preprocessors/linux.py
+++ b/plaso/preprocessors/linux.py
@@ -123,6 +123,8 @@ class LinuxStandardBaseReleasePlugin(interface.FileArtifactPreprocessorPlugin):
 
     product_values = {}
     for line in text_file_object.readlines():
+      if line[0] == '#':
+        continue
       key, value = line.split('=')
       key = key.strip().upper()
       value = value.strip().strip('"')


### PR DESCRIPTION
plaso breaks if the file has comments.

Traceback (most recent call last):
  File "/usr/bin/log2timeline.py", line 68, in <module>
    if not Main():
  File "/usr/bin/log2timeline.py", line 54, in Main
    tool.ExtractEventsFromSources()
  File "/usr/lib/python2.7/dist-packages/plaso/cli/log2timeline_tool.py", line 414, in ExtractEventsFromSources
    self._PreprocessSources(extraction_engine)
  File "/usr/lib/python2.7/dist-packages/plaso/cli/extraction_tool.py", line 175, in _PreprocessSources
    resolver_context=self._resolver_context)
  File "/usr/lib/python2.7/dist-packages/plaso/engine/engine.py", line 270, in PreprocessSources
    self.knowledge_base)
  File "/usr/lib/python2.7/dist-packages/plaso/preprocessors/manager.py", line 276, in RunPlugins
    artifacts_registry, knowledge_base, searcher, file_system)
  File "/usr/lib/python2.7/dist-packages/plaso/preprocessors/manager.py", line 146, in CollectFromFileSystem
    knowledge_base, artifact_definition, searcher, file_system)
  File "/usr/lib/python2.7/dist-packages/plaso/preprocessors/interface.py", line 82, in Collect
    source.separator)
  File "/usr/lib/python2.7/dist-packages/plaso/preprocessors/interface.py", line 135, in _ParsePathSpecification
    self._ParseFileEntry(knowledge_base, file_entry)
  File "/usr/lib/python2.7/dist-packages/plaso/preprocessors/interface.py", line 171, in _ParseFileEntry
    self._ParseFileData(knowledge_base, file_object)
  File "/usr/lib/python2.7/dist-packages/plaso/preprocessors/linux.py", line 126, in _ParseFileData
    key, value = line.split('=')
ValueError: need more than 1 value to unpack