### PR TITLE
Corrected use of incorrect attribute in CUPS IPP parser #2207

### DIFF
--- a/plaso/parsers/cups_ipp.py
+++ b/plaso/parsers/cups_ipp.py
@@ -306,7 +306,7 @@ class CupsIppParser(dtfabric_parser.DtFabricBaseParser):
           'Unable to parse datetime value with error: {0!s}'.format(exception))
 
     rfc2579_date_time_tuple = (
-        value.year, value.month, value.day,
+        value.year, value.month, value.day_of_month,
         value.hours, value.minutes, value.seconds, value.deciseconds,
         value.direction_from_utc, value.hours_from_utc, value.minutes_from_utc)
     return dfdatetime_rfc2579_date_time.RFC2579DateTime(

--- a/tests/parsers/cups_ipp.py
+++ b/tests/parsers/cups_ipp.py
@@ -17,6 +17,14 @@ from tests.parsers import test_lib
 class CupsIppParserTest(test_lib.ParserTestCase):
   """Tests for MacOS Cups IPP parser."""
 
+  # TODO: add tests for _GetStringValue
+  # TODO: add tests for _ParseAttribute
+  # TODO: add tests for _ParseAttributesGroup
+  # TODO: add tests for _ParseBooleanValue
+  # TODO: add tests for _ParseIntegerValue
+  # TODO: add tests for _ParseHeader
+  # TODO: add tests for ParseFileObject
+
   @shared_test_lib.skipUnlessHasTestFile(['mac_cups_ipp'])
   def testParse(self):
     """Tests the Parse function."""


### PR DESCRIPTION
Corrected use of incorrect attribute in CUPS IPP parser #2207