### PR TITLE
Added work-around for Python version dependent formatting #2248

### DIFF
--- a/plaso/cli/helpers/event_filters.py
+++ b/plaso/cli/helpers/event_filters.py
@@ -35,16 +35,16 @@ class EventFiltersArgumentsHelper(interface.ArgumentsHelper):
           argparse group.
     """
     argument_group.add_argument(
-        '--slice', metavar='DATE', dest='slice', type=str,
-        default='', action='store', help=(
+        '--slice', metavar='DATE', dest='slice', type=str, default='',
+        action='store', help=(
             'Create a time slice around a certain date. This parameter, if '
             'defined will display all events that happened X minutes before '
             'and after the defined date. X is controlled by the parameter '
             '--slice_size but defaults to 5 minutes.'))
 
     argument_group.add_argument(
-        '--slice_size', '--slice-size', dest='slice_size', type=int,
-        default=5, action='store', help=(
+        '--slice_size', '--slice-size', dest='slice_size', type=int, default=5,
+        action='store', help=(
             'Defines the slice size. In the case of a regular time slice it '
             'defines the number of minutes the slice size should be. In the '
             'case of the --slicer it determines the number of events before '

--- a/plaso/lib/py2to3.py
+++ b/plaso/lib/py2to3.py
@@ -24,3 +24,8 @@ else:
   STRING_TYPES = (str, )
   UNICHR = chr
   UNICODE_TYPE = str
+
+if tuple(sys.version_info[0:2]) >= (3, 5):
+  PY_3_5_AND_LATER = True
+else:
+  PY_3_5_AND_LATER = False

--- a/plaso/lib/py2to3.py
+++ b/plaso/lib/py2to3.py
@@ -25,7 +25,4 @@ else:
   UNICHR = chr
   UNICODE_TYPE = str
 
-if tuple(sys.version_info[0:2]) >= (3, 5):
-  PY_3_5_AND_LATER = True
-else:
-  PY_3_5_AND_LATER = False
+PY_3_5_AND_LATER = bool(tuple(sys.version_info[0:2]) >= (3, 5))

--- a/tests/cli/helpers/event_filters.py
+++ b/tests/cli/helpers/event_filters.py
@@ -11,6 +11,7 @@ import unittest
 from plaso.cli import tools
 from plaso.cli.helpers import event_filters
 from plaso.lib import errors
+from plaso.lib import py2to3
 
 from tests.cli import test_lib as cli_test_lib
 
@@ -53,7 +54,7 @@ optional arguments:
                         by the --slice_size parameter.
 """
 
-  _EXPECTED_OUTPUT_PY3_6 = """\
+  _EXPECTED_OUTPUT_PY_3_5_AND_LATER = """\
 usage: cli_helper.py [--slice DATE] [--slice_size SLICE_SIZE] [--slicer]
                      [FILTER]
 
@@ -97,10 +98,10 @@ optional arguments:
 
     output = self._RunArgparseFormatHelp(argument_parser)
 
-    if tuple(sys.version_info[0:2]) < (3, 6):
-      self.assertEqual(output, self._EXPECTED_OUTPUT)
+    if py2to3.PY_3_5_AND_LATER:
+      self.assertEqual(output, self._EXPECTED_OUTPUT_PY_3_5_AND_LATER)
     else:
-      self.assertEqual(output, self._EXPECTED_OUTPUT_PY3_6)
+      self.assertEqual(output, self._EXPECTED_OUTPUT)
 
   def testParseOptions(self):
     """Tests the ParseOptions function."""

--- a/tests/cli/helpers/event_filters.py
+++ b/tests/cli/helpers/event_filters.py
@@ -5,7 +5,6 @@
 from __future__ import unicode_literals
 
 import argparse
-import sys
 import unittest
 
 from plaso.cli import tools

--- a/tests/cli/helpers/event_filters.py
+++ b/tests/cli/helpers/event_filters.py
@@ -20,7 +20,7 @@ class EventFiltersArgumentsHelperTest(cli_test_lib.CLIToolTestCase):
 
   # pylint: disable=no-member,protected-access
 
-  _EXPECTED_OUTPUT_PY2 = """\
+  _EXPECTED_OUTPUT = """\
 usage: cli_helper.py [--slice DATE] [--slice_size SLICE_SIZE] [--slicer]
                      [FILTER]
 
