### PR TITLE
Removed Fedora Core 27 support due to deprecation by COPR

### DIFF
--- a/docs/sources/user/Fedora-Core-Packaged-Release.md
+++ b/docs/sources/user/Fedora-Core-Packaged-Release.md
@@ -1,6 +1,6 @@
 # Fedora Core Packaged Release 
 
-### Fedora Core 27, 28 and 29
+### Fedora Core 28 and 29
 
 **Note that other versions of Fedora Core are not supported at this time.**
 


### PR DESCRIPTION
Removed Fedora Core 27 support due to deprecation by COPR