### PR TITLE
Changes to psort to show event counters as status

### DIFF
--- a/plaso/cli/psort_tool.py
+++ b/plaso/cli/psort_tool.py
@@ -540,7 +540,6 @@ class PsortTool(
       for item, value in iter(session.analysis_reports_counter.items()):
         analysis_counter[item] = value
 
-    events_counter = None
     if self._output_format != 'null':
       storage_reader = (
           storage_factory.StorageFactory.CreateStorageReaderForFile(
@@ -550,7 +549,7 @@ class PsortTool(
       analysis_engine = psort.PsortMultiProcessEngine(
           use_zeromq=self._use_zeromq)
 
-      events_counter = analysis_engine.ExportEvents(
+      analysis_engine.ExportEvents(
           self._knowledge_base, storage_reader, self._output_module,
           configuration, deduplicate_events=self._deduplicate_events,
           event_filter=self._event_filter,
@@ -570,13 +569,6 @@ class PsortTool(
           table_view.AddRow([element, count])
 
       table_view.AddRow(['Total', analysis_counter['total']])
-      table_view.Write(self._output_writer)
-
-    if events_counter:
-      table_view = views.ViewsFactory.GetTableView(
-          self._views_format_type, title='Export results')
-      for element, count in events_counter.most_common():
-        table_view.AddRow([element, count])
       table_view.Write(self._output_writer)
 
     storage_reader = storage_factory.StorageFactory.CreateStorageReaderForFile(

--- a/plaso/cli/psteal_tool.py
+++ b/plaso/cli/psteal_tool.py
@@ -213,13 +213,11 @@ class PstealTool(
       analysis_engine = psort.PsortMultiProcessEngine(
           use_zeromq=self._use_zeromq)
 
-      events_counter = analysis_engine.ExportEvents(
+      analysis_engine.ExportEvents(
           self._knowledge_base, storage_reader, self._output_module,
           configuration, deduplicate_events=self._deduplicate_events,
           status_update_callback=status_update_callback,
           time_slice=self._time_slice, use_time_slicer=self._use_time_slicer)
-
-      counter += events_counter
 
     for item, value in iter(session.analysis_reports_counter.items()):
       counter[item] = value

--- a/plaso/cli/status_view.py
+++ b/plaso/cli/status_view.py
@@ -317,15 +317,18 @@ class StatusView(object):
     Args:
       events_status (EventsStatus): events status.
     """
-    # TODO: print additional event status as "Events MACB grouped",
-    # "Duplicate events removed", "Events filtered"
     if events_status:
       table_view = views.CLITabularTableView(
-          column_names=['Events:', 'Total'],
-          column_sizes=[15, 0])
+          column_names=['Events:', 'Filtered', 'In time slice', 'Duplicates',
+                        'MACB grouped', 'Total'],
+          column_sizes=[15, 15, 15, 15, 15, 0])
 
       table_view.AddRow([
-          '', events_status.total_number_of_events])
+          '', events_status.number_of_filtered_events,
+          events_status.number_of_events_from_time_slice,
+          events_status.number_of_duplicate_events,
+          events_status.number_of_macb_grouped_events,
+          events_status.total_number_of_events])
 
       self._output_writer.Write('\n')
       table_view.Write(self._output_writer)

--- a/plaso/engine/processing_status.py
+++ b/plaso/engine/processing_status.py
@@ -522,10 +522,12 @@ class EventsStatus(object):
   """The status of the events.
 
   Attributes:
-    number_of_duplicate_events (int): number of duplicate events.
+    number_of_duplicate_events (int): number of duplicate events, not including
+        the original.
     number_of_events_from_time_slice (int): number of events from time slice.
-    number_of_filtered_events (int): number of filtered events.
-    number_of_macb_grouped_events (int): number of MACB grouped events.
+    number_of_filtered_events (int): number of events excluded by the event
+        filter.
+    number_of_macb_grouped_events (int): number of events grouped based on MACB.
     total_number_of_events (int): total number of events in the storage file.
   """
 

--- a/plaso/engine/processing_status.py
+++ b/plaso/engine/processing_status.py
@@ -522,12 +522,20 @@ class EventsStatus(object):
   """The status of the events.
 
   Attributes:
+    number_of_duplicate_events (int): number of duplicate events.
+    number_of_events_from_time_slice (int): number of events from time slice.
+    number_of_filtered_events (int): number of filtered events.
+    number_of_macb_grouped_events (int): number of MACB grouped events.
     total_number_of_events (int): total number of events in the storage file.
   """
 
   def __init__(self):
     """Initializes an events status."""
     super(EventsStatus, self).__init__()
+    self.number_of_duplicate_events = 0
+    self.number_of_events_from_time_slice = 0
+    self.number_of_filtered_events = 0
+    self.number_of_macb_grouped_events = 0
     self.total_number_of_events = 0
 
 

--- a/tests/cli/psteal_tool.py
+++ b/tests/cli/psteal_tool.py
@@ -439,7 +439,7 @@ class PstealToolTest(test_lib.CLIToolTestCase):
       self.assertEqual(expected_output, result_output)
 
     output = output_writer.ReadOutput()
-    self.assertIn('Events processed : 38', output)
+    self.assertIn('Processing completed.', output)
 
 
 if __name__ == '__main__':

--- a/tests/multi_processing/psort.py
+++ b/tests/multi_processing/psort.py
@@ -508,10 +508,8 @@ class PsortMultiProcessEngineTest(shared_test_lib.BaseTestCase):
         storage_file_path)
 
     test_engine = psort.PsortMultiProcessEngine()
-    counter = test_engine.ExportEvents(
+    test_engine.ExportEvents(
         knowledge_base_object, storage_reader, output_module, configuration)
-
-    self.assertEqual(counter['Stored Events'], 0)
 
     lines = []
     output = output_writer.ReadOutput()


### PR DESCRIPTION
```
plaso - psort version 20190329

Storage file		: test.plaso
Processing time		: 00:00:40

Events:         Filtered        In time slice   Duplicates      MACB grouped    Total
                249334          0               0               3               249338

Identifier              PID     Status          Memory          Events          Tags            Reports
Main                    174692  exporting       107.4 MiB       4 (3)           0 (0)           0 (0)

Processing completed.
```