### PR TITLE
Remove Core

### DIFF
--- a/docs/sources/user/Fedora-Core-Packaged-Release.md
+++ b/docs/sources/user/Fedora-Core-Packaged-Release.md
@@ -1,8 +1,8 @@
-# Fedora Core Packaged Release 
+# Fedora Packaged Release 
 
-### Fedora Core 28 and 29
+### Fedora 28 and 29
 
-**Note that other versions of Fedora Core are not supported at this time.**
+**Note that other versions of Fedora are not supported at this time.**
 
 To install plaso and dependencies from the GIFT Cool Other Package Repo (COPR) you'll need to have dnf plugins installed:
 


### PR DESCRIPTION
## One line description of pull request
It's Fedora and not Fedora Core.

## Description:
Over a decade ago the appendix Core was removed by the Fedora Project. 

## Checklist:
  - [x] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
