### PR TITLE
Handle multiple detected presets #2321

### DIFF
--- a/plaso/cli/extraction_tool.py
+++ b/plaso/cli/extraction_tool.py
@@ -145,7 +145,7 @@ class ExtractionTool(
           self._buffer_size = int(self._buffer_size, 10)
       except ValueError:
         raise errors.BadConfigOption(
-            'Invalid buffer size: {0:d}.'.format(self._buffer_size))
+            'Invalid buffer size: {0!s}.'.format(self._buffer_size))
 
     self._queue_size = self.ParseNumericOption(options, 'queue_size')
 

--- a/plaso/cli/extraction_tool.py
+++ b/plaso/cli/extraction_tool.py
@@ -115,14 +115,11 @@ class ExtractionTool(
       if preset_definitions:
         preset_names = [
             preset_definition.name for preset_definition in preset_definitions]
-        if len(preset_names) != 1:
-          raise errors.BadConfigOption(
-              'More than 1 parser preset found for: {0:s} namely: {1:s}'.format(
-                  operating_system, preset_names))
+        filter_expression = ','.join(preset_names)
 
         logger.info('Parser filter expression set to: {0:s}'.format(
-            preset_names[0]))
-        configuration.parser_filter_expression = preset_names[0]
+            filter_expression))
+        configuration.parser_filter_expression = filter_expression
 
     return configuration
 
@@ -148,7 +145,7 @@ class ExtractionTool(
           self._buffer_size = int(self._buffer_size, 10)
       except ValueError:
         raise errors.BadConfigOption(
-            'Invalid buffer size: {0:s}.'.format(self._buffer_size))
+            'Invalid buffer size: {0:d}.'.format(self._buffer_size))
 
     self._queue_size = self.ParseNumericOption(options, 'queue_size')
 

--- a/plaso/parsers/presets.py
+++ b/plaso/parsers/presets.py
@@ -14,7 +14,7 @@ class ParserPreset(object):
 
   Attributes:
     name (str): name of the preset.
-    operating_system (list[OperatingSystemArtifact]): operating system
+    operating_systems (list[OperatingSystemArtifact]): operating system
         artifact attribute containers, that specify to which operating
         systems the preset applies.
     parsers (list[str]): names of parser and parser plugins.


### PR DESCRIPTION
The GetParserFilters method handles multiple presets, so if multiple matching presets are detected, we can just use them all.
https://github.com/log2timeline/plaso/blob/master/plaso/parsers/manager.py#L21