@@ -53,7 +53,7 @@ optional arguments:
                         by the --slice_size parameter.
 """
 
-  _EXPECTED_OUTPUT_PY3 = """\
+  _EXPECTED_OUTPUT_PY3_6 = """\
 usage: cli_helper.py [--slice DATE] [--slice_size SLICE_SIZE] [--slicer]
                      [FILTER]
 
@@ -97,10 +97,10 @@ optional arguments:
 
     output = self._RunArgparseFormatHelp(argument_parser)
 
-    if sys.version_info[0] < 3:
-      self.assertEqual(output, self._EXPECTED_OUTPUT_PY2)
+    if tuple(sys.version_info[0:1]) < (3, 6):
+      self.assertEqual(output, self._EXPECTED_OUTPUT)
     else:
-      self.assertEqual(output, self._EXPECTED_OUTPUT_PY3)
+      self.assertEqual(output, self._EXPECTED_OUTPUT_PY3_6)
 
   def testParseOptions(self):
     """Tests the ParseOptions function."""

--- a/tests/cli/helpers/event_filters.py
+++ b/tests/cli/helpers/event_filters.py
@@ -5,6 +5,7 @@
 from __future__ import unicode_literals
 
 import argparse
+import sys
 import unittest
 
 from plaso.cli import tools
@@ -19,7 +20,7 @@ class EventFiltersArgumentsHelperTest(cli_test_lib.CLIToolTestCase):
 
   # pylint: disable=no-member,protected-access
 
-  _EXPECTED_OUTPUT = """\
+  _EXPECTED_OUTPUT_PY2 = """\
 usage: cli_helper.py [--slice DATE] [--slice_size SLICE_SIZE] [--slicer]
                      [FILTER]
 
@@ -52,6 +53,39 @@ optional arguments:
                         by the --slice_size parameter.
 """
 
+  _EXPECTED_OUTPUT_PY3 = """\
+usage: cli_helper.py [--slice DATE] [--slice_size SLICE_SIZE] [--slicer]
+                     [FILTER]
+
+Test argument parser.
+
+positional arguments:
+  FILTER                A filter that can be used to filter the dataset before
+                        it is written into storage. More information about the
+                        filters and how to use them can be found here: https:/
+                        /plaso.readthedocs.io/en/latest/sources/user/Event-
+                        filters.html
+
+optional arguments:
+  --slice DATE          Create a time slice around a certain date. This
+                        parameter, if defined will display all events that
+                        happened X minutes before and after the defined date.
+                        X is controlled by the parameter --slice_size but
+                        defaults to 5 minutes.
+  --slice_size SLICE_SIZE, --slice-size SLICE_SIZE
+                        Defines the slice size. In the case of a regular time
+                        slice it defines the number of minutes the slice size
+                        should be. In the case of the --slicer it determines
+                        the number of events before and after a filter match
+                        has been made that will be included in the result set.
+                        The default value is 5. See --slice or --slicer for
+                        more details about this option.
+  --slicer              Create a time slice around every filter match. This
+                        parameter, if defined will save all X events before
+                        and after a filter match has been made. X is defined
+                        by the --slice_size parameter.
+"""
+
   def testAddArguments(self):
     """Tests the AddArguments function."""
     argument_parser = argparse.ArgumentParser(
@@ -62,7 +96,11 @@ optional arguments:
     event_filters.EventFiltersArgumentsHelper.AddArguments(argument_parser)
 
     output = self._RunArgparseFormatHelp(argument_parser)
-    self.assertEqual(output, self._EXPECTED_OUTPUT)
+
+    if sys.version_info[0] < 3:
+      self.assertEqual(output, self._EXPECTED_OUTPUT_PY2)
+    else:
+      self.assertEqual(output, self._EXPECTED_OUTPUT_PY3)
 
   def testParseOptions(self):
     """Tests the ParseOptions function."""

--- a/tests/cli/helpers/event_filters.py
+++ b/tests/cli/helpers/event_filters.py
@@ -97,7 +97,7 @@ optional arguments:
 
     output = self._RunArgparseFormatHelp(argument_parser)
 
-    if tuple(sys.version_info[0:1]) < (3, 6):
+    if tuple(sys.version_info[0:2]) < (3, 6):
       self.assertEqual(output, self._EXPECTED_OUTPUT)
     else:
       self.assertEqual(output, self._EXPECTED_OUTPUT_PY3_6)

--- a/tests/cli/test_lib.py
+++ b/tests/cli/test_lib.py
@@ -20,7 +20,7 @@ class SortedArgumentsHelpFormatter(argparse.HelpFormatter):
     """Adds arguments.
 
     Args:
-      actions (TODO): TODO.
+      actions (list[argparse._StoreAction]): command line actions.
     """
     actions = sorted(actions, key=operator.attrgetter('option_strings'))
     super(SortedArgumentsHelpFormatter, self).add_arguments(actions)


### PR DESCRIPTION
Added work-around for Python version dependent formatting #2248