### PR TITLE
Ensured session identifier passed as string in pinfo

### DIFF
--- a/plaso/cli/pinfo_tool.py
+++ b/plaso/cli/pinfo_tool.py
@@ -337,7 +337,7 @@ class PinfoTool(
     """
     for session_number, session in enumerate(storage.GetSessions()):
       session_identifier = uuid.UUID(hex=session.identifier)
-      session_identifier = '{1!s}'.format(session_identifier)
+      session_identifier = '{0!s}'.format(session_identifier)
 
       start_time = 'N/A'
       if session.start_time is not None:
@@ -410,7 +410,7 @@ class PinfoTool(
       start_time = timelib.Timestamp.CopyToIsoFormat(
           session.start_time)
       session_identifier = uuid.UUID(hex=session.identifier)
-      session_identifier = '{1!s}'.format(session_identifier)
+      session_identifier = '{0!s}'.format(session_identifier)
       table_view.AddRow([session_identifier, start_time])
 
     table_view.Write(self._output_writer)
@@ -487,7 +487,7 @@ class PinfoTool(
       start_time = timelib.Timestamp.CopyToIsoFormat(
           task_start.timestamp)
       task_identifier = uuid.UUID(hex=task_start.identifier)
-      task_identifier = '{1!s}'.format(task_identifier)
+      task_identifier = '{0!s}'.format(task_identifier)
       table_view.AddRow([task_identifier, start_time])
 
     table_view.Write(self._output_writer)

--- a/plaso/cli/pinfo_tool.py
+++ b/plaso/cli/pinfo_tool.py
@@ -337,7 +337,7 @@ class PinfoTool(
     """
     for session_number, session in enumerate(storage.GetSessions()):
       session_identifier = uuid.UUID(hex=session.identifier)
-      session_identifier = str(session_identifier)
+      session_identifier = '{1!s}'.format(session_identifier)
 
       start_time = 'N/A'
       if session.start_time is not None:
@@ -410,7 +410,8 @@ class PinfoTool(
       start_time = timelib.Timestamp.CopyToIsoFormat(
           session.start_time)
       session_identifier = uuid.UUID(hex=session.identifier)
-      table_view.AddRow([str(session_identifier), start_time])
+      session_identifier = '{1!s}'.format(session_identifier)
+      table_view.AddRow([session_identifier, start_time])
 
     table_view.Write(self._output_writer)
 
@@ -486,7 +487,8 @@ class PinfoTool(
       start_time = timelib.Timestamp.CopyToIsoFormat(
           task_start.timestamp)
       task_identifier = uuid.UUID(hex=task_start.identifier)
-      table_view.AddRow([str(task_identifier), start_time])
+      task_identifier = '{1!s}'.format(task_identifier)
+      table_view.AddRow([task_identifier, start_time])
 
     table_view.Write(self._output_writer)
 

--- a/plaso/cli/pinfo_tool.py
+++ b/plaso/cli/pinfo_tool.py
@@ -337,6 +337,7 @@ class PinfoTool(
     """
     for session_number, session in enumerate(storage.GetSessions()):
       session_identifier = uuid.UUID(hex=session.identifier)
+      session_identifier = str(session_identifier)
 
       start_time = 'N/A'
       if session.start_time is not None:
@@ -364,7 +365,7 @@ class PinfoTool(
         artifact_filters_string = 'N/A'
       filter_file = session.filter_file or 'N/A'
 
-      title = 'Session: {0!s}'.format(session_identifier)
+      title = 'Session: {0:s}'.format(session_identifier)
       table_view = views.ViewsFactory.GetTableView(
           self._views_format_type, title=title)
 


### PR DESCRIPTION
Session_identifier is passed as a string to several methods, but was actually a UUID.