### PR TITLE
Fix simple typo in winreg_plugins interface

### DIFF
--- a/plaso/parsers/winreg_plugins/interface.py
+++ b/plaso/parsers/winreg_plugins/interface.py
@@ -143,7 +143,7 @@ class WindowsRegistryKeyPathPrefixFilter(BaseWindowsRegistryKeyFilter):
     Returns:
       bool: True if the keys match.
     """
-    return registry_key.path.startsswith(self._key_path_prefix)
+    return registry_key.path.startswith(self._key_path_prefix)
 
 
 class WindowsRegistryKeyPathSuffixFilter(BaseWindowsRegistryKeyFilter):


### PR DESCRIPTION
## One line description of pull request
This PR fixes a simple typo in a so-far unused function.


## Description:
The function call had an "s" too much. I corrected str.startsswith to str.startswith.
The function is so far unused, but is useful for an Amcache plugin for windows 10 I'm finishing up.

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure that the code has appropriate test coverage and conforms to the Plaso [style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
