### PR TITLE
fix error on config tag analysis

### DIFF
--- a/data/tag_windows.txt
+++ b/data/tag_windows.txt
@@ -2,6 +2,8 @@ application_execution
   data_type is 'windows:prefetch:execution'
   data_type is 'windows:lnk:link' and filename contains 'Recent' and (local_path contains '.exe' or network_path contains '.exe' or relative_path contains '.exe')
   data_type == 'windows:registry:key_value' and parser =~ '.*mru' and regvalue =~ '.*\.[Ee]{1}[Xx]{1}[Ee]{1}'
+  data_type is 'windows:registry:key_value' and key_path contains '\\Search\\RecentApps\\'
+  data_type is 'windows:registry:key_value' and key_path contains '\\Services\\bam\\UserSettings\\'
   data_type is 'windows:registry:userassist' and parser contains 'userassist' and value_name contains '.exe'
   data_type is 'windows:evtx:record' and strings contains 'user mode service' and strings contains 'demand start'
   data_type is 'fs:stat' and filename contains 'Windows/Tasks/At'
@@ -9,6 +11,7 @@ application_execution
   data_type is 'windows:evt:record' and source_name is 'Security' and event_identifier is 592
   data_type is 'windows:evtx:record' and source_name is 'Microsoft-Windows-Security-Auditing' and event_identifier is 4688
   data_type is 'windows:registry:appcompatcache'
+  data_type is 'windows:registry:amcache'
 
 application_install
   data_type is 'windows:evtx:record' and source_name is 'Microsoft-Windows-Application-Experience' and event_identifier is 903

--- a/data/tag_windows.txt
+++ b/data/tag_windows.txt
@@ -1,7 +1,8 @@
 application_execution
   data_type is 'windows:prefetch:execution'
   data_type is 'windows:lnk:link' and filename contains 'Recent' and (local_path contains '.exe' or network_path contains '.exe' or relative_path contains '.exe')
-  data_type is 'windows:registry:key_value' AND (parser contains 'userassist' or parser contains 'mru') AND regvalue contains '.exe'
+  data_type == 'windows:registry:key_value' and parser =~ '.*mru' and regvalue =~ '.*\.[Ee]{1}[Xx]{1}[Ee]{1}'
+  data_type is 'windows:registry:userassist' and parser contains 'userassist' and value_name contains '.exe'
   data_type is 'windows:evtx:record' and strings contains 'user mode service' and strings contains 'demand start'
   data_type is 'fs:stat' and filename contains 'Windows/Tasks/At'
   data_type is 'windows:tasks:job'
@@ -21,7 +22,8 @@ application_removal
   data_type is 'windows:evtx:record' and source_name is 'Microsoft-Windows-Application-Experience' and event_identifier is 908
 
 document_open
-  data_type is 'windows:registry:key_value' AND parser contains 'mru' AND regvalue notcontains '.exe' AND timestamp > 0
+  data_type == 'windows:registry:key_value' and parser != "winreg/mrulistex_string_and_shell_item" and parser =~ '.*mru' and regvalue =~ '.*\S+\.\S+( |$|\")' and (not (regvalue =~ '.*\.(exe|EXE)')) and timestamp > 0
+  data_type == 'windows:lnk:link' and filename =~ '.*Recent' and (local_path =~ '.*\.[A-Za-z0-9]{1,12}$' or network_path =~ '.*\.[A-Za-z0-9]{1,12}$' or relative_path =~ '.*\.[A-Za-z0-9]{1,12}$') and (not (local_path =~ '(.*\.[Ee]{1}[Xx]{1}[Ee]{1}$)')) and (not (network_path =~ '(.*\.[Ee]{1}[Xx]{1}[Ee]{1}$)')) and (not (relative_path =~ '(.*\.[Ee]{1}[Xx]{1}[Ee]{1}$)'))
 
 login_failed
   data_type is 'windows:evtx:record' and source_name is 'Microsoft-Windows-Security-Auditing' and event_identifier is 4625
@@ -82,7 +84,7 @@ system_sleep
 
 autorun
   data_type is 'windows:registry:key_value' and parser contains 'Run'
-  data_type is 'windows:registry:key_value' AND (parser contains 'run' or parser contains 'lfu') AND (regvalue contains '.exe' OR regvalue contains '.dll')
+  data_type == 'windows:registry:key_value' and (parser =~ '.*run' or parser =~ '.*lfu') and (regvalue =~ '.*\.[Ee]{1}[Xx]{1}[Ee]{1}' or regvalue =~ '.*\.[Dd]{1}[Ll]{1}[Ll]{1}')
 
 file_download
   data_type is 'chrome:history:file_downloaded'


### PR DESCRIPTION
## One line description of pull request
Fix error on config of tag analysis. 


## Description:
In my last PR, I make a mistake, because I did not have understand than tag analysis modify the plaso dump. I was thinking than only file generate from psort was impacted.
The Rule with "contains" on field "regvalue" don't work. I choose to use another syntaxe of efilter with regexp ("=~"), and it's work fine.
I tried of reuse __all__, but same crash on plaso if field not exist or empty.
I added a new rule in tag "document_open" with use 'link' file in "recent" directory.

## Notes:


## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
