### PR TITLE
Added parser for setupapi log file #2549

### DIFF
--- a/plaso/formatters/__init__.py
+++ b/plaso/formatters/__init__.py
@@ -81,6 +81,7 @@ from plaso.formatters import santa
 from plaso.formatters import sccm
 from plaso.formatters import selinux
 from plaso.formatters import services
+from plaso.formatters import setupapi
 from plaso.formatters import shell_items
 from plaso.formatters import shutdown
 from plaso.formatters import skydrivelog

--- a/plaso/formatters/setupapi.py
+++ b/plaso/formatters/setupapi.py
@@ -14,7 +14,7 @@ class SetupapiLogFormatter(interface.ConditionalEventFormatter):
 
   FORMAT_STRING_PIECES = [
       '[{entry_type}',
-      '{message}',
+      # '{message}',
       '{exit_status}']
 
   FORMAT_STRING_SHORT_PIECES = ['{message}']

--- a/plaso/formatters/setupapi.py
+++ b/plaso/formatters/setupapi.py
@@ -13,8 +13,9 @@ class SetupapiLogFormatter(interface.ConditionalEventFormatter):
   DATA_TYPE = 'setupapi:log:line'
 
   FORMAT_STRING_PIECES = [
-      'Description: {entry_type} |',
-      'Exit status: {exit_status}']
+      '{entry_type}',
+      '[{exit_status}',
+      '{end_time}]']
 
   FORMAT_STRING_SHORT_PIECES = ['{entry_type}']
 

--- a/plaso/formatters/setupapi.py
+++ b/plaso/formatters/setupapi.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""Windows Setupapi log event formatter."""
+
+from __future__ import unicode_literals
+
+from plaso.formatters import interface
+from plaso.formatters import manager
+
+
+class SetupapiLogFormatter(interface.ConditionalEventFormatter):
+  """Formatter for a Windows Setupapi log file event."""
+
+  DATA_TYPE = 'setupapi:log:line'
+
+  FORMAT_STRING_PIECES = [
+      '[{entry_type}',
+      '{message}',
+      '{exit_status}']
+
+  FORMAT_STRING_SHORT_PIECES = ['{message}']
+
+  SOURCE_LONG = 'Windows Setupapi Log File'
+  SOURCE_SHORT = 'LOG'
+
+
+manager.FormattersManager.RegisterFormatter(SetupapiLogFormatter)

--- a/plaso/formatters/setupapi.py
+++ b/plaso/formatters/setupapi.py
@@ -13,13 +13,12 @@ class SetupapiLogFormatter(interface.ConditionalEventFormatter):
   DATA_TYPE = 'setupapi:log:line'
 
   FORMAT_STRING_PIECES = [
-      '[{entry_type}',
-      # '{message}',
-      '{exit_status}']
+      'Description: {entry_type} |',
+      'Exit status: {exit_status}']
 
-  FORMAT_STRING_SHORT_PIECES = ['{message}']
+  FORMAT_STRING_SHORT_PIECES = ['{entry_type}']
 
-  SOURCE_LONG = 'Windows Setupapi Log File'
+  SOURCE_LONG = 'Windows Setupapi Log'
   SOURCE_SHORT = 'LOG'
 
 

--- a/plaso/formatters/setupapi.py
+++ b/plaso/formatters/setupapi.py
@@ -14,10 +14,14 @@ class SetupapiLogFormatter(interface.ConditionalEventFormatter):
 
   FORMAT_STRING_PIECES = [
       '{entry_type}',
-      '[{exit_status}',
-      '{end_time}]']
+      '{entry_status}']
 
-  FORMAT_STRING_SHORT_PIECES = ['{entry_type}']
+  # Reversing fields for short description to prevent truncating the status
+  FORMAT_STRING_SHORT_PIECES = [
+      '{entry_status}',
+      '{entry_type}']
+
+  FORMAT_STRING_SEPARATOR = ' - '
 
   SOURCE_LONG = 'Windows Setupapi Log'
   SOURCE_SHORT = 'LOG'

--- a/plaso/parsers/__init__.py
+++ b/plaso/parsers/__init__.py
@@ -41,6 +41,7 @@ from plaso.parsers import safari_cookies
 from plaso.parsers import santa
 from plaso.parsers import sccm
 from plaso.parsers import selinux
+from plaso.parsers import setupapi
 from plaso.parsers import skydrivelog
 from plaso.parsers import sophos_av
 from plaso.parsers import sqlite

--- a/plaso/parsers/setupapi.py
+++ b/plaso/parsers/setupapi.py
@@ -121,14 +121,14 @@ class SetupapiLogParser(text_parser.PyparsingMultiLineTextParser):
           log entry.
     """
     date_time = dfdatetime_time_elements.TimeElementsInMilliseconds()
-    # Setupapi logs record in local time
-    date_time.is_local_time = True
 
     time_elements_structure = self._GetValueFromStructure(
         structure, 'start_time')
     try:
       datetime_iso8601 = self._GetISO8601String(time_elements_structure)
       date_time.CopyFromStringISO8601(datetime_iso8601)
+      # Setupapi logs record in local time
+      date_time.is_local_time = True
     except ValueError:
       parser_mediator.ProduceExtractionWarning(
           'invalid date time value: {0!s}'.format(time_elements_structure))

--- a/plaso/parsers/setupapi.py
+++ b/plaso/parsers/setupapi.py
@@ -95,7 +95,7 @@ class SetupapiLogParser(text_parser.PyparsingMultiLineTextParser):
     try:
       date_time = dfdatetime_time_elements.TimeElementsInMilliseconds(
           time_elements_tuple=time_elements_structure)
-      # Setupapi logs record in local time
+      # Setupapi logs stores date and time values in local time.
       date_time.is_local_time = True
     except ValueError:
       parser_mediator.ProduceExtractionWarning(

--- a/plaso/parsers/setupapi.py
+++ b/plaso/parsers/setupapi.py
@@ -21,7 +21,7 @@ class SetupapiLogEventData(events.EventData):
 
   Attributes:
     entry_type (str): log entry type such as "Device Install".
-    entry_status (str): the exit status of the entry.
+    entry_status (str): the status of the entry.
   """
 
   DATA_TYPE = 'setupapi:log:line'

--- a/plaso/parsers/setupapi.py
+++ b/plaso/parsers/setupapi.py
@@ -33,7 +33,7 @@ class SetupapiLogEventData(events.EventData):
     """Initializes event data."""
     super(SetupapiLogEventData, self).__init__(data_type=self.DATA_TYPE)
     self.entry_type = None
-    # self.start_time = None
+    # TODO: Add fields
     # self.message = None
     # self.section_end = None
     self.exit_status = None
@@ -92,17 +92,6 @@ class SetupapiLogParser(text_parser.PyparsingMultiLineTextParser):
     Raises:
       ValueError: if the structure cannot be converted into a date time string.
     """
-    # TODO: get timezone offset properly
-    time_zone_offset = '+0000'
-
-    try:
-      time_zone_offset_hours = int(time_zone_offset[1:3], 10)
-      time_zone_offset_minutes = int(time_zone_offset[3:5], 10)
-    except (IndexError, TypeError, ValueError) as exception:
-      raise ValueError(
-          'unable to parse time zone offset with error: {0!s}.'.format(
-              exception))
-
     year = self._GetValueFromStructure(structure, 'year')
     month = self._GetValueFromStructure(structure, 'month')
     day_of_month = self._GetValueFromStructure(structure, 'day')
@@ -113,11 +102,8 @@ class SetupapiLogParser(text_parser.PyparsingMultiLineTextParser):
 
     try:
       iso8601 = (
-          '{0:04d}-{1:02d}-{2:02d}T{3:02d}:{4:02d}:{5:02d}.{6:03d}'
-          '{7:s}{8:02d}:{9:02d}').format(
-              year, month, day_of_month, hours, minutes, seconds, microseconds,
-              time_zone_offset[0], time_zone_offset_hours,
-              time_zone_offset_minutes)
+          '{0:04d}-{1:02d}-{2:02d}T{3:02d}:{4:02d}:{5:02d}.{6:03d}').format(
+              year, month, day_of_month, hours, minutes, seconds, microseconds)
     except (TypeError, ValueError) as exception:
       raise ValueError(
           'unable to format date time string with error: {0!s}.'.format(
@@ -135,6 +121,8 @@ class SetupapiLogParser(text_parser.PyparsingMultiLineTextParser):
           log entry.
     """
     date_time = dfdatetime_time_elements.TimeElementsInMilliseconds()
+    # Setupapi logs record in local time
+    date_time.is_local_time = True
 
     time_elements_structure = self._GetValueFromStructure(
         structure, 'start_time')

--- a/plaso/parsers/setupapi.py
+++ b/plaso/parsers/setupapi.py
@@ -66,7 +66,7 @@ class SetupapiLogParser(text_parser.PyparsingMultiLineTextParser):
   _SETUPAPI_LINE = (
       pyparsing.SkipTo('>>>  [', include=True).suppress() +
       pyparsing.SkipTo(']').setResultsName('entry_type') +
-      pyparsing.SkipTo('>>>  Section start',include=True).suppress() +
+      pyparsing.SkipTo('>>>  Section start', include=True).suppress() +
       _SETUPAPI_DATE_TIME.setResultsName('start_time') +
       pyparsing.SkipTo('<<<  Section end ').setResultsName('message') +
       # _SETUPAPI_DATE_TIME.setResultsName('end_time') +

--- a/plaso/parsers/setupapi.py
+++ b/plaso/parsers/setupapi.py
@@ -1,0 +1,216 @@
+# -*- coding: utf-8 -*-
+"""Parser for Windows Setupapi log files."""
+
+from __future__ import unicode_literals
+
+import pyparsing
+
+from dfdatetime import time_elements as dfdatetime_time_elements
+
+from plaso.containers import events
+from plaso.containers import time_events
+from plaso.lib import errors
+from plaso.lib import definitions
+from plaso.parsers import logger
+from plaso.parsers import manager
+from plaso.parsers import text_parser
+
+
+class SetupapiLogEventData(events.EventData):
+  """Setupapi log event data.
+
+  Attributes:
+    entry_type (str): log entry type such as "Device Install".
+    section_start (str): date and time of the start of the log entry event.
+    message (str): contents of the log entry.
+    section_end (str): date and time of the start of the log entry event.
+    exit_status (str): the exit status of the entry.
+  """
+
+  DATA_TYPE = 'setupapi:log:line'
+
+  def __init__(self):
+    """Initializes event data."""
+    super(SetupapiLogEventData, self).__init__(data_type=self.DATA_TYPE)
+    self.entry_type = None
+    # self.start_time = None
+    self.message = None
+    # self.section_end = None
+    self.exit_status = None
+
+
+class SetupapiLogParser(text_parser.PyparsingMultiLineTextParser):
+  """Parses events from Windows Setupapi log files."""
+
+  NAME = 'setupapi'
+
+  DESCRIPTION = 'Parser for Windows Setupapi log files.'
+
+  _ENCODING = 'utf-8'
+
+  # Increase the buffer size, as log messages are often several lines long.
+  BUFFER_SIZE = 16384
+
+  _SLASH = pyparsing.Literal('/').suppress()
+
+  _FOUR_DIGITS = text_parser.PyparsingConstants.FOUR_DIGITS
+  _TWO_DIGITS = text_parser.PyparsingConstants.TWO_DIGITS
+
+  _SETUPAPI_DATE_TIME = pyparsing.Group(
+      _FOUR_DIGITS.setResultsName('year') + _SLASH +
+      _TWO_DIGITS.setResultsName('month') + _SLASH +
+      _TWO_DIGITS.setResultsName('day') +
+      text_parser.PyparsingConstants.TIME_MSEC_ELEMENTS
+  )
+
+  _SETUPAPI_LINE = (
+      pyparsing.SkipTo('>>>  [') +
+      pyparsing.SkipTo(']').setResultsName('entry_type') +
+      pyparsing.SkipTo('>>>  Section start') +
+      _SETUPAPI_DATE_TIME.setResultsName('start_time') +
+      pyparsing.SkipTo('<<<  Section end ').setResultsName('message') +
+      # _SETUPAPI_DATE_TIME.setResultsName('end_time') +
+      pyparsing.SkipTo('<<<  [Exit status: ') +
+      pyparsing.SkipTo(']').setResultsName('exit_status') +
+      pyparsing.ZeroOrMore(pyparsing.lineEnd()))
+
+  LINE_STRUCTURES = [
+      ('logline', _SETUPAPI_LINE),
+  ]
+
+  def _GetISO8601String(self, structure):
+    """Retrieves an ISO 8601 date time string from the structure.
+
+    Args:
+      structure (pyparsing.ParseResults): structure of tokens derived from a
+          log entry.
+
+    Returns:
+      str: ISO 8601 date time string.
+
+    Raises:
+      ValueError: if the structure cannot be converted into a date time string.
+    """
+    # TODO: get timezone offset properly
+    time_zone_offset = '+00:00'
+
+    try:
+      time_zone_offset_hours = int(time_zone_offset[1:3], 10)
+      time_zone_offset_minutes = int(time_zone_offset[3:5], 10)
+    except (IndexError, TypeError, ValueError) as exception:
+      raise ValueError(
+          'unable to parse time zone offset with error: {0!s}.'.format(
+              exception))
+
+    year = self._GetValueFromStructure(structure, 'year')
+    month = self._GetValueFromStructure(structure, 'month')
+    day_of_month = self._GetValueFromStructure(structure, 'day')
+    hours = self._GetValueFromStructure(structure, 'hours')
+    minutes = self._GetValueFromStructure(structure, 'minutes')
+    seconds = self._GetValueFromStructure(structure, 'seconds')
+    microseconds = self._GetValueFromStructure(structure, 'microseconds')
+
+    try:
+      iso8601 = (
+          '{0:04d}-{1:02d}-{2:02d}T{3:02d}:{4:02d}:{5:02d}.{6:03d}'
+          '{7:s}{8:02d}:{9:02d}').format(
+              year, month, day_of_month, hours, minutes, seconds, microseconds,
+              time_zone_offset[0], time_zone_offset_hours,
+              time_zone_offset_minutes)
+    except (TypeError, ValueError) as exception:
+      raise ValueError(
+          'unable to format date time string with error: {0!s}.'.format(
+              exception))
+
+    return iso8601
+
+  def _ParseRecordLogline(self, parser_mediator, structure):
+    """Parses a logline record structure and produces events.
+
+    Args:
+      parser_mediator (ParserMediator): mediates interactions between parsers
+          and other components, such as storage and dfvfs.
+      structure (pyparsing.ParseResults): structure of tokens derived from
+          log entry.
+    """
+    date_time = dfdatetime_time_elements.TimeElementsInMilliseconds()
+
+    time_elements_structure = self._GetValueFromStructure(
+        structure, 'start_time')
+    try:
+      datetime_iso8601 = self._GetISO8601String(time_elements_structure)
+      date_time.CopyFromStringISO8601(datetime_iso8601)
+    except ValueError:
+      parser_mediator.ProduceExtractionWarning(
+          'invalid date time value: {0!s}'.format(time_elements_structure))
+      return
+
+    # Replace newlines with spaces in structure.message to preserve output.
+    message = self._GetValueFromStructure(structure, 'message')
+    if message:
+      message = message.replace('\n', ' ')
+
+    event_data = SetupapiLogEventData()
+    event_data.entry_type = self._GetValueFromStructure(structure, 'entry_type')
+    event_data.message = self._GetValueFromStructure(structure, 'message')
+    # event_data.section_end = None
+    event_data.exit_status = self._GetValueFromStructure(
+        structure, 'exit_status')
+
+    event = time_events.DateTimeValuesEvent(
+        date_time, definitions.TIME_DESCRIPTION_ADDED)
+
+    parser_mediator.ProduceEventWithEventData(event, event_data)
+
+  def ParseRecord(self, parser_mediator, key, structure):
+    """Parses a log record structure and produces events.
+
+    Args:
+      parser_mediator (ParserMediator): mediates interactions between parsers
+          and other components, such as storage and dfvfs.
+      key (str): identifier of the structure of tokens.
+      structure (pyparsing.ParseResults): structure of tokens derived from
+          a log entry.
+
+    Raises:
+      ParseError: when the structure type is unknown.
+    """
+    if key != 'logline':
+      raise errors.ParseError(
+          'Unable to parse record, unknown structure: {0:s}'.format(key))
+
+    self._ParseRecordLogline(parser_mediator, structure)
+
+  def VerifyStructure(self, parser_mediator, lines):
+    """Verify that this file is a Windows Setupapi log file.
+
+    Args:
+      parser_mediator (ParserMediator): mediates interactions between parsers
+          and other components, such as storage and dfvfs.
+      lines (str): one or more lines from the text file.
+
+    Returns:
+      bool: True if this is the correct parser, False otherwise.
+    """
+    try:
+      structure = self._SETUPAPI_LINE.parseString(lines)
+    except pyparsing.ParseException as exception:
+      logger.debug('Not a Windows Setupapi log file: {0!s}'.format(exception))
+      return False
+
+    date_time = dfdatetime_time_elements.TimeElementsInMilliseconds()
+
+    date_time_string = self._GetValueFromStructure(structure, 'start_time')
+    try:
+      datetime_iso8601 = self._GetISO8601String(date_time_string)
+      date_time.CopyFromStringISO8601(datetime_iso8601)
+    except ValueError as exception:
+      logger.debug((
+          'Not a Windows Setupapi log file, invalid date/time: {0!s} '
+          'with error: {1!s}').format(date_time_string, exception))
+      return False
+
+    return True
+
+
+manager.ParsersManager.RegisterParser(SetupapiLogParser)

--- a/plaso/parsers/setupapi.py
+++ b/plaso/parsers/setupapi.py
@@ -22,7 +22,7 @@ class SetupapiLogEventData(events.EventData):
   Attributes:
     entry_type (str): log entry type such as "Device Install".
     section_start (str): date and time of the start of the log entry event.
-    message (str): contents of the log entry.
+    # message (str): contents of the log entry.
     # section_end (str): date and time of the start of the log entry event.
     exit_status (str): the exit status of the entry.
   """
@@ -34,7 +34,7 @@ class SetupapiLogEventData(events.EventData):
     super(SetupapiLogEventData, self).__init__(data_type=self.DATA_TYPE)
     self.entry_type = None
     # self.start_time = None
-    self.message = None
+    # self.message = None
     # self.section_end = None
     self.exit_status = None
 
@@ -72,6 +72,7 @@ class SetupapiLogParser(text_parser.PyparsingMultiLineTextParser):
       # _SETUPAPI_DATE_TIME.setResultsName('end_time') +
       pyparsing.SkipTo('<<<  [Exit status: ', include=True).suppress() +
       pyparsing.SkipTo(']').setResultsName('exit_status') +
+      pyparsing.SkipTo(pyparsing.lineEnd()) +
       pyparsing.ZeroOrMore(pyparsing.lineEnd()))
 
   LINE_STRUCTURES = [
@@ -152,7 +153,7 @@ class SetupapiLogParser(text_parser.PyparsingMultiLineTextParser):
 
     event_data = SetupapiLogEventData()
     event_data.entry_type = self._GetValueFromStructure(structure, 'entry_type')
-    event_data.message = self._GetValueFromStructure(structure, 'message')
+    # event_data.message = self._GetValueFromStructure(structure, 'message')
     # event_data.section_end = None
     event_data.exit_status = self._GetValueFromStructure(
         structure, 'exit_status')

--- a/test_data/setupapi.dev.log
+++ b/test_data/setupapi.dev.log
@@ -1,0 +1,10653 @@
+[Device Install Log]
+     OS Version = 10.0.10240
+     Service Pack = 0.0
+     Suite = 0x0100
+     ProductType = 1
+     Architecture = amd64
+
+[BeginLog]
+
+[Boot Session: 2015/11/22 17:58:03.498]
+
+>>>  [Device Install (Hardware initiated) - SWD\IP_TUNNEL_VBUS\ISATAP_0]
+>>>  Section start 2015/11/22 17:59:28.110
+     dvi: {Build Driver List} 17:59:28.176
+     dvi:      Searching for hardware ID(s):
+     dvi:           *isatap
+     dvi:      Searching for compatible ID(s):
+     dvi:           swd\genericraw
+     dvi:           swd\generic
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - *ISATAP
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\nettun.inf_amd64_73be4b5cbfb3a9a0\nettun.inf
+     dvi:           DevDesc      - Microsoft ISATAP Adapter
+     dvi:           Section      - ISATAP.ndi
+     dvi:           Rank         - 0x00ff0000
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 06/21/2006
+     dvi:           Version      - 10.0.10240.16384
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - SWD\GenericRaw
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\c_swdevice.inf_amd64_7d0967caf567eff0\c_swdevice.inf
+     dvi:           DevDesc      - Generic software device
+     dvi:           Section      - SoftwareDevice
+     dvi:           Rank         - 0x00ff3000
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 06/21/2006
+     dvi:           Version      - 10.0.10240.16384
+     dvi: {Build Driver List - exit(0x00000000)} 17:59:30.797
+     dvi: {DIF_SELECTBESTCOMPATDRV} 17:59:30.797
+     dvi:      Default installer: Enter 17:59:30.922
+     dvi:           {Select Best Driver}
+     dvi:                Class GUID of device changed to: {4d36e972-e325-11ce-bfc1-08002be10318}.
+     dvi:                Selected:
+     dvi:                     Description - [Microsoft ISATAP Adapter]
+     dvi:                     InfFile     - [c:\windows\system32\driverstore\filerepository\nettun.inf_amd64_73be4b5cbfb3a9a0\nettun.inf]
+     dvi:                     Section     - [ISATAP.ndi]
+     dvi:           {Select Best Driver - exit(0x00000000)}
+     dvi:      Default installer: Exit
+     dvi: {DIF_SELECTBESTCOMPATDRV - exit(0x00000000)} 17:59:30.922
+     ndv: {Core Device Install} 17:59:30.922
+     ndv:      {Installing device - SWD\IP_TUNNEL_VBUS\ISATAP_0} 17:59:30.922
+     sto:           {Configure Driver Package: C:\Windows\System32\DriverStore\FileRepository\nettun.inf_amd64_73be4b5cbfb3a9a0\nettun.inf}
+     sto:                Source Filter  = *isatap
+     inf:                Class GUID     = {4d36e972-e325-11ce-bfc1-08002be10318}
+     inf:                Class Options  = Configurable
+     inf:                {Configure Driver: Microsoft ISATAP Adapter}
+     inf:                     Section Name = ISATAP.ndi
+     inf:                     {Add Service: tunnel}
+     inf:                          Start Type    = 3
+     inf:                          Service Type  = 1
+     inf:                          Error Control = 1
+     inf:                          Image Path    = \SystemRoot\System32\drivers\tunnel.sys
+     inf:                          Display Name  = Microsoft Tunnel Miniport Adapter Driver
+     inf:                          Group         = NDIS
+     inf:                          Created new service 'tunnel'.
+     inf:                     {Add Service: exit(0x00000000)}
+     inf:                     Hardware Id  = *ISATAP
+     inf:                     {Configure Driver Configuration: ISATAP.ndi}
+     inf:                          Service Name  = tunnel
+     inf:                          Config Flags  = 0x00000000
+     inf:                     {Configure Driver Configuration: exit(0x00000000)}
+     inf:                {Configure Driver: exit(0x00000000)}
+     sto:           {Configure Driver Package: exit(0x00000000)}
+     dvi:           Install Device: Configuring device (nettun.inf:*isatap,ISATAP.ndi). 17:59:33.172
+     dvi:           Install Device: Configuring device completed. 17:59:33.188
+     dvi:           Install Device: Removing device sub-tree. 17:59:33.236
+     dvi:           Install Device: Removing device sub-tree completed. 17:59:33.454
+     dvi:           Install Device: Restarting device. 17:59:33.454
+     dvi:           Install Device: Restarting device completed. 17:59:33.938
+     ndv:      {Installing device - exit(0x00000000)} 17:59:33.938
+     ndv: {Core Device Install - exit(0x00000000)} 17:59:33.938
+     ndv: Waiting for device post-install to complete. 17:59:33.938
+     ndv: Device post-install completed. 17:59:37.110
+<<<  Section end 2015/11/22 17:59:37.142
+<<<  [Exit status: SUCCESS]
+
+
+[Boot Session: 2016/10/05 11:12:57.496]
+
+>>>  [Sysprep Respecialize - {804b345a-ffd7-854c-a1b5-ca9598907846}]
+>>>  Section start 2016/10/05 11:16:03.747
+<<<  Section end 2016/10/05 11:16:04.247
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Device Install (Hardware initiated) - SWD\IP_TUNNEL_VBUS\Teredo_Tunnel_Device]
+>>>  Section start 2016/10/05 11:16:16.471
+     dvi: {Build Driver List} 11:16:16.831
+     dvi:      Searching for hardware ID(s):
+     dvi:           *teredo
+     dvi:      Searching for compatible ID(s):
+     dvi:           swd\genericraw
+     dvi:           swd\generic
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - *TEREDO
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\nettun.inf_amd64_73be4b5cbfb3a9a0\nettun.inf
+     dvi:           DevDesc      - Microsoft Teredo Tunneling Adapter
+     dvi:           Section      - TEREDO.ndi
+     dvi:           Rank         - 0x00ff0000
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 06/21/2006
+     dvi:           Version      - 10.0.10240.16384
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - SWD\GenericRaw
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\c_swdevice.inf_amd64_7d0967caf567eff0\c_swdevice.inf
+     dvi:           DevDesc      - Generic software device
+     dvi:           Section      - SoftwareDevice
+     dvi:           Rank         - 0x00ff3000
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 06/21/2006
+     dvi:           Version      - 10.0.10240.16384
+     dvi: {Build Driver List - exit(0x00000000)} 11:16:20.528
+     dvi: {DIF_SELECTBESTCOMPATDRV} 11:16:20.528
+     dvi:      Default installer: Enter 11:16:20.809
+     dvi:           {Select Best Driver}
+     dvi:                Class GUID of device changed to: {4d36e972-e325-11ce-bfc1-08002be10318}.
+     dvi:                Selected:
+     dvi:                     Description - [Microsoft Teredo Tunneling Adapter]
+     dvi:                     InfFile     - [c:\windows\system32\driverstore\filerepository\nettun.inf_amd64_73be4b5cbfb3a9a0\nettun.inf]
+     dvi:                     Section     - [TEREDO.ndi]
+     dvi:           {Select Best Driver - exit(0x00000000)}
+     dvi:      Default installer: Exit
+     dvi: {DIF_SELECTBESTCOMPATDRV - exit(0x00000000)} 11:16:20.809
+     ndv: {Core Device Install} 11:16:20.809
+     ndv:      {Installing device - SWD\IP_TUNNEL_VBUS\TEREDO_TUNNEL_DEVICE} 11:16:20.809
+     sto:           {Configure Driver Package: C:\Windows\System32\DriverStore\FileRepository\nettun.inf_amd64_73be4b5cbfb3a9a0\nettun.inf}
+     sto:                Source Filter  = *teredo
+     inf:                Class GUID     = {4d36e972-e325-11ce-bfc1-08002be10318}
+     inf:                Class Options  = Configurable
+     inf:                {Configure Driver: Microsoft Teredo Tunneling Adapter}
+     inf:                     Section Name = TEREDO.ndi
+     inf:                     {Add Service: tunnel}
+     inf:                          Start Type    = 3
+     inf:                          Service Type  = 1
+     inf:                          Error Control = 1
+     inf:                          Image Path    = \SystemRoot\System32\drivers\tunnel.sys
+     inf:                          Display Name  = Microsoft Tunnel Miniport Adapter Driver
+     inf:                          Group         = NDIS
+     inf:                          Updated service 'tunnel'.
+     inf:                     {Add Service: exit(0x00000000)}
+     inf:                     Hardware Id  = *TEREDO
+     inf:                     {Configure Driver Configuration: TEREDO.ndi}
+     inf:                          Service Name  = tunnel
+     inf:                          Config Flags  = 0x00000000
+     inf:                     {Configure Driver Configuration: exit(0x00000000)}
+     inf:                {Configure Driver: exit(0x00000000)}
+     sto:           {Configure Driver Package: exit(0x00000000)}
+     dvi:           Install Device: Configuring device (nettun.inf:*teredo,TEREDO.ndi). 11:16:23.983
+     dvi:           Install Device: Configuring device completed. 11:16:23.983
+     dvi:           Install Device: Removing device sub-tree. 11:16:24.388
+     dvi:           Install Device: Removing device sub-tree completed. 11:16:24.747
+     dvi:           Install Device: Restarting device. 11:16:24.747
+     dvi:           Install Device: Restarting device completed. 11:16:25.091
+     ndv:      {Installing device - exit(0x00000000)} 11:16:25.107
+     ndv: {Core Device Install - exit(0x00000000)} 11:16:25.107
+     ndv: Waiting for device post-install to complete. 11:16:25.107
+     ndv: Device post-install completed. 11:16:26.388
+<<<  Section end 2016/10/05 11:16:26.388
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup Import Driver Package - C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxGuest.inf]
+>>>  Section start 2016/10/05 11:37:14.273
+      cmd: "C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxDrvInst.exe" driver install "C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxGuest.inf" "C:\Program Files\Oracle\VirtualBox Guest Additions\install_drivers.log"
+     inf: Provider: Oracle Corporation
+     inf: Class GUID: {4D36E97D-E325-11CE-BFC1-08002BE10318}
+     inf: Driver Version: 07/18/2016,5.0.26
+     inf: Catalog File: VBoxGuest.cat
+     sto: {Copy Driver Package: C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxGuest.inf} 11:37:14.431
+     sto:      Driver Package = C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxGuest.inf
+     sto:      Flags          = 0x00000007
+     sto:      Destination    = C:\Users\GOLD_A~1\AppData\Local\Temp\{1a68c03b-c314-7549-a760-8240ab735e32}
+     sto:      Copying driver package files to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{1a68c03b-c314-7549-a760-8240ab735e32}'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxControl.exe' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{1a68c03b-c314-7549-a760-8240ab735e32}\VBoxControl.exe'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxTray.exe' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{1a68c03b-c314-7549-a760-8240ab735e32}\VBoxTray.exe'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxGuest.cat' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{1a68c03b-c314-7549-a760-8240ab735e32}\VBoxGuest.cat'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxGuest.inf' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{1a68c03b-c314-7549-a760-8240ab735e32}\VBoxGuest.inf'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxGuest.sys' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{1a68c03b-c314-7549-a760-8240ab735e32}\VBoxGuest.sys'.
+     sto: {Copy Driver Package: exit(0x00000000)} 11:37:14.715
+     pol: {Driver package policy check} 11:37:15.070
+     pol: {Driver package policy check - exit(0x00000000)} 11:37:15.070
+     sto: {Stage Driver Package: C:\Users\GOLD_A~1\AppData\Local\Temp\{1a68c03b-c314-7549-a760-8240ab735e32}\VBoxGuest.inf} 11:37:15.070
+     inf:      {Query Configurability: C:\Users\GOLD_A~1\AppData\Local\Temp\{1a68c03b-c314-7549-a760-8240ab735e32}\VBoxGuest.inf} 11:37:15.070
+!    inf:           Found legacy DelService operation for 'VBoxTray'. Code = 1303
+!    inf:           Found legacy AddReg operation using non-relative key (HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run). Code = 1305
+!    inf:           Driver package 'VBoxGuest.inf' is NOT configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 11:37:15.085
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{1a68c03b-c314-7549-a760-8240ab735e32}\VBoxControl.exe' to 'C:\Windows\System32\DriverStore\Temp\{34f454b9-3dfd-6644-bbee-e310f2406335}\VBoxControl.exe'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{1a68c03b-c314-7549-a760-8240ab735e32}\VBoxTray.exe' to 'C:\Windows\System32\DriverStore\Temp\{34f454b9-3dfd-6644-bbee-e310f2406335}\VBoxTray.exe'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{1a68c03b-c314-7549-a760-8240ab735e32}\VBoxGuest.cat' to 'C:\Windows\System32\DriverStore\Temp\{34f454b9-3dfd-6644-bbee-e310f2406335}\VBoxGuest.cat'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{1a68c03b-c314-7549-a760-8240ab735e32}\VBoxGuest.inf' to 'C:\Windows\System32\DriverStore\Temp\{34f454b9-3dfd-6644-bbee-e310f2406335}\VBoxGuest.inf'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{1a68c03b-c314-7549-a760-8240ab735e32}\VBoxGuest.sys' to 'C:\Windows\System32\DriverStore\Temp\{34f454b9-3dfd-6644-bbee-e310f2406335}\VBoxGuest.sys'.
+     sto:      {DRIVERSTORE IMPORT VALIDATE} 11:37:15.259
+     sig:           {_VERIFY_FILE_SIGNATURE} 11:37:16.132
+     sig:                Key      = VBoxGuest.inf
+     sig:                FilePath = C:\Windows\System32\DriverStore\Temp\{34f454b9-3dfd-6644-bbee-e310f2406335}\VBoxGuest.inf
+     sig:                Catalog  = C:\Windows\System32\DriverStore\Temp\{34f454b9-3dfd-6644-bbee-e310f2406335}\VBoxGuest.cat
+!    sig:                Verifying file against specific (valid) catalog failed! (0x800b0109)
+!    sig:                Error 0x800b0109: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
+     sig:           {_VERIFY_FILE_SIGNATURE exit(0x800b0109)} 11:37:17.116
+     sig:           {_VERIFY_FILE_SIGNATURE} 11:37:17.116
+     sig:                Key      = VBoxGuest.inf
+     sig:                FilePath = C:\Windows\System32\DriverStore\Temp\{34f454b9-3dfd-6644-bbee-e310f2406335}\VBoxGuest.inf
+     sig:                Catalog  = C:\Windows\System32\DriverStore\Temp\{34f454b9-3dfd-6644-bbee-e310f2406335}\VBoxGuest.cat
+     sig:                Success: File is signed in Authenticode(tm) catalog.
+     sig:                Error 0xe0000242: The publisher of an Authenticode(tm) signed catalog has not yet been established as trusted.
+     sig:           {_VERIFY_FILE_SIGNATURE exit(0xe0000242)} 11:37:17.351
+!    sig:           Driver package signer is unknown, but user trusts signer.
+     sig:           Driver package certificate was successfully installed.
+     sto:      {DRIVERSTORE IMPORT VALIDATE: exit(0x00000000)} 11:38:02.351
+     sig:      Signer Score = 0x0F000000
+     sig:      Signer Name  = Oracle Corporation
+     sto:      {DRIVERSTORE IMPORT BEGIN} 11:38:02.351
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 11:38:02.351
+     cpy:      {Copy Directory: C:\Windows\System32\DriverStore\Temp\{34f454b9-3dfd-6644-bbee-e310f2406335}} 11:38:02.351
+     cpy:           Target Path = C:\Windows\System32\DriverStore\FileRepository\vboxguest.inf_amd64_015c006906a48641
+     cpy:      {Copy Directory: exit(0x00000000)} 11:38:02.367
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\vboxguest.inf_amd64_015c006906a48641\VBoxGuest.inf} 11:38:02.367
+     idb:           Created driver package object 'vboxguest.inf_amd64_015c006906a48641' in SYSTEM database node.
+     idb:           Created driver INF file object 'oem2.inf' in SYSTEM database node.
+     idb:           Registered driver package 'vboxguest.inf_amd64_015c006906a48641' with 'oem2.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 11:38:02.367
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\vboxguest.inf_amd64_015c006906a48641\VBoxGuest.inf} 11:38:02.367
+     idb:           Activating driver package 'vboxguest.inf_amd64_015c006906a48641'.
+     cpy:           Published 'vboxguest.inf_amd64_015c006906a48641\vboxguest.inf' to 'oem2.inf'.
+     idb:           Indexed 2 device IDs for 'vboxguest.inf_amd64_015c006906a48641'.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 47 ms
+     idb:      {Publish Driver Package: exit(0x00000000)} 11:38:02.460
+     sto:      {DRIVERSTORE IMPORT END} 11:38:02.460
+     sig:           Installed catalog 'VBoxGuest.cat' as 'oem2.cat'.
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 11:38:03.007
+     sto: {Stage Driver Package: exit(0x00000000)} 11:38:03.007
+<<<  Section end 2016/10/05 11:38:03.023
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [SetupCopyOEMInf - C:\Windows\System32\DriverStore\FileRepository\vboxguest.inf_amd64_015c006906a48641\VBoxGuest.inf]
+>>>  Section start 2016/10/05 11:38:03.288
+      cmd: "C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxDrvInst.exe" driver install "C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxGuest.inf" "C:\Program Files\Oracle\VirtualBox Guest Additions\install_drivers.log"
+     inf: Driver Store Path: C:\Windows\System32\DriverStore\FileRepository\vboxguest.inf_amd64_015c006906a48641\vboxguest.inf
+     inf: Published Inf Path: C:\Windows\INF\oem2.inf
+     sig: Installing catalog VBoxGuest.cat as: oem2.CAT
+<<<  Section end 2016/10/05 11:38:03.511
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Device Install (UpdateDriverForPlugAndPlayDevices) - PCI\VEN_80EE&DEV_CAFE&SUBSYS_00000000&REV_00]
+>>>  Section start 2016/10/05 11:38:03.976
+      cmd: "C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxDrvInst.exe" driver install "C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxGuest.inf" "C:\Program Files\Oracle\VirtualBox Guest Additions\install_drivers.log"
+     dvi: {Update Device Driver - PCI\VEN_80EE&DEV_CAFE&SUBSYS_00000000&REV_00\3&267A616A&1&20}
+     dvi:      {Build Driver List} 11:38:04.195
+     dvi:           Searching for hardware ID(s):
+     dvi:                pci\ven_80ee&dev_cafe&subsys_00000000&rev_00
+     dvi:                pci\ven_80ee&dev_cafe&subsys_00000000
+     dvi:                pci\ven_80ee&dev_cafe&rev_00
+     dvi:                pci\ven_80ee&dev_cafe
+     dvi:                pci\ven_80ee&dev_cafe&cc_088000
+     dvi:                pci\ven_80ee&dev_cafe&cc_0880
+     dvi:           Searching for compatible ID(s):
+     dvi:                pci\ven_80ee&cc_088000
+     dvi:                pci\ven_80ee&cc_0880
+     dvi:                pci\ven_80ee
+     dvi:                pci\cc_088000
+     dvi:                pci\cc_0880
+     dvi:           Created Driver Node:
+     dvi:                HardwareID   - PCI\VEN_80ee&DEV_cafe
+     dvi:                InfName      - c:\windows\system32\driverstore\filerepository\vboxguest.inf_amd64_015c006906a48641\vboxguest.inf
+     dvi:                DevDesc      - VirtualBox Device
+     dvi:                Section      - VBoxGuest_Install
+     dvi:                Rank         - 0x00ff0003
+     dvi:                Signer Score - Authenticode
+     dvi:                DrvDate      - 07/18/2016
+     dvi:                Version      - 5.0.26.0
+     dvi:      {Build Driver List - exit(0x00000000)} 11:38:04.273
+     dvi:      {DIF_SELECTBESTCOMPATDRV} 11:38:04.273
+     dvi:           Default installer: Enter 11:38:04.273
+     dvi:                {Select Best Driver}
+     dvi:                     Class GUID of device changed to: {4d36e97d-e325-11ce-bfc1-08002be10318}.
+     dvi:                     Selected:
+     dvi:                          Description - [VirtualBox Device]
+     dvi:                          InfFile     - [c:\windows\system32\driverstore\filerepository\vboxguest.inf_amd64_015c006906a48641\vboxguest.inf]
+     dvi:                          Section     - [VBoxGuest_Install]
+     dvi:                {Select Best Driver - exit(0x00000000)}
+     dvi:           Default installer: Exit
+     dvi:      {DIF_SELECTBESTCOMPATDRV - exit(0x00000000)} 11:38:04.307
+     ndv:      Forcing driver install:
+     ndv:           Inf Name       - oem2.inf
+     ndv:           Driver Date    - 07/18/2016
+     ndv:           Driver Version - 5.0.26.0
+     ndv:      Driver package 'C:\Windows\INF\oem2.inf' exists under 'C:\Windows\System32\DriverStore\FileRepository\vboxguest.inf_amd64_015c006906a48641\vboxguest.inf' (oem2.inf).
+     dvi:      Searching for hardware ID(s):
+     dvi:           pci\ven_80ee&dev_cafe&subsys_00000000&rev_00
+     dvi:           pci\ven_80ee&dev_cafe&subsys_00000000
+     dvi:           pci\ven_80ee&dev_cafe&rev_00
+     dvi:           pci\ven_80ee&dev_cafe
+     dvi:           pci\ven_80ee&dev_cafe&cc_088000
+     dvi:           pci\ven_80ee&dev_cafe&cc_0880
+     dvi:      Searching for compatible ID(s):
+     dvi:           pci\ven_80ee&cc_088000
+     dvi:           pci\ven_80ee&cc_0880
+     dvi:           pci\ven_80ee
+     dvi:           pci\cc_088000
+     dvi:           pci\cc_0880
+     dvi:      Class GUID of device changed to: {4d36e97d-e325-11ce-bfc1-08002be10318}.
+     dvi:      {Plug and Play Service: Device Install for PCI\VEN_80EE&DEV_CAFE&SUBSYS_00000000&REV_00\3&267A616A&1&20}
+     ndv:           Driver INF Path: C:\Windows\INF\oem2.inf
+     ndv:           Driver Node Name: vboxguest.inf:5503dd42a9865fae:VBoxGuest_Install:5.0.26.0:pci\ven_80ee&dev_cafe
+     ndv:           Driver Store Path: C:\Windows\System32\DriverStore\FileRepository\vboxguest.inf_amd64_015c006906a48641\vboxguest.inf
+     dvi:           Searching for hardware ID(s):
+     dvi:                pci\ven_80ee&dev_cafe&subsys_00000000&rev_00
+     dvi:                pci\ven_80ee&dev_cafe&subsys_00000000
+     dvi:                pci\ven_80ee&dev_cafe&rev_00
+     dvi:                pci\ven_80ee&dev_cafe
+     dvi:                pci\ven_80ee&dev_cafe&cc_088000
+     dvi:                pci\ven_80ee&dev_cafe&cc_0880
+     dvi:           Searching for compatible ID(s):
+     dvi:                pci\ven_80ee&cc_088000
+     dvi:                pci\ven_80ee&cc_0880
+     dvi:                pci\ven_80ee
+     dvi:                pci\cc_088000
+     dvi:                pci\cc_0880
+     dvi:           Class GUID of device changed to: {4d36e97d-e325-11ce-bfc1-08002be10318}.
+     ndv:           {Core Device Install} 11:38:05.791
+     ndv:                {Installing device - PCI\VEN_80EE&DEV_CAFE&SUBSYS_00000000&REV_00\3&267A616A&1&20} 11:38:05.791
+     dvi:                     {DIF_ALLOW_INSTALL} 11:38:05.791
+     dvi:                          Default installer: Enter 11:38:05.791
+     dvi:                          Default installer: Exit
+     dvi:                     {DIF_ALLOW_INSTALL - exit(0xe000020e)} 11:38:05.791
+     dvi:                     {DIF_INSTALLDEVICEFILES} 11:38:06.413
+     dvi:                          Default installer: Enter 11:38:06.413
+     dvi:                          Default installer: Exit
+     dvi:                     {DIF_INSTALLDEVICEFILES - exit(0x00000000)} 11:38:06.445
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxguest.inf_amd64_015c006906a48641\VBoxGuest.sys' to 'C:\Windows\system32\DRIVERS\VBoxGuest.sys'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxguest.inf_amd64_015c006906a48641\VBoxTray.exe' to 'C:\Windows\system32\VBoxTray.exe'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxguest.inf_amd64_015c006906a48641\VBoxControl.exe' to 'C:\Windows\system32\VBoxControl.exe'.
+     dvi:                     {DIF_REGISTER_COINSTALLERS} 11:38:06.929
+     dvi:                          Reset Device: Resetting device configuration. 11:38:06.929
+     dvi:                          Reset Device: Resetting device configuration completed. 11:38:06.929
+     dvi:                          Default installer: Enter 11:38:06.945
+     dvi:                          Default installer: Exit
+     dvi:                     {DIF_REGISTER_COINSTALLERS - exit(0x00000000)} 11:38:06.945
+     dvi:                     {DIF_INSTALLINTERFACES} 11:38:06.945
+     dvi:                          Default installer: Enter 11:38:06.945
+     dvi:                          Default installer: Exit
+     dvi:                     {DIF_INSTALLINTERFACES - exit(0x00000000)} 11:38:06.945
+     dvi:                     {DIF_INSTALLDEVICE} 11:38:06.945
+     dvi:                          Default installer: Enter 11:38:06.945
+     dvi:                               {Install DEVICE}
+     dvi:                                    {Writing Device Properties}
+     dvi:                                         Strong Name=oem2.inf:5503dd42a9865fae:VBoxGuest_Install:5.0.26.0:pci\ven_80ee&dev_cafe
+     dvi:                                    {Writing Device Properties - Complete}
+     inf:                                    DelService=VBoxTray,0x00000004  (vboxguest.inf line 60)
+     dvi:                                    Delete Services: Service 'VBoxTray' does not exist.
+     inf:                                    AddService=VBoxGuest,0x00000002,VBoxGuest_ServiceInstallSection  (vboxguest.inf line 59)
+     dvi:                                    Add Service: Created service 'VBoxGuest'.
+     dvi:                               {Install DEVICE exit (0x00000000)}
+     dvi:                               Install Device: Configuring device class. 11:38:07.007
+     dvi:                               Install Device: Configuring device class completed. 11:38:07.007
+     dvi:                               {Restarting Devices} 11:38:07.054
+     dvi:                                    Restart: PCI\VEN_80EE&DEV_CAFE&SUBSYS_00000000&REV_00\3&267A616A&1&20
+     dvi:                               {Restarting Devices exit} 11:38:07.132
+     dvi:                          Default installer: Exit
+     dvi:                     {DIF_INSTALLDEVICE - exit(0x00000000)} 11:38:07.147
+     dvi:                     {DIF_NEWDEVICEWIZARD_FINISHINSTALL} 11:38:07.147
+     dvi:                          Default installer: Enter 11:38:07.147
+     dvi:                          Default installer: Exit
+     dvi:                     {DIF_NEWDEVICEWIZARD_FINISHINSTALL - exit(0xe000020e)} 11:38:07.147
+     ndv:                {Installing device - exit(0x00000000)} 11:38:07.147
+     ndv:           {Core Device Install - exit(0x00000000)} 11:38:07.147
+     ump:      {Plug and Play Service: Device Install exit(00000000)}
+     ndv: {Update Device Driver - exit(00000000)}
+<<<  Section end 2016/10/05 11:38:07.179
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [SetupCopyOEMInf - C:\Windows\System32\DriverStore\FileRepository\vboxguest.inf_amd64_015c006906a48641\VBoxGuest.inf]
+>>>  Section start 2016/10/05 11:38:07.179
+      cmd: "C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxDrvInst.exe" driver install "C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxGuest.inf" "C:\Program Files\Oracle\VirtualBox Guest Additions\install_drivers.log"
+     inf: Driver Store Path: C:\Windows\System32\DriverStore\FileRepository\vboxguest.inf_amd64_015c006906a48641\vboxguest.inf
+     inf: Published Inf Path: C:\Windows\INF\oem2.inf
+<<<  Section end 2016/10/05 11:38:07.194
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup Import Driver Package - C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxVideoW8.inf]
+>>>  Section start 2016/10/05 11:38:09.167
+      cmd: "C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxDrvInst.exe" driver install "C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxVideoW8.inf" "C:\Program Files\Oracle\VirtualBox Guest Additions\install_drivers.log"
+     inf: Provider: Oracle Corporation
+     inf: Class GUID: {4D36E968-E325-11CE-BFC1-08002BE10318}
+     inf: Driver Version: 07/18/2016,5.0.26
+     inf: Catalog File: VBoxVideoW8.cat
+     sto: {Copy Driver Package: C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxVideoW8.inf} 11:38:09.227
+     sto:      Driver Package = C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxVideoW8.inf
+     sto:      Flags          = 0x00000007
+     sto:      Destination    = C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}
+     sto:      Copying driver package files to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxOGLfeedbackspu-x86.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLfeedbackspu-x86.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxD3D9wddm.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxD3D9wddm.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxVideoW8.sys' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxVideoW8.sys'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxOGLcrutil-x86.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLcrutil-x86.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxOGL.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGL.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxOGLpackspu-x86.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLpackspu-x86.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxOGLpassthroughspu.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLpassthroughspu.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\wined3dwddm-x86.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\wined3dwddm-x86.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxDispD3D-x86.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxDispD3D-x86.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxOGLfeedbackspu.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLfeedbackspu.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxOGLarrayspu-x86.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLarrayspu-x86.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxOGLcrutil.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLcrutil.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxOGLerrorspu-x86.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLerrorspu-x86.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxD3D9wddm-x86.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxD3D9wddm-x86.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxOGLpackspu.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLpackspu.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxOGL-x86.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGL-x86.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxOGLpassthroughspu-x86.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLpassthroughspu-x86.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\wined3dwddm.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\wined3dwddm.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxDispD3D.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxDispD3D.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxOGLarrayspu.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLarrayspu.dll'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxVideoW8.cat' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxVideoW8.cat'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxVideoW8.inf' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxVideoW8.inf'.
+     flq:      Copying 'C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxOGLerrorspu.dll' to 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLerrorspu.dll'.
+     sto: {Copy Driver Package: exit(0x00000000)} 11:38:10.651
+     pol: {Driver package policy check} 11:38:10.667
+     pol: {Driver package policy check - exit(0x00000000)} 11:38:10.667
+     sto: {Stage Driver Package: C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxVideoW8.inf} 11:38:10.667
+     inf:      {Query Configurability: C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxVideoW8.inf} 11:38:10.667
+!    inf:           Legacy directive 'RegisterDlls' will be ignored. Code = 2222, Line = 44
+!    inf:           Found legacy RegisterDlls operation. Code = 1301
+!    inf:           Driver package 'VBoxVideoW8.inf' is NOT configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 11:38:10.683
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLfeedbackspu-x86.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxOGLfeedbackspu-x86.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxD3D9wddm.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxD3D9wddm.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxVideoW8.sys' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxVideoW8.sys'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLcrutil-x86.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxOGLcrutil-x86.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGL.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxOGL.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLpackspu-x86.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxOGLpackspu-x86.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLpassthroughspu.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxOGLpassthroughspu.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\wined3dwddm-x86.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\wined3dwddm-x86.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxDispD3D-x86.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxDispD3D-x86.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLfeedbackspu.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxOGLfeedbackspu.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLarrayspu-x86.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxOGLarrayspu-x86.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLcrutil.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxOGLcrutil.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLerrorspu-x86.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxOGLerrorspu-x86.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxD3D9wddm-x86.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxD3D9wddm-x86.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLpackspu.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxOGLpackspu.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGL-x86.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxOGL-x86.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLpassthroughspu-x86.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxOGLpassthroughspu-x86.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\wined3dwddm.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\wined3dwddm.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxDispD3D.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxDispD3D.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLarrayspu.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxOGLarrayspu.dll'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxVideoW8.cat' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxVideoW8.cat'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxVideoW8.inf' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxVideoW8.inf'.
+     flq:      Copying 'C:\Users\GOLD_A~1\AppData\Local\Temp\{64d59cf3-efc7-714c-8784-077834466a3e}\VBoxOGLerrorspu.dll' to 'C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxOGLerrorspu.dll'.
+     sto:      {DRIVERSTORE IMPORT VALIDATE} 11:38:13.335
+     sig:           {_VERIFY_FILE_SIGNATURE} 11:38:13.351
+     sig:                Key      = VBoxVideoW8.inf
+     sig:                FilePath = C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxVideoW8.inf
+     sig:                Catalog  = C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxVideoW8.cat
+!    sig:                Verifying file against specific (valid) catalog failed! (0x800b0109)
+!    sig:                Error 0x800b0109: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
+     sig:           {_VERIFY_FILE_SIGNATURE exit(0x800b0109)} 11:38:13.383
+     sig:           {_VERIFY_FILE_SIGNATURE} 11:38:13.383
+     sig:                Key      = VBoxVideoW8.inf
+     sig:                FilePath = C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxVideoW8.inf
+     sig:                Catalog  = C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}\VBoxVideoW8.cat
+     sig:                Success: File is signed in Authenticode(tm) catalog.
+     sig:                Error 0xe0000241: The INF was signed with an Authenticode(tm) catalog from a trusted publisher.
+     sig:           {_VERIFY_FILE_SIGNATURE exit(0xe0000241)} 11:38:13.399
+     sto:      {DRIVERSTORE IMPORT VALIDATE: exit(0x00000000)} 11:38:13.607
+     sig:      Signer Score = 0x0F000000
+     sig:      Signer Name  = Oracle Corporation
+     sto:      {DRIVERSTORE IMPORT BEGIN} 11:38:13.623
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 11:38:13.623
+     cpy:      {Copy Directory: C:\Windows\System32\DriverStore\Temp\{6f3fe43c-c588-2746-8059-32007ade986c}} 11:38:13.623
+     cpy:           Target Path = C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21
+     cpy:      {Copy Directory: exit(0x00000000)} 11:38:13.623
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxVideoW8.inf} 11:38:13.638
+     idb:           Created driver package object 'vboxvideow8.inf_amd64_3e57494f9da28c21' in DRIVERS database node.
+     idb:           Created driver INF file object 'oem3.inf' in DRIVERS database node.
+     idb:           Registered driver package 'vboxvideow8.inf_amd64_3e57494f9da28c21' with 'oem3.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 11:38:13.638
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxVideoW8.inf} 11:38:13.638
+     idb:           Activating driver package 'vboxvideow8.inf_amd64_3e57494f9da28c21'.
+     cpy:           Published 'vboxvideow8.inf_amd64_3e57494f9da28c21\vboxvideow8.inf' to 'oem3.inf'.
+!    inf:           Legacy directive 'RegisterDlls' will be ignored. Code = 2222, Line = 44
+     idb:           Indexed 2 device IDs for 'vboxvideow8.inf_amd64_3e57494f9da28c21'.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 187 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 266 ms
+     idb:      {Publish Driver Package: exit(0x00000000)} 11:38:14.101
+     sto:      {DRIVERSTORE IMPORT END} 11:38:14.101
+     sig:           Installed catalog 'VBoxVideoW8.cat' as 'oem3.cat'.
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 11:38:14.633
+     sto: {Stage Driver Package: exit(0x00000000)} 11:38:14.633
+<<<  Section end 2016/10/05 11:38:14.663
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [SetupCopyOEMInf - C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxVideoW8.inf]
+>>>  Section start 2016/10/05 11:38:14.663
+      cmd: "C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxDrvInst.exe" driver install "C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxVideoW8.inf" "C:\Program Files\Oracle\VirtualBox Guest Additions\install_drivers.log"
+     inf: Driver Store Path: C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\vboxvideow8.inf
+     inf: Published Inf Path: C:\Windows\INF\oem3.inf
+     sig: Installing catalog VBoxVideoW8.cat as: oem3.CAT
+<<<  Section end 2016/10/05 11:38:14.710
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Device Install (UpdateDriverForPlugAndPlayDevices) - PCI\VEN_80EE&DEV_BEEF&SUBSYS_00000000&REV_00]
+>>>  Section start 2016/10/05 11:38:15.476
+      cmd: "C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxDrvInst.exe" driver install "C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxVideoW8.inf" "C:\Program Files\Oracle\VirtualBox Guest Additions\install_drivers.log"
+     dvi: {Update Device Driver - PCI\VEN_80EE&DEV_BEEF&SUBSYS_00000000&REV_00\3&267A616A&1&10}
+     dvi:      {Build Driver List} 11:38:15.476
+     dvi:           Searching for hardware ID(s):
+     dvi:                pci\ven_80ee&dev_beef&subsys_00000000&rev_00
+     dvi:                pci\ven_80ee&dev_beef&subsys_00000000
+     dvi:                pci\ven_80ee&dev_beef&rev_00
+     dvi:                pci\ven_80ee&dev_beef
+     dvi:                pci\ven_80ee&dev_beef&cc_030000
+     dvi:                pci\ven_80ee&dev_beef&cc_0300
+     dvi:           Searching for compatible ID(s):
+     dvi:                pci\ven_80ee&cc_030000
+     dvi:                pci\ven_80ee&cc_0300
+     dvi:                pci\ven_80ee
+     dvi:                pci\cc_030000
+     dvi:                pci\cc_0300
+     dvi:           Created Driver Node:
+     dvi:                HardwareID   - PCI\VEN_80EE&DEV_BEEF
+     dvi:                InfName      - c:\windows\system32\driverstore\filerepository\vboxvideow8.inf_amd64_3e57494f9da28c21\vboxvideow8.inf
+     dvi:                DevDesc      - VirtualBox Graphics Adapter for Windows 8+
+     dvi:                Section      - VBoxVideo
+     dvi:                Rank         - 0x00f80003
+     dvi:                Signer Score - Authenticode
+     dvi:                DrvDate      - 07/18/2016
+     dvi:                Version      - 5.0.26.0
+     dvi:      {Build Driver List - exit(0x00000000)} 11:38:15.555
+     dvi:      {DIF_SELECTBESTCOMPATDRV} 11:38:15.555
+     dvi:           Using exported function 'DisplayClassInstaller' in module 'C:\Windows\system32\DispCI.dll'.
+     dvi:           Class installer == DispCI.dll,DisplayClassInstaller
+     dvi:           Class installer: Enter 11:38:15.573
+     dvi:           Class installer: Exit
+     dvi:           Default installer: Enter 11:38:15.591
+     dvi:                {Select Best Driver}
+     dvi:                     Class GUID of device remains: {4d36e968-e325-11ce-bfc1-08002be10318}.
+     dvi:                     Selected:
+     dvi:                          Description - [VirtualBox Graphics Adapter for Windows 8+]
+     dvi:                          InfFile     - [c:\windows\system32\driverstore\filerepository\vboxvideow8.inf_amd64_3e57494f9da28c21\vboxvideow8.inf]
+     dvi:                          Section     - [VBoxVideo]
+     dvi:                {Select Best Driver - exit(0x00000000)}
+     dvi:           Default installer: Exit
+     dvi:      {DIF_SELECTBESTCOMPATDRV - exit(0x00000000)} 11:38:15.607
+     ndv:      Forcing driver install:
+     ndv:           Inf Name       - oem3.inf
+     ndv:           Driver Date    - 07/18/2016
+     ndv:           Driver Version - 5.0.26.0
+     ndv:      Driver package 'C:\Windows\INF\oem3.inf' exists under 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\vboxvideow8.inf' (oem3.inf).
+     dvi:      Searching for hardware ID(s):
+     dvi:           pci\ven_80ee&dev_beef&subsys_00000000&rev_00
+     dvi:           pci\ven_80ee&dev_beef&subsys_00000000
+     dvi:           pci\ven_80ee&dev_beef&rev_00
+     dvi:           pci\ven_80ee&dev_beef
+     dvi:           pci\ven_80ee&dev_beef&cc_030000
+     dvi:           pci\ven_80ee&dev_beef&cc_0300
+     dvi:      Searching for compatible ID(s):
+     dvi:           pci\ven_80ee&cc_030000
+     dvi:           pci\ven_80ee&cc_0300
+     dvi:           pci\ven_80ee
+     dvi:           pci\cc_030000
+     dvi:           pci\cc_0300
+     dvi:      Class GUID of device remains: {4d36e968-e325-11ce-bfc1-08002be10318}.
+     dvi:      {Plug and Play Service: Device Install for PCI\VEN_80EE&DEV_BEEF&SUBSYS_00000000&REV_00\3&267A616A&1&10}
+     ndv:           Driver INF Path: C:\Windows\INF\oem3.inf
+     ndv:           Driver Node Name: vboxvideow8.inf:5503dd4286a0eee1:VBoxVideo:5.0.26.0:pci\ven_80ee&dev_beef
+     ndv:           Driver Store Path: C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\vboxvideow8.inf
+     dvi:           Searching for hardware ID(s):
+     dvi:                pci\ven_80ee&dev_beef&subsys_00000000&rev_00
+     dvi:                pci\ven_80ee&dev_beef&subsys_00000000
+     dvi:                pci\ven_80ee&dev_beef&rev_00
+     dvi:                pci\ven_80ee&dev_beef
+     dvi:                pci\ven_80ee&dev_beef&cc_030000
+     dvi:                pci\ven_80ee&dev_beef&cc_0300
+     dvi:           Searching for compatible ID(s):
+     dvi:                pci\ven_80ee&cc_030000
+     dvi:                pci\ven_80ee&cc_0300
+     dvi:                pci\ven_80ee
+     dvi:                pci\cc_030000
+     dvi:                pci\cc_0300
+     dvi:           Class GUID of device changed to: {4d36e968-e325-11ce-bfc1-08002be10318}.
+     ndv:           {Core Device Install} 11:38:15.711
+     ndv:                {Installing device - PCI\VEN_80EE&DEV_BEEF&SUBSYS_00000000&REV_00\3&267A616A&1&10} 11:38:15.727
+!    ndv:                     Device class {4d36e968-e325-11ce-bfc1-08002be10318} is not configurable.
+     dvi:                     {DIF_ALLOW_INSTALL} 11:38:15.727
+     dvi:                          Using exported function 'DisplayClassInstaller' in module 'C:\Windows\system32\DispCI.dll'.
+     dvi:                          Class installer == DispCI.dll,DisplayClassInstaller
+     dvi:                          Class installer: Enter 11:38:15.727
+     dvi:                          Class installer: Exit
+     dvi:                          Default installer: Enter 11:38:15.743
+     dvi:                          Default installer: Exit
+     dvi:                     {DIF_ALLOW_INSTALL - exit(0xe000020e)} 11:38:15.743
+     dvi:                     {DIF_INSTALLDEVICEFILES} 11:38:15.743
+     dvi:                          Class installer: Enter 11:38:15.743
+     dvi:                               {Build Driver List} 11:38:15.743
+     dvi:                                    Searching for hardware ID(s):
+     dvi:                                         pci\ven_80ee&dev_beef&subsys_00000000&rev_00
+     dvi:                                         pci\ven_80ee&dev_beef&subsys_00000000
+     dvi:                                         pci\ven_80ee&dev_beef&rev_00
+     dvi:                                         pci\ven_80ee&dev_beef
+     dvi:                                         pci\ven_80ee&dev_beef&cc_030000
+     dvi:                                         pci\ven_80ee&dev_beef&cc_0300
+     dvi:                                    Searching for compatible ID(s):
+     dvi:                                         pci\ven_80ee&cc_030000
+     dvi:                                         pci\ven_80ee&cc_0300
+     dvi:                                         pci\ven_80ee
+     dvi:                                         pci\cc_030000
+     dvi:                                         pci\cc_0300
+     dvi:                                    Created Driver Node:
+     dvi:                                         HardwareID   - PCI\CC_0300
+     dvi:                                         InfName      - C:\Windows\System32\DriverStore\FileRepository\display.inf_amd64_54c15e45dc857c30\display.inf
+     dvi:                                         DevDesc      - Microsoft Basic Display Adapter
+     dvi:                                         Section      - MSBDA
+     dvi:                                         Rank         - 0x00fb2004
+     dvi:                                         Signer Score - INBOX
+     dvi:                                         DrvDate      - 06/21/2006
+     dvi:                                         Version      - 10.0.10240.16384
+     dvi:                                    Created Driver Node:
+     dvi:                                         HardwareID   - PCI\VEN_80EE&DEV_BEEF
+     dvi:                                         InfName      - C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\vboxvideow8.inf
+     dvi:                                         DevDesc      - VirtualBox Graphics Adapter for Windows 8+
+     dvi:                                         Section      - VBoxVideo
+     dvi:                                         Rank         - 0x00f80003
+     dvi:                                         Signer Score - Authenticode
+     dvi:                                         DrvDate      - 07/18/2016
+     dvi:                                         Version      - 5.0.26.0
+     dvi:                               {Build Driver List - exit(0x00000000)} 11:38:16.913
+     dvi:                               {Build Driver List} 11:38:16.913
+     dvi:                                    Searching for hardware ID(s):
+     dvi:                                         root\basicrender
+     dvi:                                    Created Driver Node:
+     dvi:                                         HardwareID   - ROOT\BASICRENDER
+     dvi:                                         InfName      - C:\Windows\System32\DriverStore\FileRepository\basicrender.inf_amd64_7ff523d87d1709ac\basicrender.inf
+     dvi:                                         DevDesc      - Microsoft Basic Render Driver
+     dvi:                                         Section      - BasicRender
+     dvi:                                         Rank         - 0x00fb0000
+     dvi:                                         Signer Score - INBOX
+     dvi:                                         DrvDate      - 06/21/2006
+     dvi:                                         Version      - 10.0.10240.16384
+     dvi:                               {Build Driver List - exit(0x00000000)} 11:38:17.132
+     dvi:                          Class installer: Exit
+     dvi:                          Default installer: Enter 11:38:17.163
+     dvi:                          Default installer: Exit
+     dvi:                     {DIF_INSTALLDEVICEFILES - exit(0x00000000)} 11:38:17.179
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxVideoW8.sys' to 'C:\Windows\system32\DRIVERS\VBoxVideoW8.sys'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxDispD3D.dll' to 'C:\Windows\system32\VBoxDispD3D.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxDispD3D-x86.dll' to 'C:\Windows\SysWow64\VBoxDispD3D-x86.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxOGL.dll' to 'C:\Windows\system32\VBoxOGL.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxD3D9wddm.dll' to 'C:\Windows\system32\VBoxD3D9wddm.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\wined3dwddm.dll' to 'C:\Windows\system32\wined3dwddm.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxOGLarrayspu.dll' to 'C:\Windows\system32\VBoxOGLarrayspu.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxOGLcrutil.dll' to 'C:\Windows\system32\VBoxOGLcrutil.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxOGLerrorspu.dll' to 'C:\Windows\system32\VBoxOGLerrorspu.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxOGLfeedbackspu.dll' to 'C:\Windows\system32\VBoxOGLfeedbackspu.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxOGLpackspu.dll' to 'C:\Windows\system32\VBoxOGLpackspu.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxOGLpassthroughspu.dll' to 'C:\Windows\system32\VBoxOGLpassthroughspu.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxOGL-x86.dll' to 'C:\Windows\SysWow64\VBoxOGL-x86.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxD3D9wddm-x86.dll' to 'C:\Windows\SysWow64\VBoxD3D9wddm-x86.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\wined3dwddm-x86.dll' to 'C:\Windows\SysWow64\wined3dwddm-x86.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxOGLarrayspu-x86.dll' to 'C:\Windows\SysWow64\VBoxOGLarrayspu-x86.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxOGLcrutil-x86.dll' to 'C:\Windows\SysWow64\VBoxOGLcrutil-x86.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxOGLerrorspu-x86.dll' to 'C:\Windows\SysWow64\VBoxOGLerrorspu-x86.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxOGLfeedbackspu-x86.dll' to 'C:\Windows\SysWow64\VBoxOGLfeedbackspu-x86.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxOGLpackspu-x86.dll' to 'C:\Windows\SysWow64\VBoxOGLpackspu-x86.dll'.
+     flq:                     Copying 'C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxOGLpassthroughspu-x86.dll' to 'C:\Windows\SysWow64\VBoxOGLpassthroughspu-x86.dll'.
+     dvi:                     {DIF_REGISTER_COINSTALLERS} 11:38:21.679
+     dvi:                          Reset Device: Resetting device configuration. 11:38:21.679
+     dvi:                          Reset Device: Resetting device configuration completed. 11:38:21.679
+     dvi:                          Class installer: Enter 11:38:21.679
+     dvi:                          Class installer: Exit
+     dvi:                          Default installer: Enter 11:38:21.679
+     dvi:                          Default installer: Exit
+     dvi:                     {DIF_REGISTER_COINSTALLERS - exit(0x00000000)} 11:38:21.679
+     dvi:                     {DIF_INSTALLINTERFACES} 11:38:21.679
+     dvi:                          Class installer: Enter 11:38:21.679
+     dvi:                          Class installer: Exit
+     dvi:                          Default installer: Enter 11:38:21.695
+     dvi:                          Default installer: Exit
+     dvi:                     {DIF_INSTALLINTERFACES - exit(0x00000000)} 11:38:21.695
+     dvi:                     {DIF_INSTALLDEVICE} 11:38:21.695
+     dvi:                          Class installer: Enter 11:38:21.695
+     inf:                               AddService=VBoxVideoW8,0x00000002,VBoxVideo_Service_Inst,VBoxVideo_EventLog_Inst  (oem3.inf line 87)
+     dvi:                               Add Service: Created service 'VBoxVideoW8'.
+     dvi:                               {Install DEVICE}
+     dvi:                                    {Writing Device Properties}
+     dvi:                                         Strong Name=oem3.inf:5503dd4286a0eee1:VBoxVideo:5.0.26.0:pci\ven_80ee&dev_beef
+     dvi:                                    {Writing Device Properties - Complete}
+     inf:                                    AddService=VBoxVideoW8,0x00000002,VBoxVideo_Service_Inst,VBoxVideo_EventLog_Inst  (vboxvideow8.inf line 87)
+     dvi:                                    Add Service: Modified existing service 'VBoxVideoW8'.
+     dvi:                               {Install DEVICE exit (0x00000000)}
+     dvi:                               Install Device: Configuring device class. 11:38:21.804
+     dvi:                               Install Device: Configuring device class completed. 11:38:21.804
+     dvi:                               {Restarting Devices} 11:38:21.804
+     dvi:                                    Query-remove: PCI\VEN_80EE&DEV_BEEF&SUBSYS_00000000&REV_00\3&267A616A&1&10
+     dvi:                                    Restart: PCI\VEN_80EE&DEV_BEEF&SUBSYS_00000000&REV_00\3&267A616A&1&10
+     dvi:                                    Restart verified: PCI\VEN_80EE&DEV_BEEF&SUBSYS_00000000&REV_00\3&267A616A&1&10
+     dvi:                               {Restarting Devices exit} 11:38:24.015
+     dvi:                          Class installer: Exit
+     dvi:                     {DIF_INSTALLDEVICE - exit(0x00000000)} 11:38:24.015
+     dvi:                     {DIF_NEWDEVICEWIZARD_FINISHINSTALL} 11:38:24.015
+     dvi:                          Class installer: Enter 11:38:24.015
+     dvi:                          Class installer: Exit
+     dvi:                          Default installer: Enter 11:38:24.015
+     dvi:                          Default installer: Exit
+     dvi:                     {DIF_NEWDEVICEWIZARD_FINISHINSTALL - exit(0xe000020e)} 11:38:24.015
+     ndv:                {Installing device - exit(0x00000000)} 11:38:24.027
+     ndv:           {Core Device Install - exit(0x00000000)} 11:38:24.027
+     dvi:           {DIF_DESTROYPRIVATEDATA} 11:38:24.027
+     dvi:                Class installer: Enter 11:38:24.027
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 11:38:24.027
+     dvi:                Default installer: Exit
+     dvi:           {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 11:38:24.039
+     ump:      {Plug and Play Service: Device Install exit(00000000)}
+     dvi:      {DIF_DESTROYPRIVATEDATA} 11:38:24.086
+     dvi:           Class installer: Enter 11:38:24.086
+     dvi:           Class installer: Exit
+     dvi:           Default installer: Enter 11:38:24.086
+     dvi:           Default installer: Exit
+     dvi:      {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 11:38:24.103
+     ndv: {Update Device Driver - exit(00000000)}
+<<<  Section end 2016/10/05 11:38:24.118
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [SetupCopyOEMInf - C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\VBoxVideoW8.inf]
+>>>  Section start 2016/10/05 11:38:24.118
+      cmd: "C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxDrvInst.exe" driver install "C:\Program Files\Oracle\VirtualBox Guest Additions\VBoxVideoW8.inf" "C:\Program Files\Oracle\VirtualBox Guest Additions\install_drivers.log"
+     inf: Driver Store Path: C:\Windows\System32\DriverStore\FileRepository\vboxvideow8.inf_amd64_3e57494f9da28c21\vboxvideow8.inf
+     inf: Published Inf Path: C:\Windows\INF\oem3.inf
+<<<  Section end 2016/10/05 11:38:24.118
+<<<  [Exit status: SUCCESS]
+
+
+[Boot Session: 2016/10/05 01:53:52.487]
+
+>>>  [Device Installation Restrictions Policy Check]
+>>>  Section start 2016/10/05 01:55:14.190
+<<<  Section end 2016/10/05 01:55:14.207
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Device and Driver Disk Cleanup Handler]
+>>>  Section start 2016/10/05 02:32:35.176
+      cmd: taskhostw.exe
+     set: Searching for not-recently detected devices that may be removed from the system.
+     set: Devices will be removed during this pass.
+     set: Device SW\{96E080C7-143C-11D1-B40F-00A0C9223196}\{3C0D501A-140B-11D1-B40F-00A0C9223196} will be removed.
+     set: Device SW\{96E080C7-143C-11D1-B40F-00A0C9223196}\{3C0D501A-140B-11D1-B40F-00A0C9223196} was removed.
+     set: Device was last used with alternate Hardware Configuration (0), setting re-specialize.
+     set: Device SW\{CFD669F1-9BC2-11D0-8299-0000F822FE8A}\{0A4252A0-7E70-11D0-A5D6-28DB04C10000} will be removed.
+     set: Device SW\{CFD669F1-9BC2-11D0-8299-0000F822FE8A}\{0A4252A0-7E70-11D0-A5D6-28DB04C10000} was removed.
+     set: Device was last used with alternate Hardware Configuration (0), setting re-specialize.
+     set: Device SW\{EEC12DB6-AD9C-4168-8658-B03DAEF417FE}\{ABD61E00-9350-47E2-A632-4438B90C6641} will be removed.
+     set: Device SW\{EEC12DB6-AD9C-4168-8658-B03DAEF417FE}\{ABD61E00-9350-47E2-A632-4438B90C6641} was removed.
+     set: Device was last used with alternate Hardware Configuration (0), setting re-specialize.
+     set: Device SW\{DDF4358E-BB2C-11D0-A42F-00A0C9223196}\{97EBAACB-95BD-11D0-A3EA-00A0C9223196} will be removed.
+     set: Device SW\{DDF4358E-BB2C-11D0-A42F-00A0C9223196}\{97EBAACB-95BD-11D0-A3EA-00A0C9223196} was removed.
+     set: Device was last used with alternate Hardware Configuration (0), setting re-specialize.
+     set: Device SW\{97EBAACC-95BD-11D0-A3EA-00A0C9223196}\{53172480-4791-11D0-A5D6-28DB04C10000} will be removed.
+     set: Device SW\{97EBAACC-95BD-11D0-A3EA-00A0C9223196}\{53172480-4791-11D0-A5D6-28DB04C10000} was removed.
+     set: Device was last used with alternate Hardware Configuration (0), setting re-specialize.
+     set: Device SW\{CFD669F1-9BC2-11D0-8299-0000F822FE8A}\{CF1DDA2C-9743-11D0-A3EE-00A0C9223196} will be removed.
+     set: Device SW\{CFD669F1-9BC2-11D0-8299-0000F822FE8A}\{CF1DDA2C-9743-11D0-A3EE-00A0C9223196} was removed.
+     set: Device was last used with alternate Hardware Configuration (0), setting re-specialize.
+     set: Devices removed: 6
+     set: Searching for unused drivers that may be removed from the system.
+     set: Drivers will be removed during this pass.
+     set: Recovery Timestamp: 11/23/2015 01:58:46:0157.
+     set: Preserving oem2.inf because it was imported after the recovery timestamp
+     set: Preserving oem3.inf because it was imported after the recovery timestamp
+     set: Driver packages removed: 0
+     set: Total size on disk: 0
+<<<  Section end 2016/10/05 02:32:47.476
+<<<  [Exit status: SUCCESS]
+
+
+[Boot Session: 2016/10/09 21:42:30.490]
+
+>>>  [Device Installation Restrictions Policy Check]
+>>>  Section start 2016/10/09 21:43:14.962
+<<<  Section end 2016/10/09 21:43:14.976
+<<<  [Exit status: SUCCESS]
+
+
+[Boot Session: 2016/10/09 22:06:29.499]
+
+>>>  [Device Installation Restrictions Policy Check]
+>>>  Section start 2016/10/09 22:07:19.864
+<<<  Section end 2016/10/09 22:07:19.881
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Disable Device Install]
+>>>  Section start 2016/10/09 22:39:33.512
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     ump: DeviceInstall service is not started.
+<<<  Section end 2016/10/09 22:39:33.512
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Stage Driver Updates]
+>>>  Section start 2016/10/09 22:39:33.859
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 41
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_miradisp.inf_31bf3856ad364e35_10.0.10240.16394_none_65e15c6ab1574881\miradisp.inf} 22:39:34.325
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_miradisp.inf_31bf3856ad364e35_10.0.10240.16394_none_65e15c6ab1574881\miradisp.inf} 22:39:34.800
+     inf:           Driver package uses WDF.
+     inf:           Driver package 'miradisp.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:34.800
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:34.800
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:34.800
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_miradisp.inf_31bf3856ad364e35_10.0.10240.16394_none_65e15c6ab1574881\MiraDispKmd.sys' to 'C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_01ce808b39cab47d\MiraDispKmd.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_miradisp.inf_31bf3856ad364e35_10.0.10240.16394_none_65e15c6ab1574881\MiraDisp.dll' to 'C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_01ce808b39cab47d\MiraDisp.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_miradisp.inf_31bf3856ad364e35_10.0.10240.16394_none_65e15c6ab1574881\miradisp.inf' to 'C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_01ce808b39cab47d\miradisp.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_miradisp.inf_31bf3856ad364e35_10.0.10240.16394_none_65e15c6ab1574881\MsMiraDisp.dll' to 'C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_01ce808b39cab47d\MsMiraDisp.dll'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_01ce808b39cab47d\miradisp.inf} 22:39:34.888
+     idb:           Created driver package object 'miradisp.inf_amd64_01ce808b39cab47d' in DRIVERS database node.
+     idb:           Driver INF file object 'miradisp.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'miradisp.inf_amd64_01ce808b39cab47d' with 'miradisp.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:34.888
+     sto:      {DRIVERSTORE IMPORT END} 22:39:34.888
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:34.888
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:34.888
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_hidscanner.inf_31bf3856ad364e35_10.0.10240.16732_none_1347b790e8468683\hidscanner.inf} 22:39:34.888
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_hidscanner.inf_31bf3856ad364e35_10.0.10240.16732_none_1347b790e8468683\hidscanner.inf} 22:39:34.888
+     inf:           Driver package uses WDF.
+     inf:           Driver package 'hidscanner.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:34.888
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:34.888
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:34.904
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_hidscanner.inf_31bf3856ad364e35_10.0.10240.16732_none_1347b790e8468683\hidscanner.dll' to 'C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_a4bdb031f38afa10\hidscanner.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_hidscanner.inf_31bf3856ad364e35_10.0.10240.16732_none_1347b790e8468683\hidscanner.inf' to 'C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_a4bdb031f38afa10\hidscanner.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_a4bdb031f38afa10\hidscanner.inf} 22:39:34.934
+     idb:           Created driver package object 'hidscanner.inf_amd64_a4bdb031f38afa10' in DRIVERS database node.
+     idb:           Driver INF file object 'hidscanner.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'hidscanner.inf_amd64_a4bdb031f38afa10' with 'hidscanner.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:34.950
+     sto:      {DRIVERSTORE IMPORT END} 22:39:34.950
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:34.950
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:34.950
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_xusb22.inf_31bf3856ad364e35_10.0.10240.17113_none_adcb38b4a7fca310\xusb22.inf} 22:39:34.950
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_xusb22.inf_31bf3856ad364e35_10.0.10240.17113_none_adcb38b4a7fca310\xusb22.inf} 22:39:34.950
+     inf:           Driver package 'xusb22.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:34.950
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:34.950
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:34.950
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_xusb22.inf_31bf3856ad364e35_10.0.10240.17113_none_adcb38b4a7fca310\x64\xusb22.sys' to 'C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_74d42d005ba12dd5\x64\xusb22.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_xusb22.inf_31bf3856ad364e35_10.0.10240.17113_none_adcb38b4a7fca310\xusb22.inf' to 'C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_74d42d005ba12dd5\xusb22.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_74d42d005ba12dd5\xusb22.inf} 22:39:35.012
+     idb:           Created driver package object 'xusb22.inf_amd64_74d42d005ba12dd5' in DRIVERS database node.
+     idb:           Driver INF file object 'xusb22.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'xusb22.inf_amd64_74d42d005ba12dd5' with 'xusb22.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:35.012
+     sto:      {DRIVERSTORE IMPORT END} 22:39:35.012
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:35.012
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:35.012
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_acpi.inf_31bf3856ad364e35_10.0.10240.16397_none_2a89249c68b52b02\acpi.inf} 22:39:35.012
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_acpi.inf_31bf3856ad364e35_10.0.10240.16397_none_2a89249c68b52b02\acpi.inf} 22:39:35.012
+     inf:           Driver package 'acpi.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:35.028
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:35.028
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:35.028
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_acpi.inf_31bf3856ad364e35_10.0.10240.16397_none_2a89249c68b52b02\acpi.inf' to 'C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_19a61be22ae9944e\acpi.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_acpi.inf_31bf3856ad364e35_10.0.10240.16397_none_2a89249c68b52b02\acpi.sys' to 'C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_19a61be22ae9944e\acpi.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_19a61be22ae9944e\acpi.inf} 22:39:35.044
+     idb:           Created driver package object 'acpi.inf_amd64_19a61be22ae9944e' in SYSTEM database node.
+     idb:           Driver INF file object 'acpi.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'acpi.inf_amd64_19a61be22ae9944e' with 'acpi.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:35.044
+     sto:      {DRIVERSTORE IMPORT END} 22:39:35.044
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:35.044
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:35.044
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_wfcvsc.inf_31bf3856ad364e35_10.0.10240.17113_none_75ab4e4e05eb00d2\wfcvsc.inf} 22:39:35.044
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_wfcvsc.inf_31bf3856ad364e35_10.0.10240.17113_none_75ab4e4e05eb00d2\wfcvsc.inf} 22:39:35.044
+     inf:           Driver package is fully isolated.
+     inf:           Driver package 'wfcvsc.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:35.059
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:35.059
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:35.059
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wfcvsc.inf_31bf3856ad364e35_10.0.10240.17113_none_75ab4e4e05eb00d2\fcvsc.sys' to 'C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_f146c688c52c6479\fcvsc.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wfcvsc.inf_31bf3856ad364e35_10.0.10240.17113_none_75ab4e4e05eb00d2\wfcvsc.inf' to 'C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_f146c688c52c6479\wfcvsc.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_f146c688c52c6479\wfcvsc.inf} 22:39:35.106
+     idb:           Created driver package object 'wfcvsc.inf_amd64_f146c688c52c6479' in SYSTEM database node.
+     idb:           Driver INF file object 'wfcvsc.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'wfcvsc.inf_amd64_f146c688c52c6479' with 'wfcvsc.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:35.137
+     sto:      {DRIVERSTORE IMPORT END} 22:39:35.137
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:35.137
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:35.137
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_sensorshidclassdriver.inf_31bf3856ad364e35_10.0.10240.16515_none_b200461c595346c5\sensorshidclassdriver.inf} 22:39:35.137
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_sensorshidclassdriver.inf_31bf3856ad364e35_10.0.10240.16515_none_b200461c595346c5\sensorshidclassdriver.inf} 22:39:35.137
+     inf:           Driver package uses WDF.
+     inf:           Driver package 'sensorshidclassdriver.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:35.137
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:35.137
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:35.137
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_sensorshidclassdriver.inf_31bf3856ad364e35_10.0.10240.16515_none_b200461c595346c5\sensorshidclassdriver.inf' to 'C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_57265cb2d2642968\sensorshidclassdriver.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_sensorshidclassdriver.inf_31bf3856ad364e35_10.0.10240.16515_none_b200461c595346c5\SensorsHid.dll' to 'C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_57265cb2d2642968\SensorsHid.dll'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_57265cb2d2642968\sensorshidclassdriver.inf} 22:39:35.168
+     idb:           Created driver package object 'sensorshidclassdriver.inf_amd64_57265cb2d2642968' in DRIVERS database node.
+     idb:           Driver INF file object 'sensorshidclassdriver.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'sensorshidclassdriver.inf_amd64_57265cb2d2642968' with 'sensorshidclassdriver.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:35.168
+     sto:      {DRIVERSTORE IMPORT END} 22:39:35.187
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:35.187
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:35.187
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_bth.inf_31bf3856ad364e35_10.0.10240.16515_none_7a47d7dc563bfea7\bth.inf} 22:39:35.187
+!    inf:      Needed section [PciD3ColdSupported] found in included INF "pci.inf", not referenced from [BthUsb.NT.HW]. Code = 1313, Line = 203
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_bth.inf_31bf3856ad364e35_10.0.10240.16515_none_7a47d7dc563bfea7\bth.inf} 22:39:35.356
+!    inf:           Found legacy AddReg operation using non-relative key (HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\fsquirt.exe). Code = 1305
+!    inf:           Needed section [PciD3ColdSupported] found in included INF "pci.inf", not referenced from [BthUsb.NT.HW]. Code = 1313, Line = 203
+!    inf:           Driver package 'bth.inf' is NOT configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:35.372
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:35.387
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:35.387
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bth.inf_31bf3856ad364e35_10.0.10240.16515_none_7a47d7dc563bfea7\BTHUSB.SYS' to 'C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\BTHUSB.SYS'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bth.inf_31bf3856ad364e35_10.0.10240.16515_none_7a47d7dc563bfea7\BthMini.SYS' to 'C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\BthMini.SYS'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bth.inf_31bf3856ad364e35_10.0.10240.16515_none_7a47d7dc563bfea7\fsquirt.exe' to 'C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\fsquirt.exe'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bth.inf_31bf3856ad364e35_10.0.10240.16515_none_7a47d7dc563bfea7\bthenum.sys' to 'C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\bthenum.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bth.inf_31bf3856ad364e35_10.0.10240.16515_none_7a47d7dc563bfea7\bthport.sys' to 'C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\bthport.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bth.inf_31bf3856ad364e35_10.0.10240.16515_none_7a47d7dc563bfea7\bth.inf' to 'C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\bth.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\bth.inf} 22:39:35.466
+     idb:           Created driver package object 'bth.inf_amd64_97f04f59eaecdf7a' in DRIVERS database node.
+     idb:           Driver INF file object 'bth.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'bth.inf_amd64_97f04f59eaecdf7a' with 'bth.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:35.482
+     sto:      {DRIVERSTORE IMPORT END} 22:39:35.482
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:35.482
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:35.482
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_bthleenum.inf_31bf3856ad364e35_10.0.10240.16766_none_93c33ffcf31d8bb1\bthleenum.inf} 22:39:35.482
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_bthleenum.inf_31bf3856ad364e35_10.0.10240.16766_none_93c33ffcf31d8bb1\bthleenum.inf} 22:39:35.528
+     inf:           Driver package 'bthleenum.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:35.528
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:35.528
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:35.528
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bthleenum.inf_31bf3856ad364e35_10.0.10240.16766_none_93c33ffcf31d8bb1\bthleenum.inf' to 'C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_0dabadc4461923c4\bthleenum.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bthleenum.inf_31bf3856ad364e35_10.0.10240.16766_none_93c33ffcf31d8bb1\BthLEEnum.sys' to 'C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_0dabadc4461923c4\BthLEEnum.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_0dabadc4461923c4\bthleenum.inf} 22:39:35.559
+     idb:           Created driver package object 'bthleenum.inf_amd64_0dabadc4461923c4' in DRIVERS database node.
+     idb:           Driver INF file object 'bthleenum.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'bthleenum.inf_amd64_0dabadc4461923c4' with 'bthleenum.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:35.559
+     sto:      {DRIVERSTORE IMPORT END} 22:39:35.559
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:35.559
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:35.559
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_genericusbfn.inf_31bf3856ad364e35_10.0.10240.17113_none_bd78180b57938b09\genericusbfn.inf} 22:39:35.559
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_genericusbfn.inf_31bf3856ad364e35_10.0.10240.17113_none_bd78180b57938b09\genericusbfn.inf} 22:39:35.574
+     inf:           Driver package 'genericusbfn.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:35.574
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:35.574
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:35.574
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_genericusbfn.inf_31bf3856ad364e35_10.0.10240.17113_none_bd78180b57938b09\genericusbfn.inf' to 'C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_d519ce9ec210da10\genericusbfn.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_genericusbfn.inf_31bf3856ad364e35_10.0.10240.17113_none_bd78180b57938b09\genericusbfn.sys' to 'C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_d519ce9ec210da10\genericusbfn.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_d519ce9ec210da10\genericusbfn.inf} 22:39:35.606
+     idb:           Created driver package object 'genericusbfn.inf_amd64_d519ce9ec210da10' in SYSTEM database node.
+     idb:           Driver INF file object 'genericusbfn.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'genericusbfn.inf_amd64_d519ce9ec210da10' with 'genericusbfn.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:35.606
+     sto:      {DRIVERSTORE IMPORT END} 22:39:35.606
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:35.606
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:35.606
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_usbstor.inf_31bf3856ad364e35_10.0.10240.16732_none_508b2fa9327c50d0\usbstor.inf} 22:39:35.606
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_usbstor.inf_31bf3856ad364e35_10.0.10240.16732_none_508b2fa9327c50d0\usbstor.inf} 22:39:35.621
+     inf:           Driver package 'usbstor.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:35.637
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:35.653
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:35.653
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbstor.inf_31bf3856ad364e35_10.0.10240.16732_none_508b2fa9327c50d0\usbstor.inf' to 'C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_2780d7dc6ecda26e\usbstor.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbstor.inf_31bf3856ad364e35_10.0.10240.16732_none_508b2fa9327c50d0\USBSTOR.SYS' to 'C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_2780d7dc6ecda26e\USBSTOR.SYS'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_2780d7dc6ecda26e\usbstor.inf} 22:39:35.669
+     idb:           Created driver package object 'usbstor.inf_amd64_2780d7dc6ecda26e' in SYSTEM database node.
+     idb:           Driver INF file object 'usbstor.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'usbstor.inf_amd64_2780d7dc6ecda26e' with 'usbstor.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:35.699
+     sto:      {DRIVERSTORE IMPORT END} 22:39:35.715
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:35.715
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:35.715
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.16542_none_c5c529099e38bdd6\usbport.inf} 22:39:35.715
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.16542_none_c5c529099e38bdd6\usbport.inf} 22:39:35.731
+     inf:           Driver package 'usbport.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:35.747
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:35.747
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:35.747
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.16542_none_c5c529099e38bdd6\usbhub.sys' to 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbhub.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.16542_none_c5c529099e38bdd6\usbehci.sys' to 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbehci.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.16542_none_c5c529099e38bdd6\usbport.inf' to 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbport.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.16542_none_c5c529099e38bdd6\usbohci.sys' to 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbohci.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.16542_none_c5c529099e38bdd6\usbuhci.sys' to 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbuhci.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.16542_none_c5c529099e38bdd6\usbport.sys' to 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbport.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.16542_none_c5c529099e38bdd6\usbd.sys' to 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbd.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbport.inf} 22:39:35.825
+     idb:           Created driver package object 'usbport.inf_amd64_4215f546c8e8f9d6' in SYSTEM database node.
+     idb:           Driver INF file object 'usbport.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'usbport.inf_amd64_4215f546c8e8f9d6' with 'usbport.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:35.825
+     sto:      {DRIVERSTORE IMPORT END} 22:39:35.825
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:35.825
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:35.825
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_usbhub3.inf_31bf3856ad364e35_10.0.10240.16603_none_fde4a6eee7af98e3\usbhub3.inf} 22:39:35.840
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_usbhub3.inf_31bf3856ad364e35_10.0.10240.16603_none_fde4a6eee7af98e3\usbhub3.inf} 22:39:35.840
+     inf:           Driver package 'usbhub3.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:35.840
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:35.840
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:35.840
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbhub3.inf_31bf3856ad364e35_10.0.10240.16603_none_fde4a6eee7af98e3\usbhub3.inf' to 'C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_caa57285880769f4\usbhub3.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbhub3.inf_31bf3856ad364e35_10.0.10240.16603_none_fde4a6eee7af98e3\USBHUB3.SYS' to 'C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_caa57285880769f4\USBHUB3.SYS'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_caa57285880769f4\usbhub3.inf} 22:39:35.872
+     idb:           Created driver package object 'usbhub3.inf_amd64_caa57285880769f4' in SYSTEM database node.
+     idb:           Driver INF file object 'usbhub3.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'usbhub3.inf_amd64_caa57285880769f4' with 'usbhub3.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:35.872
+     sto:      {DRIVERSTORE IMPORT END} 22:39:35.872
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:35.872
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:35.872
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_usbxhci.inf_31bf3856ad364e35_10.0.10240.16461_none_28328d049912952d\usbxhci.inf} 22:39:35.872
+!    inf:      Needed section [PciD3ColdSupported] found in included INF "pci.inf", not referenced from [Generic_NoDebug.Install.NT.Hw]. Code = 1313, Line = 102
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_usbxhci.inf_31bf3856ad364e35_10.0.10240.16461_none_28328d049912952d\usbxhci.inf} 22:39:35.887
+!    inf:           Needed section [PciD3ColdSupported] found in included INF "pci.inf", not referenced from [Generic_NoDebug.Install.NT.Hw]. Code = 1313, Line = 102
+     inf:           Driver package 'usbxhci.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:35.903
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:35.903
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:35.903
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbxhci.inf_31bf3856ad364e35_10.0.10240.16461_none_28328d049912952d\usbxhci.inf' to 'C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_7b59c1e1fa52c844\usbxhci.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbxhci.inf_31bf3856ad364e35_10.0.10240.16461_none_28328d049912952d\USBXHCI.SYS' to 'C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_7b59c1e1fa52c844\USBXHCI.SYS'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_7b59c1e1fa52c844\usbxhci.inf} 22:39:35.934
+     idb:           Created driver package object 'usbxhci.inf_amd64_7b59c1e1fa52c844' in SYSTEM database node.
+     idb:           Driver INF file object 'usbxhci.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'usbxhci.inf_amd64_7b59c1e1fa52c844' with 'usbxhci.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:35.951
+     sto:      {DRIVERSTORE IMPORT END} 22:39:35.951
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:35.951
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:35.951
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_sdbus.inf_31bf3856ad364e35_10.0.10240.16515_none_79e5d0646501d8ec\sdbus.inf} 22:39:35.951
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_sdbus.inf_31bf3856ad364e35_10.0.10240.16515_none_79e5d0646501d8ec\sdbus.inf} 22:39:35.967
+     inf:           Driver package 'sdbus.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:35.967
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:35.967
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:35.967
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_sdbus.inf_31bf3856ad364e35_10.0.10240.16515_none_79e5d0646501d8ec\dumpsd.sys' to 'C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_b33128a95ba9fe0b\dumpsd.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_sdbus.inf_31bf3856ad364e35_10.0.10240.16515_none_79e5d0646501d8ec\sdbus.inf' to 'C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_b33128a95ba9fe0b\sdbus.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_sdbus.inf_31bf3856ad364e35_10.0.10240.16515_none_79e5d0646501d8ec\sdbus.sys' to 'C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_b33128a95ba9fe0b\sdbus.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_b33128a95ba9fe0b\sdbus.inf} 22:39:36.043
+     idb:           Created driver package object 'sdbus.inf_amd64_b33128a95ba9fe0b' in SYSTEM database node.
+     idb:           Driver INF file object 'sdbus.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'sdbus.inf_amd64_b33128a95ba9fe0b' with 'sdbus.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:36.075
+     sto:      {DRIVERSTORE IMPORT END} 22:39:36.075
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:36.075
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:36.075
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_mdmbtmdm.inf_31bf3856ad364e35_10.0.10240.16515_none_f5a6e1bb2609bdc5\mdmbtmdm.inf} 22:39:36.092
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_mdmbtmdm.inf_31bf3856ad364e35_10.0.10240.16515_none_f5a6e1bb2609bdc5\mdmbtmdm.inf} 22:39:36.092
+     inf:           Driver package 'mdmbtmdm.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:36.092
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:36.110
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:36.110
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_mdmbtmdm.inf_31bf3856ad364e35_10.0.10240.16515_none_f5a6e1bb2609bdc5\mdmbtmdm.inf' to 'C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_57032036ac5b3f02\mdmbtmdm.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_mdmbtmdm.inf_31bf3856ad364e35_10.0.10240.16515_none_f5a6e1bb2609bdc5\bthmodem.sys' to 'C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_57032036ac5b3f02\bthmodem.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_57032036ac5b3f02\mdmbtmdm.inf} 22:39:36.139
+     idb:           Created driver package object 'mdmbtmdm.inf_amd64_57032036ac5b3f02' in DRIVERS database node.
+     idb:           Driver INF file object 'mdmbtmdm.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'mdmbtmdm.inf_amd64_57032036ac5b3f02' with 'mdmbtmdm.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:36.153
+     sto:      {DRIVERSTORE IMPORT END} 22:39:36.153
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:36.153
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:36.153
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_bthaudhid.inf_31bf3856ad364e35_10.0.10240.17113_none_1beb2dede19186db\bthaudhid.inf} 22:39:36.153
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_bthaudhid.inf_31bf3856ad364e35_10.0.10240.17113_none_1beb2dede19186db\bthaudhid.inf} 22:39:36.184
+     inf:           Driver package 'bthaudhid.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:36.184
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:36.184
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:36.184
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bthaudhid.inf_31bf3856ad364e35_10.0.10240.17113_none_1beb2dede19186db\BthhfHid.sys' to 'C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_aaeb679851734af2\BthhfHid.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bthaudhid.inf_31bf3856ad364e35_10.0.10240.17113_none_1beb2dede19186db\bthaudhid.inf' to 'C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_aaeb679851734af2\bthaudhid.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bthaudhid.inf_31bf3856ad364e35_10.0.10240.17113_none_1beb2dede19186db\BthAvrcpTg.sys' to 'C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_aaeb679851734af2\BthAvrcpTg.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_aaeb679851734af2\bthaudhid.inf} 22:39:36.215
+     idb:           Created driver package object 'bthaudhid.inf_amd64_aaeb679851734af2' in SYSTEM database node.
+     idb:           Driver INF file object 'bthaudhid.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'bthaudhid.inf_amd64_aaeb679851734af2' with 'bthaudhid.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:36.215
+     sto:      {DRIVERSTORE IMPORT END} 22:39:36.215
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:36.215
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:36.215
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_bthhfenum.inf_31bf3856ad364e35_10.0.10240.16412_none_b2ef11ef014f9a50\bthhfenum.inf} 22:39:36.215
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_bthhfenum.inf_31bf3856ad364e35_10.0.10240.16412_none_b2ef11ef014f9a50\bthhfenum.inf} 22:39:36.232
+!    inf:           Found legacy AddReg operation using non-relative key (HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SvcHost). Code = 1305
+!    inf:           Driver package 'bthhfenum.inf' is NOT configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:36.232
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:36.232
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:36.232
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bthhfenum.inf_31bf3856ad364e35_10.0.10240.16412_none_b2ef11ef014f9a50\BthHFSrv.dll' to 'C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_06170919fa54ed29\BthHFSrv.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bthhfenum.inf_31bf3856ad364e35_10.0.10240.16412_none_b2ef11ef014f9a50\bthhfenum.inf' to 'C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_06170919fa54ed29\bthhfenum.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bthhfenum.inf_31bf3856ad364e35_10.0.10240.16412_none_b2ef11ef014f9a50\bthhfenum.sys' to 'C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_06170919fa54ed29\bthhfenum.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_06170919fa54ed29\bthhfenum.inf} 22:39:36.262
+     idb:           Created driver package object 'bthhfenum.inf_amd64_06170919fa54ed29' in SYSTEM database node.
+     idb:           Driver INF file object 'bthhfenum.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'bthhfenum.inf_amd64_06170919fa54ed29' with 'bthhfenum.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:36.262
+     sto:      {DRIVERSTORE IMPORT END} 22:39:36.262
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:36.262
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:36.262
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_wudfusbcciddriver.inf_31bf3856ad364e35_10.0.10240.16942_none_6a807a679c5c43fe\wudfusbcciddriver.inf} 22:39:36.262
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_wudfusbcciddriver.inf_31bf3856ad364e35_10.0.10240.16942_none_6a807a679c5c43fe\wudfusbcciddriver.inf} 22:39:36.325
+!    inf:           Found legacy AddReg operation using non-relative key (HKLM\Software\Microsoft\Cryptography\Calais\Readers). Code = 1305
+!    inf:           Driver package 'wudfusbcciddriver.inf' is NOT configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:36.325
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:36.325
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:36.325
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wudfusbcciddriver.inf_31bf3856ad364e35_10.0.10240.16942_none_6a807a679c5c43fe\WUDFUsbccidDriver.dll' to 'C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_dcc0445e956fcf69\WUDFUsbccidDriver.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wudfusbcciddriver.inf_31bf3856ad364e35_10.0.10240.16942_none_6a807a679c5c43fe\wudfusbcciddriver.inf' to 'C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_dcc0445e956fcf69\wudfusbcciddriver.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_dcc0445e956fcf69\wudfusbcciddriver.inf} 22:39:36.356
+     idb:           Created driver package object 'wudfusbcciddriver.inf_amd64_dcc0445e956fcf69' in DRIVERS database node.
+     idb:           Driver INF file object 'wudfusbcciddriver.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'wudfusbcciddriver.inf_amd64_dcc0445e956fcf69' with 'wudfusbcciddriver.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:36.372
+     sto:      {DRIVERSTORE IMPORT END} 22:39:36.372
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:36.372
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:36.372
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_hdaudbus.inf_31bf3856ad364e35_10.0.10240.17113_none_7f15d1a2213da442\hdaudbus.inf} 22:39:36.372
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_hdaudbus.inf_31bf3856ad364e35_10.0.10240.17113_none_7f15d1a2213da442\hdaudbus.inf} 22:39:36.419
+     inf:           Driver package 'hdaudbus.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:36.434
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:36.434
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:36.434
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_hdaudbus.inf_31bf3856ad364e35_10.0.10240.17113_none_7f15d1a2213da442\hdaudbus.inf' to 'C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_3a98a84dd82f9b0a\hdaudbus.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_hdaudbus.inf_31bf3856ad364e35_10.0.10240.17113_none_7f15d1a2213da442\hdaudbus.sys' to 'C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_3a98a84dd82f9b0a\hdaudbus.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_3a98a84dd82f9b0a\hdaudbus.inf} 22:39:36.450
+     idb:           Created driver package object 'hdaudbus.inf_amd64_3a98a84dd82f9b0a' in SYSTEM database node.
+     idb:           Driver INF file object 'hdaudbus.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'hdaudbus.inf_amd64_3a98a84dd82f9b0a' with 'hdaudbus.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:36.450
+     sto:      {DRIVERSTORE IMPORT END} 22:39:36.450
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:36.450
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:36.450
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_wdmaudio.inf_31bf3856ad364e35_10.0.10240.16644_none_686b26bfb4cfd8e6\wdmaudio.inf} 22:39:36.450
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_wdmaudio.inf_31bf3856ad364e35_10.0.10240.16644_none_686b26bfb4cfd8e6\wdmaudio.inf} 22:39:36.466
+     inf:           Driver package 'wdmaudio.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:36.466
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:36.466
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:36.466
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wdmaudio.inf_31bf3856ad364e35_10.0.10240.16644_none_686b26bfb4cfd8e6\drmkaud.sys' to 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\drmkaud.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wdmaudio.inf_31bf3856ad364e35_10.0.10240.16644_none_686b26bfb4cfd8e6\SysFxUI.dll' to 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\SysFxUI.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wdmaudio.inf_31bf3856ad364e35_10.0.10240.16644_none_686b26bfb4cfd8e6\WMALFXGFXDSP.dll' to 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\WMALFXGFXDSP.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wdmaudio.inf_31bf3856ad364e35_10.0.10240.16644_none_686b26bfb4cfd8e6\portcls.sys' to 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\portcls.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wdmaudio.inf_31bf3856ad364e35_10.0.10240.16644_none_686b26bfb4cfd8e6\MsApoFxProxy.dll' to 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\MsApoFxProxy.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wdmaudio.inf_31bf3856ad364e35_10.0.10240.16644_none_686b26bfb4cfd8e6\wdmaudio.inf' to 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\wdmaudio.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wdmaudio.inf_31bf3856ad364e35_10.0.10240.16644_none_686b26bfb4cfd8e6\drmk.sys' to 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\drmk.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\wdmaudio.inf} 22:39:36.559
+     idb:           Created driver package object 'wdmaudio.inf_amd64_58b3142a36627a91' in DRIVERS database node.
+     idb:           Driver INF file object 'wdmaudio.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'wdmaudio.inf_amd64_58b3142a36627a91' with 'wdmaudio.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:36.559
+     sto:      {DRIVERSTORE IMPORT END} 22:39:36.559
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:36.559
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:36.575
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_hdaudio.inf_31bf3856ad364e35_10.0.10240.17113_none_1d54749002268c94\hdaudio.inf} 22:39:36.575
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_hdaudio.inf_31bf3856ad364e35_10.0.10240.17113_none_1d54749002268c94\hdaudio.inf} 22:39:36.638
+     inf:           Driver package 'hdaudio.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:36.672
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:36.672
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:36.672
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_hdaudio.inf_31bf3856ad364e35_10.0.10240.17113_none_1d54749002268c94\hdaudio.inf' to 'C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_9b7a5db27f6d6cbd\hdaudio.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_hdaudio.inf_31bf3856ad364e35_10.0.10240.17113_none_1d54749002268c94\HdAudio.sys' to 'C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_9b7a5db27f6d6cbd\HdAudio.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_9b7a5db27f6d6cbd\hdaudio.inf} 22:39:36.700
+     idb:           Created driver package object 'hdaudio.inf_amd64_9b7a5db27f6d6cbd' in DRIVERS database node.
+     idb:           Driver INF file object 'hdaudio.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'hdaudio.inf_amd64_9b7a5db27f6d6cbd' with 'hdaudio.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:36.716
+     sto:      {DRIVERSTORE IMPORT END} 22:39:36.716
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:36.716
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:36.716
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_netrtwlane_13.inf_31bf3856ad364e35_10.0.10240.16394_none_c45ee1d3ac882b6b\netrtwlane_13.inf} 22:39:36.716
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_netrtwlane_13.inf_31bf3856ad364e35_10.0.10240.16394_none_c45ee1d3ac882b6b\netrtwlane_13.inf} 22:39:36.794
+     inf:           Driver package 'netrtwlane_13.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:36.824
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:36.824
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:36.824
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_netrtwlane_13.inf_31bf3856ad364e35_10.0.10240.16394_none_c45ee1d3ac882b6b\netrtwlane_13.inf' to 'C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_8e17ee2826ff2b07\netrtwlane_13.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_netrtwlane_13.inf_31bf3856ad364e35_10.0.10240.16394_none_c45ee1d3ac882b6b\rtwlane_13.sys' to 'C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_8e17ee2826ff2b07\rtwlane_13.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_8e17ee2826ff2b07\netrtwlane_13.inf} 22:39:36.856
+     idb:           Created driver package object 'netrtwlane_13.inf_amd64_8e17ee2826ff2b07' in DRIVERS database node.
+     idb:           Driver INF file object 'netrtwlane_13.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'netrtwlane_13.inf_amd64_8e17ee2826ff2b07' with 'netrtwlane_13.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:36.872
+     sto:      {DRIVERSTORE IMPORT END} 22:39:36.872
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:36.872
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:36.872
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_netwmbclass.inf_31bf3856ad364e35_10.0.10240.16392_none_d4f359d5f456fedf\netwmbclass.inf} 22:39:36.872
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_netwmbclass.inf_31bf3856ad364e35_10.0.10240.16392_none_d4f359d5f456fedf\netwmbclass.inf} 22:39:36.903
+     inf:           Driver package 'netwmbclass.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:36.919
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:36.919
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:36.919
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_netwmbclass.inf_31bf3856ad364e35_10.0.10240.16392_none_d4f359d5f456fedf\netwmbclass.inf' to 'C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_ed51114936bfc236\netwmbclass.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_netwmbclass.inf_31bf3856ad364e35_10.0.10240.16392_none_d4f359d5f456fedf\wmbclass.sys' to 'C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_ed51114936bfc236\wmbclass.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_ed51114936bfc236\netwmbclass.inf} 22:39:36.949
+     idb:           Created driver package object 'netwmbclass.inf_amd64_ed51114936bfc236' in DRIVERS database node.
+     idb:           Driver INF file object 'netwmbclass.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'netwmbclass.inf_amd64_ed51114936bfc236' with 'netwmbclass.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:36.949
+     sto:      {DRIVERSTORE IMPORT END} 22:39:36.949
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:36.949
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:36.949
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_netrndis.inf_31bf3856ad364e35_10.0.10240.16732_none_cfc7701ce075d895\netrndis.inf} 22:39:36.949
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_netrndis.inf_31bf3856ad364e35_10.0.10240.16732_none_cfc7701ce075d895\netrndis.inf} 22:39:36.949
+     inf:           Driver package 'netrndis.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:36.967
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:36.967
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:36.967
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_netrndis.inf_31bf3856ad364e35_10.0.10240.16732_none_cfc7701ce075d895\usb8023x.sys' to 'C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_609a0bb012179987\usb8023x.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_netrndis.inf_31bf3856ad364e35_10.0.10240.16732_none_cfc7701ce075d895\rndismp6.sys' to 'C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_609a0bb012179987\rndismp6.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_netrndis.inf_31bf3856ad364e35_10.0.10240.16732_none_cfc7701ce075d895\netrndis.inf' to 'C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_609a0bb012179987\netrndis.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_netrndis.inf_31bf3856ad364e35_10.0.10240.16732_none_cfc7701ce075d895\rndismpx.sys' to 'C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_609a0bb012179987\rndismpx.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_netrndis.inf_31bf3856ad364e35_10.0.10240.16732_none_cfc7701ce075d895\usb80236.sys' to 'C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_609a0bb012179987\usb80236.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_609a0bb012179987\netrndis.inf} 22:39:36.997
+     idb:           Created driver package object 'netrndis.inf_amd64_609a0bb012179987' in DRIVERS database node.
+     idb:           Driver INF file object 'netrndis.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'netrndis.inf_amd64_609a0bb012179987' with 'netrndis.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:37.012
+     sto:      {DRIVERSTORE IMPORT END} 22:39:37.012
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:37.012
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:37.012
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17113_none_5ac3b75f6e9688f5\prnms003.inf} 22:39:37.012
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17113_none_5ac3b75f6e9688f5\prnms003.inf} 22:39:37.012
+     inf:           Driver package 'prnms003.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:37.012
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:37.012
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:37.012
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17113_none_5ac3b75f6e9688f5\Amd64\PrintConfig.dll' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_73e8526b6d7c748c\Amd64\PrintConfig.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17113_none_5ac3b75f6e9688f5\Amd64\unishare.gpd' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_73e8526b6d7c748c\Amd64\unishare.gpd'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17113_none_5ac3b75f6e9688f5\Amd64\unishare-pipelineconfig.xml' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_73e8526b6d7c748c\Amd64\unishare-pipelineconfig.xml'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17113_none_5ac3b75f6e9688f5\prnms003.cat' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_73e8526b6d7c748c\prnms003.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17113_none_5ac3b75f6e9688f5\prnms003.inf' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_73e8526b6d7c748c\prnms003.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_73e8526b6d7c748c\prnms003.inf} 22:39:37.090
+     idb:           Created driver package object 'prnms003.inf_amd64_73e8526b6d7c748c' in DRIVERS database node.
+     idb:           Driver INF file object 'prnms003.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'prnms003.inf_amd64_73e8526b6d7c748c' with 'prnms003.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:37.107
+     sto:      {DRIVERSTORE IMPORT END} 22:39:37.107
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:37.107
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:37.107
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17113_none_5b4cc99487b4c55e\prnms004.inf} 22:39:37.107
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17113_none_5b4cc99487b4c55e\prnms004.inf} 22:39:37.107
+     inf:           Driver package 'prnms004.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:37.107
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:37.107
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:37.107
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17113_none_5b4cc99487b4c55e\prnms004.cat' to 'C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_dc355e772d68650c\prnms004.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17113_none_5b4cc99487b4c55e\prnms004.inf' to 'C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_dc355e772d68650c\prnms004.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17113_none_5b4cc99487b4c55e\Amd64\unisharev4-manifest.ini' to 'C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_dc355e772d68650c\Amd64\unisharev4-manifest.ini'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17113_none_5b4cc99487b4c55e\Amd64\unisharev4.gpd' to 'C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_dc355e772d68650c\Amd64\unisharev4.gpd'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17113_none_5b4cc99487b4c55e\Amd64\unisharev4-pipelineconfig.xml' to 'C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_dc355e772d68650c\Amd64\unisharev4-pipelineconfig.xml'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_dc355e772d68650c\prnms004.inf} 22:39:37.122
+     idb:           Created driver package object 'prnms004.inf_amd64_dc355e772d68650c' in DRIVERS database node.
+     idb:           Driver INF file object 'prnms004.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'prnms004.inf_amd64_dc355e772d68650c' with 'prnms004.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:37.139
+     sto:      {DRIVERSTORE IMPORT END} 22:39:37.139
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:37.139
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:37.139
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\ntprint.inf} 22:39:37.139
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\ntprint.inf} 22:39:37.139
+     inf:           Driver package 'ntprint.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:37.139
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:37.139
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:37.156
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\UNIRES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\UNIRES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\TTFSUB.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\TTFSUB.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\UNIDRV.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\UNIDRV.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\UNIDRV.HLP' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\UNIDRV.HLP'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\PCL4RES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\PCL4RES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\PS_SCHM.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\PS_SCHM.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\MXDWDRV.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\MXDWDRV.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\PSCRIPT.HLP' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\PSCRIPT.HLP'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\PSCRIPT.NTF' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\PSCRIPT.NTF'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\PCL5ERES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\PCL5ERES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\PCL5URES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\PCL5URES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\PSCRIPT5.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\PSCRIPT5.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\PJL.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\PJL.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\STDSCHEM.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\STDSCHEM.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\STDNAMES.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\STDNAMES.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\STDSCHMX.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\STDSCHMX.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\STDDTYPE.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\STDDTYPE.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\PSCRPTFE.NTF' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\PSCRPTFE.NTF'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\MSXPSINC.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\MSXPSINC.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\UNIDRVUI.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\UNIDRVUI.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\MSXPSINC.PPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\MSXPSINC.PPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\PS5UI.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\PS5UI.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\PCLXL.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\PCLXL.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\PCLXL.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\PCLXL.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\P6DISP.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\P6DISP.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\P6FONT.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\P6FONT.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\LOCALE.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\LOCALE.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\Amd64\PJLMON.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64\PJLMON.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\ntprint.cat' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\ntprint.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_42f4dbc255696491\ntprint.inf' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\ntprint.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\ntprint.inf} 22:39:37.544
+     idb:           Created driver package object 'ntprint.inf_amd64_f9aae5bf86267495' in DRIVERS database node.
+     idb:           Driver INF file object 'ntprint.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'ntprint.inf_amd64_f9aae5bf86267495' with 'ntprint.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:37.544
+     sto:      {DRIVERSTORE IMPORT END} 22:39:37.544
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:37.544
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:37.544
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17113_none_4e14625f3f3544d3\ntprint4.inf} 22:39:37.544
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17113_none_4e14625f3f3544d3\ntprint4.inf} 22:39:37.544
+     inf:           Driver package 'ntprint4.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:37.544
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:37.544
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:37.544
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17113_none_4e14625f3f3544d3\Amd64\PWGRRenderFilter.dll' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\Amd64\PWGRRenderFilter.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17113_none_4e14625f3f3544d3\Amd64\MSxpsPS.dll' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\Amd64\MSxpsPS.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17113_none_4e14625f3f3544d3\Amd64\MSxpsPCL6.dll' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\Amd64\MSxpsPCL6.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17113_none_4e14625f3f3544d3\Amd64\V3HostingFilter.dll' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\Amd64\V3HostingFilter.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17113_none_4e14625f3f3544d3\Amd64\PDFRenderFilter.dll' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\Amd64\PDFRenderFilter.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17113_none_4e14625f3f3544d3\Amd64\V3HostingFilter-pipelineconfig.xml' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\Amd64\V3HostingFilter-pipelineconfig.xml'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17113_none_4e14625f3f3544d3\ntprint4.cat' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\ntprint4.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17113_none_4e14625f3f3544d3\ntprint4.inf' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\ntprint4.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\ntprint4.inf} 22:39:37.700
+     idb:           Created driver package object 'ntprint4.inf_amd64_34fc089922f9b11d' in DRIVERS database node.
+     idb:           Driver INF file object 'ntprint4.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'ntprint4.inf_amd64_34fc089922f9b11d' with 'ntprint4.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:37.700
+     sto:      {DRIVERSTORE IMPORT END} 22:39:37.700
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:37.700
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:37.700
+     sto: {Stage Driver Package: C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\ntprint.inf} 22:39:37.716
+     inf:      {Query Configurability: C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\ntprint.inf} 22:39:37.716
+     inf:           Driver package 'ntprint.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:37.716
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:37.716
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:37.716
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\PCL5URES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\PCL5URES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\PSCRIPT5.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\PSCRIPT5.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\PJL.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\PJL.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\STDSCHEM.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\STDSCHEM.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\STDNAMES.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\STDNAMES.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\STDSCHMX.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\STDSCHMX.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\STDDTYPE.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\STDDTYPE.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\PSCRPTFE.NTF' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\PSCRPTFE.NTF'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\MSXPSINC.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\MSXPSINC.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\UNIDRVUI.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\UNIDRVUI.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\MSXPSINC.PPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\MSXPSINC.PPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\PS5UI.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\PS5UI.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\PCLXL.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\PCLXL.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\PCLXL.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\PCLXL.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\P6DISP.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\P6DISP.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\P6FONT.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\P6FONT.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\LOCALE.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\LOCALE.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\PJLMON.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\PJLMON.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\UNIRES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\UNIRES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\TTFSUB.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\TTFSUB.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\UNIDRV.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\UNIDRV.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\UNIDRV.HLP' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\UNIDRV.HLP'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\PCL4RES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\PCL4RES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\PS_SCHM.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\PS_SCHM.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\MXDWDRV.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\MXDWDRV.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\PSCRIPT.HLP' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\PSCRIPT.HLP'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\PSCRIPT.NTF' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\PSCRIPT.NTF'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\I386\PCL5ERES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386\PCL5ERES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\ntprint.cat' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\ntprint.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17113_none_e6d6403e9d0bf35b\ntprint.inf' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\ntprint.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\ntprint.inf} 22:39:38.247
+     idb:           Created driver package object 'ntprint.inf_x86_f9aae5bf86267495' in DRIVERS database node.
+     idb:           Driver INF file object 'ntprint.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'ntprint.inf_x86_f9aae5bf86267495' with 'ntprint.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:38.263
+     sto:      {DRIVERSTORE IMPORT END} 22:39:38.263
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:38.263
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:38.263
+     sto: {Stage Driver Package: C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17113_none_fea51bdbb63917bf\prnms003.inf} 22:39:38.263
+     inf:      {Query Configurability: C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17113_none_fea51bdbb63917bf\prnms003.inf} 22:39:38.263
+     inf:           Driver package is fully isolated.
+     inf:           Driver package 'prnms003.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:38.263
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:38.263
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:38.280
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17113_none_fea51bdbb63917bf\prnms003.cat' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_157f2e5194701963\prnms003.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17113_none_fea51bdbb63917bf\prnms003.inf' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_157f2e5194701963\prnms003.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17113_none_fea51bdbb63917bf\I386\unishare.gpd' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_157f2e5194701963\I386\unishare.gpd'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17113_none_fea51bdbb63917bf\I386\unishare-pipelineconfig.xml' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_157f2e5194701963\I386\unishare-pipelineconfig.xml'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17113_none_fea51bdbb63917bf\I386\PrintConfig.dll' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_157f2e5194701963\I386\PrintConfig.dll'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_157f2e5194701963\prnms003.inf} 22:39:38.357
+     idb:           Created driver package object 'prnms003.inf_x86_157f2e5194701963' in DRIVERS database node.
+     idb:           Driver INF file object 'prnms003.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'prnms003.inf_x86_157f2e5194701963' with 'prnms003.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:38.357
+     sto:      {DRIVERSTORE IMPORT END} 22:39:38.357
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:38.357
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:38.357
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_ucmucsi.inf_31bf3856ad364e35_10.0.10240.16389_none_172d148ed918ff15\ucmucsi.inf} 22:39:38.357
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_ucmucsi.inf_31bf3856ad364e35_10.0.10240.16389_none_172d148ed918ff15\ucmucsi.inf} 22:39:38.357
+     inf:           Driver package 'ucmucsi.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:38.372
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:38.372
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:38.372
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ucmucsi.inf_31bf3856ad364e35_10.0.10240.16389_none_172d148ed918ff15\ucmucsi.inf' to 'C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_86bd71749200d4fb\ucmucsi.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ucmucsi.inf_31bf3856ad364e35_10.0.10240.16389_none_172d148ed918ff15\UcmUcsi.sys' to 'C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_86bd71749200d4fb\UcmUcsi.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_86bd71749200d4fb\ucmucsi.inf} 22:39:38.403
+     idb:           Created driver package object 'ucmucsi.inf_amd64_86bd71749200d4fb' in SYSTEM database node.
+     idb:           Driver INF file object 'ucmucsi.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'ucmucsi.inf_amd64_86bd71749200d4fb' with 'ucmucsi.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:38.403
+     sto:      {DRIVERSTORE IMPORT END} 22:39:38.403
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:38.403
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:38.403
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_pci.inf_31bf3856ad364e35_10.0.10240.16942_none_11ad952af51946e9\pci.inf} 22:39:38.403
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_pci.inf_31bf3856ad364e35_10.0.10240.16942_none_11ad952af51946e9\pci.inf} 22:39:38.403
+     inf:           Driver package 'pci.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:38.420
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:38.420
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:38.420
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_pci.inf_31bf3856ad364e35_10.0.10240.16942_none_11ad952af51946e9\pci.inf' to 'C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_61ccd5db98b3abf1\pci.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_pci.inf_31bf3856ad364e35_10.0.10240.16942_none_11ad952af51946e9\pci.sys' to 'C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_61ccd5db98b3abf1\pci.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_61ccd5db98b3abf1\pci.inf} 22:39:38.434
+     idb:           Created driver package object 'pci.inf_amd64_61ccd5db98b3abf1' in SYSTEM database node.
+     idb:           Driver INF file object 'pci.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'pci.inf_amd64_61ccd5db98b3abf1' with 'pci.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:38.452
+     sto:      {DRIVERSTORE IMPORT END} 22:39:38.452
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:38.452
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:38.452
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_usbser.inf_31bf3856ad364e35_10.0.10240.16732_none_0a9642fe457725ba\usbser.inf} 22:39:38.452
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_usbser.inf_31bf3856ad364e35_10.0.10240.16732_none_0a9642fe457725ba\usbser.inf} 22:39:38.452
+     inf:           Driver package 'usbser.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:38.452
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:38.452
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:38.452
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbser.inf_31bf3856ad364e35_10.0.10240.16732_none_0a9642fe457725ba\usbser.inf' to 'C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_5de2576d6f02918e\usbser.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbser.inf_31bf3856ad364e35_10.0.10240.16732_none_0a9642fe457725ba\usbser.sys' to 'C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_5de2576d6f02918e\usbser.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_5de2576d6f02918e\usbser.inf} 22:39:38.496
+     idb:           Created driver package object 'usbser.inf_amd64_5de2576d6f02918e' in SYSTEM database node.
+     idb:           Driver INF file object 'usbser.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'usbser.inf_amd64_5de2576d6f02918e' with 'usbser.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:38.496
+     sto:      {DRIVERSTORE IMPORT END} 22:39:38.496
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:38.496
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:38.496
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_stornvme.inf_31bf3856ad364e35_10.0.10240.16431_none_b94d338f8f0910e2\stornvme.inf} 22:39:38.496
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_stornvme.inf_31bf3856ad364e35_10.0.10240.16431_none_b94d338f8f0910e2\stornvme.inf} 22:39:38.496
+     inf:           Driver package 'stornvme.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:38.516
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:38.516
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:38.516
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_stornvme.inf_31bf3856ad364e35_10.0.10240.16431_none_b94d338f8f0910e2\stornvme.inf' to 'C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_5ffb10fc0bbc4ac0\stornvme.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_stornvme.inf_31bf3856ad364e35_10.0.10240.16431_none_b94d338f8f0910e2\stornvme.sys' to 'C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_5ffb10fc0bbc4ac0\stornvme.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_5ffb10fc0bbc4ac0\stornvme.inf} 22:39:38.530
+     idb:           Created driver package object 'stornvme.inf_amd64_5ffb10fc0bbc4ac0' in SYSTEM database node.
+     idb:           Driver INF file object 'stornvme.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'stornvme.inf_amd64_5ffb10fc0bbc4ac0' with 'stornvme.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:38.530
+     sto:      {DRIVERSTORE IMPORT END} 22:39:38.530
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:38.530
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:38.530
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_msports.inf_31bf3856ad364e35_10.0.10240.16732_none_009c91a4530779c0\msports.inf} 22:39:38.547
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_msports.inf_31bf3856ad364e35_10.0.10240.16732_none_009c91a4530779c0\msports.inf} 22:39:38.547
+!    inf:           Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 128
+!    inf:           Found legacy LogConfig operation. Code = 1301
+!    inf:           Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 133
+!    inf:           Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 220
+!    inf:           Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 248
+!    inf:           Driver package 'msports.inf' is NOT configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:38.547
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:38.563
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:38.563
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_msports.inf_31bf3856ad364e35_10.0.10240.16732_none_009c91a4530779c0\serial.sys' to 'C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\serial.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_msports.inf_31bf3856ad364e35_10.0.10240.16732_none_009c91a4530779c0\msports.inf' to 'C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\msports.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_msports.inf_31bf3856ad364e35_10.0.10240.16732_none_009c91a4530779c0\serenum.sys' to 'C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\serenum.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_msports.inf_31bf3856ad364e35_10.0.10240.16732_none_009c91a4530779c0\parport.sys' to 'C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\parport.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\msports.inf} 22:39:38.747
+     idb:           Created driver package object 'msports.inf_amd64_46e9747fe38474e5' in SYSTEM database node.
+     idb:           Driver INF file object 'msports.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'msports.inf_amd64_46e9747fe38474e5' with 'msports.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:38.778
+     sto:      {DRIVERSTORE IMPORT END} 22:39:38.796
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:38.796
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:38.796
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_buttonconverter.inf_31bf3856ad364e35_10.0.10240.16515_none_2e186184227fb405\buttonconverter.inf} 22:39:38.796
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_buttonconverter.inf_31bf3856ad364e35_10.0.10240.16515_none_2e186184227fb405\buttonconverter.inf} 22:39:38.796
+     inf:           Driver package 'buttonconverter.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:38.796
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:38.796
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:38.796
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_buttonconverter.inf_31bf3856ad364e35_10.0.10240.16515_none_2e186184227fb405\buttonconverter.sys' to 'C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_b210406b0d8c4695\buttonconverter.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_buttonconverter.inf_31bf3856ad364e35_10.0.10240.16515_none_2e186184227fb405\buttonconverter.inf' to 'C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_b210406b0d8c4695\buttonconverter.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_b210406b0d8c4695\buttonconverter.inf} 22:39:38.824
+     idb:           Created driver package object 'buttonconverter.inf_amd64_b210406b0d8c4695' in SYSTEM database node.
+     idb:           Driver INF file object 'buttonconverter.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'buttonconverter.inf_amd64_b210406b0d8c4695' with 'buttonconverter.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:38.844
+     sto:      {DRIVERSTORE IMPORT END} 22:39:38.844
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:38.844
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:38.844
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_mrvlpcie8897.inf_31bf3856ad364e35_10.0.10240.16515_none_3eb55dfb31919bf1\mrvlpcie8897.inf} 22:39:38.844
+!    sto:      Driver package already imported as 'mrvlpcie8897.inf' (C:\Windows\System32\DriverStore\FileRepository\mrvlpcie8897.inf_amd64_f68a8d902ea4d964\mrvlpcie8897.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:38.844
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_vhdmp.inf_31bf3856ad364e35_10.0.10240.17113_none_ae849d286453d0b3\vhdmp.inf} 22:39:38.844
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_vhdmp.inf_31bf3856ad364e35_10.0.10240.17113_none_ae849d286453d0b3\vhdmp.inf} 22:39:38.844
+     inf:           Driver package 'vhdmp.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:38.844
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:38.844
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:38.856
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_vhdmp.inf_31bf3856ad364e35_10.0.10240.17113_none_ae849d286453d0b3\vhdmp.inf' to 'C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_b486fbf51614c321\vhdmp.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_vhdmp.inf_31bf3856ad364e35_10.0.10240.17113_none_ae849d286453d0b3\vhdmp.sys' to 'C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_b486fbf51614c321\vhdmp.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_b486fbf51614c321\vhdmp.inf} 22:39:38.871
+     idb:           Created driver package object 'vhdmp.inf_amd64_b486fbf51614c321' in SYSTEM database node.
+     idb:           Driver INF file object 'vhdmp.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'vhdmp.inf_amd64_b486fbf51614c321' with 'vhdmp.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:38.888
+     sto:      {DRIVERSTORE IMPORT END} 22:39:38.888
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:38.888
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:38.888
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_msgpiowin32.inf_31bf3856ad364e35_10.0.10240.16425_none_275c9c62bee34e13\msgpiowin32.inf} 22:39:38.888
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_msgpiowin32.inf_31bf3856ad364e35_10.0.10240.16425_none_275c9c62bee34e13\msgpiowin32.inf} 22:39:38.888
+     inf:           Driver package 'msgpiowin32.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:38.888
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:38.888
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:38.888
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_msgpiowin32.inf_31bf3856ad364e35_10.0.10240.16425_none_275c9c62bee34e13\msgpiowin32.inf' to 'C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_4563c8367012234f\msgpiowin32.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_msgpiowin32.inf_31bf3856ad364e35_10.0.10240.16425_none_275c9c62bee34e13\msgpiowin32.sys' to 'C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_4563c8367012234f\msgpiowin32.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_4563c8367012234f\msgpiowin32.inf} 22:39:38.919
+     idb:           Created driver package object 'msgpiowin32.inf_amd64_4563c8367012234f' in SYSTEM database node.
+     idb:           Driver INF file object 'msgpiowin32.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'msgpiowin32.inf_amd64_4563c8367012234f' with 'msgpiowin32.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:38.919
+     sto:      {DRIVERSTORE IMPORT END} 22:39:38.919
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:38.919
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:38.919
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_wpdmtp.inf_31bf3856ad364e35_10.0.10240.16431_none_279c23d2215c89a2\wpdmtp.inf} 22:39:38.919
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_wpdmtp.inf_31bf3856ad364e35_10.0.10240.16431_none_279c23d2215c89a2\wpdmtp.inf} 22:39:38.936
+!    inf:           Legacy directive 'RegisterDlls' will be ignored. Code = 2222, Line = 109
+!    inf:           Found legacy RegisterDlls operation. Code = 1301
+!    inf:           Legacy directive 'RegisterDlls' will be ignored. Code = 2222, Line = 190
+!    inf:           Legacy directive 'RegisterDlls' will be ignored. Code = 2222, Line = 217
+!    inf:           Driver package 'wpdmtp.inf' is NOT configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:38.936
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:38.936
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:38.936
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wpdmtp.inf_31bf3856ad364e35_10.0.10240.16431_none_279c23d2215c89a2\WpdMtp.dll' to 'C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\WpdMtp.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wpdmtp.inf_31bf3856ad364e35_10.0.10240.16431_none_279c23d2215c89a2\wpdmtp.inf' to 'C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\wpdmtp.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wpdmtp.inf_31bf3856ad364e35_10.0.10240.16431_none_279c23d2215c89a2\WpdMtpbt.dll' to 'C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\WpdMtpbt.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wpdmtp.inf_31bf3856ad364e35_10.0.10240.16431_none_279c23d2215c89a2\WpdMtpDr.dll' to 'C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\WpdMtpDr.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wpdmtp.inf_31bf3856ad364e35_10.0.10240.16431_none_279c23d2215c89a2\WpdMtpIP.dll' to 'C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\WpdMtpIP.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wpdmtp.inf_31bf3856ad364e35_10.0.10240.16431_none_279c23d2215c89a2\WpdMtpUS.dll' to 'C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\WpdMtpUS.dll'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\wpdmtp.inf} 22:39:38.996
+     idb:           Created driver package object 'wpdmtp.inf_amd64_5bffa673ab8cb4d4' in DRIVERS database node.
+     idb:           Driver INF file object 'wpdmtp.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'wpdmtp.inf_amd64_5bffa673ab8cb4d4' with 'wpdmtp.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:38.996
+     sto:      {DRIVERSTORE IMPORT END} 22:39:39.016
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:39.016
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:39.016
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_tsusbhub.inf_31bf3856ad364e35_10.0.10240.16732_none_11f5843010008a70\tsusbhub.inf} 22:39:39.016
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_tsusbhub.inf_31bf3856ad364e35_10.0.10240.16732_none_11f5843010008a70\tsusbhub.inf} 22:39:39.016
+     inf:           Driver package uses WDF.
+     inf:           Driver package 'tsusbhub.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:39:39.016
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:39:39.016
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:39:39.016
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_tsusbhub.inf_31bf3856ad364e35_10.0.10240.16732_none_11f5843010008a70\tsusbhub.inf' to 'C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_b01c6baade1c797a\tsusbhub.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_tsusbhub.inf_31bf3856ad364e35_10.0.10240.16732_none_11f5843010008a70\tsusbhub.sys' to 'C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_b01c6baade1c797a\tsusbhub.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_b01c6baade1c797a\tsusbhub.inf} 22:39:39.044
+     idb:           Created driver package object 'tsusbhub.inf_amd64_b01c6baade1c797a' in SYSTEM database node.
+     idb:           Driver INF file object 'tsusbhub.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'tsusbhub.inf_amd64_b01c6baade1c797a' with 'tsusbhub.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:39:39.044
+     sto:      {DRIVERSTORE IMPORT END} 22:39:39.044
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:39:39.060
+     sto: {Stage Driver Package: exit(0x00000000)} 22:39:39.060
+<<<  Section end 2016/10/09 22:39:39.060
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Install Driver Updates]
+>>>  Section start 2016/10/09 22:39:39.060
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Transaction        = CbsDriversAndPrimitives
+     sto: Driver Updates     = 41
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_01ce808b39cab47d\miradisp.inf} 22:39:39.309
+     sto:      Driver Package = miradisp.inf_amd64_01ce808b39cab47d
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_01ce808b39cab47d\miradisp.inf} 22:39:39.309
+     idb:           Changing active driver package from 'miradisp.inf_amd64_1ae5c465b296b702' to 'miradisp.inf_amd64_01ce808b39cab47d'.
+     cpy:           Unpublished 'miradisp.inf'.
+     idb:           Deindexed 3 driver files for 'miradisp.inf_amd64_1ae5c465b296b702'.
+     idb:           Deindexed 2 device IDs for 'miradisp.inf_amd64_1ae5c465b296b702'.
+     cpy:           Published 'miradisp.inf_amd64_01ce808b39cab47d\miradisp.inf' to 'miradisp.inf'.
+     idb:           Indexed 3 driver files for 'miradisp.inf_amd64_01ce808b39cab47d'.
+     idb:           Indexed 2 device IDs for 'miradisp.inf_amd64_01ce808b39cab47d'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:39.435
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:39.435
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_a4bdb031f38afa10\hidscanner.inf} 22:39:39.435
+     sto:      Driver Package = hidscanner.inf_amd64_a4bdb031f38afa10
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_a4bdb031f38afa10\hidscanner.inf} 22:39:39.435
+     idb:           Changing active driver package from 'hidscanner.inf_amd64_59c6e34e5bb0339a' to 'hidscanner.inf_amd64_a4bdb031f38afa10'.
+     cpy:           Unpublished 'hidscanner.inf'.
+     idb:           Deindexed 1 driver file for 'hidscanner.inf_amd64_59c6e34e5bb0339a'.
+     idb:           Deindexed 2 device IDs for 'hidscanner.inf_amd64_59c6e34e5bb0339a'.
+     cpy:           Published 'hidscanner.inf_amd64_a4bdb031f38afa10\hidscanner.inf' to 'hidscanner.inf'.
+     idb:           Indexed 1 driver file for 'hidscanner.inf_amd64_a4bdb031f38afa10'.
+     idb:           Indexed 2 device IDs for 'hidscanner.inf_amd64_a4bdb031f38afa10'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:39.544
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:39.544
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_74d42d005ba12dd5\xusb22.inf} 22:39:39.544
+     sto:      Driver Package = xusb22.inf_amd64_74d42d005ba12dd5
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_74d42d005ba12dd5\xusb22.inf} 22:39:39.544
+     idb:           Changing active driver package from 'xusb22.inf_amd64_438b7c551e424b28' to 'xusb22.inf_amd64_74d42d005ba12dd5'.
+     cpy:           Unpublished 'xusb22.inf'.
+     idb:           Deindexed 1 driver file for 'xusb22.inf_amd64_438b7c551e424b28'.
+     idb:           Deindexed 6 device IDs for 'xusb22.inf_amd64_438b7c551e424b28'.
+     cpy:           Published 'xusb22.inf_amd64_74d42d005ba12dd5\xusb22.inf' to 'xusb22.inf'.
+     idb:           Indexed 1 driver file for 'xusb22.inf_amd64_74d42d005ba12dd5'.
+     idb:           Indexed 6 device IDs for 'xusb22.inf_amd64_74d42d005ba12dd5'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:39.621
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:39.621
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_19a61be22ae9944e\acpi.inf} 22:39:39.621
+     sto:      Driver Package = acpi.inf_amd64_19a61be22ae9944e
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_19a61be22ae9944e\acpi.inf} 22:39:39.621
+     idb:           Changing active driver package from 'acpi.inf_amd64_ad65e307b13e6893' to 'acpi.inf_amd64_19a61be22ae9944e'.
+     cpy:           Unpublished 'acpi.inf'.
+     idb:           Deindexed 1 driver file for 'acpi.inf_amd64_ad65e307b13e6893'.
+     idb:           Deindexed 3 device IDs for 'acpi.inf_amd64_ad65e307b13e6893'.
+     cpy:           Published 'acpi.inf_amd64_19a61be22ae9944e\acpi.inf' to 'acpi.inf'.
+     idb:           Indexed 1 driver file for 'acpi.inf_amd64_19a61be22ae9944e'.
+     idb:           Indexed 3 device IDs for 'acpi.inf_amd64_19a61be22ae9944e'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:39.748
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:39.748
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_f146c688c52c6479\wfcvsc.inf} 22:39:39.748
+     sto:      Driver Package = wfcvsc.inf_amd64_f146c688c52c6479
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_f146c688c52c6479\wfcvsc.inf} 22:39:39.748
+     idb:           Changing active driver package from 'wfcvsc.inf_amd64_f049c0f8aa802928' to 'wfcvsc.inf_amd64_f146c688c52c6479'.
+     cpy:           Unpublished 'wfcvsc.inf'.
+     idb:           Deindexed 1 driver file for 'wfcvsc.inf_amd64_f049c0f8aa802928'.
+     idb:           Deindexed 2 device IDs for 'wfcvsc.inf_amd64_f049c0f8aa802928'.
+     cpy:           Published 'wfcvsc.inf_amd64_f146c688c52c6479\wfcvsc.inf' to 'wfcvsc.inf'.
+     idb:           Indexed 1 driver file for 'wfcvsc.inf_amd64_f146c688c52c6479'.
+     idb:           Indexed 2 device IDs for 'wfcvsc.inf_amd64_f146c688c52c6479'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:39.810
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:39.810
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_57265cb2d2642968\sensorshidclassdriver.inf} 22:39:39.810
+     sto:      Driver Package = sensorshidclassdriver.inf_amd64_57265cb2d2642968
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_57265cb2d2642968\sensorshidclassdriver.inf} 22:39:39.810
+     idb:           Changing active driver package from 'sensorshidclassdriver.inf_amd64_63666a8e1afcc522' to 'sensorshidclassdriver.inf_amd64_57265cb2d2642968'.
+     cpy:           Unpublished 'sensorshidclassdriver.inf'.
+     idb:           Deindexed 1 driver file for 'sensorshidclassdriver.inf_amd64_63666a8e1afcc522'.
+     idb:           Deindexed 14 device IDs for 'sensorshidclassdriver.inf_amd64_63666a8e1afcc522'.
+     cpy:           Published 'sensorshidclassdriver.inf_amd64_57265cb2d2642968\sensorshidclassdriver.inf' to 'sensorshidclassdriver.inf'.
+     idb:           Indexed 1 driver file for 'sensorshidclassdriver.inf_amd64_57265cb2d2642968'.
+     idb:           Indexed 14 device IDs for 'sensorshidclassdriver.inf_amd64_57265cb2d2642968'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:39.888
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:39.888
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\bth.inf} 22:39:39.888
+     sto:      Driver Package = bth.inf_amd64_97f04f59eaecdf7a
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\bth.inf} 22:39:39.888
+     idb:           Changing active driver package from 'bth.inf_amd64_6e5d1d4c2e1fa2ec' to 'bth.inf_amd64_97f04f59eaecdf7a'.
+     cpy:           Unpublished 'bth.inf'.
+     idb:           Deindexed 5 driver files for 'bth.inf_amd64_6e5d1d4c2e1fa2ec'.
+     idb:           Deindexed 87 device IDs for 'bth.inf_amd64_6e5d1d4c2e1fa2ec'.
+     cpy:           Published 'bth.inf_amd64_97f04f59eaecdf7a\bth.inf' to 'bth.inf'.
+!    inf:           Needed section [PciD3ColdSupported] found in included INF "pci.inf", not referenced from [BthUsb.NT.HW]. Code = 1313, Line = 203
+     idb:           Indexed 5 driver files for 'bth.inf_amd64_97f04f59eaecdf7a'.
+     idb:           Indexed 87 device IDs for 'bth.inf_amd64_97f04f59eaecdf7a'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:40.046
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:40.046
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_0dabadc4461923c4\bthleenum.inf} 22:39:40.046
+     sto:      Driver Package = bthleenum.inf_amd64_0dabadc4461923c4
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_0dabadc4461923c4\bthleenum.inf} 22:39:40.046
+     idb:           Changing active driver package from 'bthleenum.inf_amd64_91c9f1f9f9c90133' to 'bthleenum.inf_amd64_0dabadc4461923c4'.
+     cpy:           Unpublished 'bthleenum.inf'.
+     idb:           Deindexed 1 driver file for 'bthleenum.inf_amd64_91c9f1f9f9c90133'.
+     idb:           Deindexed 8 device IDs for 'bthleenum.inf_amd64_91c9f1f9f9c90133'.
+     cpy:           Published 'bthleenum.inf_amd64_0dabadc4461923c4\bthleenum.inf' to 'bthleenum.inf'.
+     idb:           Indexed 1 driver file for 'bthleenum.inf_amd64_0dabadc4461923c4'.
+     idb:           Indexed 8 device IDs for 'bthleenum.inf_amd64_0dabadc4461923c4'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:40.092
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:40.092
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_d519ce9ec210da10\genericusbfn.inf} 22:39:40.092
+     sto:      Driver Package = genericusbfn.inf_amd64_d519ce9ec210da10
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_d519ce9ec210da10\genericusbfn.inf} 22:39:40.107
+     idb:           Changing active driver package from 'genericusbfn.inf_amd64_74a699053034b56d' to 'genericusbfn.inf_amd64_d519ce9ec210da10'.
+     cpy:           Unpublished 'genericusbfn.inf'.
+     idb:           Deindexed 1 driver file for 'genericusbfn.inf_amd64_74a699053034b56d'.
+     idb:           Deindexed 6 device IDs for 'genericusbfn.inf_amd64_74a699053034b56d'.
+     cpy:           Published 'genericusbfn.inf_amd64_d519ce9ec210da10\genericusbfn.inf' to 'genericusbfn.inf'.
+     idb:           Indexed 1 driver file for 'genericusbfn.inf_amd64_d519ce9ec210da10'.
+     idb:           Indexed 6 device IDs for 'genericusbfn.inf_amd64_d519ce9ec210da10'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:40.153
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:40.153
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_2780d7dc6ecda26e\usbstor.inf} 22:39:40.153
+     sto:      Driver Package = usbstor.inf_amd64_2780d7dc6ecda26e
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_2780d7dc6ecda26e\usbstor.inf} 22:39:40.153
+     idb:           Changing active driver package from 'usbstor.inf_amd64_8c69d27bb757b62d' to 'usbstor.inf_amd64_2780d7dc6ecda26e'.
+     cpy:           Unpublished 'usbstor.inf'.
+     idb:           Deindexed 1 driver file for 'usbstor.inf_amd64_8c69d27bb757b62d'.
+     idb:           Deindexed 73 device IDs for 'usbstor.inf_amd64_8c69d27bb757b62d'.
+     cpy:           Published 'usbstor.inf_amd64_2780d7dc6ecda26e\usbstor.inf' to 'usbstor.inf'.
+     idb:           Indexed 1 driver file for 'usbstor.inf_amd64_2780d7dc6ecda26e'.
+     idb:           Indexed 73 device IDs for 'usbstor.inf_amd64_2780d7dc6ecda26e'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:40.294
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:40.294
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbport.inf} 22:39:40.294
+     sto:      Driver Package = usbport.inf_amd64_4215f546c8e8f9d6
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbport.inf} 22:39:40.294
+     idb:           Changing active driver package from 'usbport.inf_amd64_1e58ad6583f1ecab' to 'usbport.inf_amd64_4215f546c8e8f9d6'.
+     cpy:           Unpublished 'usbport.inf'.
+     idb:           Deindexed 6 driver files for 'usbport.inf_amd64_1e58ad6583f1ecab'.
+     idb:           Deindexed 155 device IDs for 'usbport.inf_amd64_1e58ad6583f1ecab'.
+     cpy:           Published 'usbport.inf_amd64_4215f546c8e8f9d6\usbport.inf' to 'usbport.inf'.
+     idb:           Indexed 6 driver files for 'usbport.inf_amd64_4215f546c8e8f9d6'.
+     idb:           Indexed 155 device IDs for 'usbport.inf_amd64_4215f546c8e8f9d6'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:40.481
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:40.481
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_caa57285880769f4\usbhub3.inf} 22:39:40.481
+     sto:      Driver Package = usbhub3.inf_amd64_caa57285880769f4
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_caa57285880769f4\usbhub3.inf} 22:39:40.481
+     idb:           Changing active driver package from 'usbhub3.inf_amd64_8c7cb6330f81414a' to 'usbhub3.inf_amd64_caa57285880769f4'.
+     cpy:           Unpublished 'usbhub3.inf'.
+     idb:           Deindexed 1 driver file for 'usbhub3.inf_amd64_8c7cb6330f81414a'.
+     idb:           Deindexed 4 device IDs for 'usbhub3.inf_amd64_8c7cb6330f81414a'.
+     cpy:           Published 'usbhub3.inf_amd64_caa57285880769f4\usbhub3.inf' to 'usbhub3.inf'.
+     idb:           Indexed 1 driver file for 'usbhub3.inf_amd64_caa57285880769f4'.
+     idb:           Indexed 4 device IDs for 'usbhub3.inf_amd64_caa57285880769f4'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:40.590
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:40.590
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_7b59c1e1fa52c844\usbxhci.inf} 22:39:40.590
+     sto:      Driver Package = usbxhci.inf_amd64_7b59c1e1fa52c844
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_7b59c1e1fa52c844\usbxhci.inf} 22:39:40.590
+     idb:           Changing active driver package from 'usbxhci.inf_amd64_57248f1a8744b4fc' to 'usbxhci.inf_amd64_7b59c1e1fa52c844'.
+     cpy:           Unpublished 'usbxhci.inf'.
+!    inf:           Needed section [PciD3ColdSupported] found in included INF "pci.inf", not referenced from [Generic_NoDebug.Install.NT.Hw]. Code = 1313, Line = 102
+     idb:           Deindexed 1 driver file for 'usbxhci.inf_amd64_57248f1a8744b4fc'.
+     idb:           Deindexed 4 device IDs for 'usbxhci.inf_amd64_57248f1a8744b4fc'.
+     cpy:           Published 'usbxhci.inf_amd64_7b59c1e1fa52c844\usbxhci.inf' to 'usbxhci.inf'.
+!    inf:           Needed section [PciD3ColdSupported] found in included INF "pci.inf", not referenced from [Generic_NoDebug.Install.NT.Hw]. Code = 1313, Line = 102
+     idb:           Indexed 1 driver file for 'usbxhci.inf_amd64_7b59c1e1fa52c844'.
+     idb:           Indexed 4 device IDs for 'usbxhci.inf_amd64_7b59c1e1fa52c844'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:40.676
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:40.676
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_b33128a95ba9fe0b\sdbus.inf} 22:39:40.676
+     sto:      Driver Package = sdbus.inf_amd64_b33128a95ba9fe0b
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_b33128a95ba9fe0b\sdbus.inf} 22:39:40.676
+     idb:           Changing active driver package from 'sdbus.inf_amd64_7fb86acc31fcdbad' to 'sdbus.inf_amd64_b33128a95ba9fe0b'.
+     cpy:           Unpublished 'sdbus.inf'.
+     idb:           Deindexed 2 driver files for 'sdbus.inf_amd64_7fb86acc31fcdbad'.
+     idb:           Deindexed 29 device IDs for 'sdbus.inf_amd64_7fb86acc31fcdbad'.
+     cpy:           Published 'sdbus.inf_amd64_b33128a95ba9fe0b\sdbus.inf' to 'sdbus.inf'.
+     idb:           Indexed 2 driver files for 'sdbus.inf_amd64_b33128a95ba9fe0b'.
+     idb:           Indexed 29 device IDs for 'sdbus.inf_amd64_b33128a95ba9fe0b'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:40.778
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:40.778
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_57032036ac5b3f02\mdmbtmdm.inf} 22:39:40.778
+     sto:      Driver Package = mdmbtmdm.inf_amd64_57032036ac5b3f02
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_57032036ac5b3f02\mdmbtmdm.inf} 22:39:40.793
+     idb:           Changing active driver package from 'mdmbtmdm.inf_amd64_a39b901bc01403cc' to 'mdmbtmdm.inf_amd64_57032036ac5b3f02'.
+     cpy:           Unpublished 'mdmbtmdm.inf'.
+     idb:           Deindexed 1 driver file for 'mdmbtmdm.inf_amd64_a39b901bc01403cc'.
+     idb:           Deindexed 4 device IDs for 'mdmbtmdm.inf_amd64_a39b901bc01403cc'.
+     cpy:           Published 'mdmbtmdm.inf_amd64_57032036ac5b3f02\mdmbtmdm.inf' to 'mdmbtmdm.inf'.
+     idb:           Indexed 1 driver file for 'mdmbtmdm.inf_amd64_57032036ac5b3f02'.
+     idb:           Indexed 4 device IDs for 'mdmbtmdm.inf_amd64_57032036ac5b3f02'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:40.934
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:40.934
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_aaeb679851734af2\bthaudhid.inf} 22:39:40.934
+     sto:      Driver Package = bthaudhid.inf_amd64_aaeb679851734af2
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_aaeb679851734af2\bthaudhid.inf} 22:39:40.934
+     idb:           Changing active driver package from 'bthaudhid.inf_amd64_b9a1f939467681b0' to 'bthaudhid.inf_amd64_aaeb679851734af2'.
+     cpy:           Unpublished 'bthaudhid.inf'.
+     idb:           Deindexed 2 driver files for 'bthaudhid.inf_amd64_b9a1f939467681b0'.
+     idb:           Deindexed 4 device IDs for 'bthaudhid.inf_amd64_b9a1f939467681b0'.
+     cpy:           Published 'bthaudhid.inf_amd64_aaeb679851734af2\bthaudhid.inf' to 'bthaudhid.inf'.
+     idb:           Indexed 2 driver files for 'bthaudhid.inf_amd64_aaeb679851734af2'.
+     idb:           Indexed 4 device IDs for 'bthaudhid.inf_amd64_aaeb679851734af2'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:40.982
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:40.982
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_06170919fa54ed29\bthhfenum.inf} 22:39:40.982
+     sto:      Driver Package = bthhfenum.inf_amd64_06170919fa54ed29
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_06170919fa54ed29\bthhfenum.inf} 22:39:40.996
+     idb:           Changing active driver package from 'bthhfenum.inf_amd64_40249d17ba142187' to 'bthhfenum.inf_amd64_06170919fa54ed29'.
+     cpy:           Unpublished 'bthhfenum.inf'.
+     idb:           Deindexed 2 driver files for 'bthhfenum.inf_amd64_40249d17ba142187'.
+     idb:           Deindexed 4 device IDs for 'bthhfenum.inf_amd64_40249d17ba142187'.
+     cpy:           Published 'bthhfenum.inf_amd64_06170919fa54ed29\bthhfenum.inf' to 'bthhfenum.inf'.
+     idb:           Indexed 2 driver files for 'bthhfenum.inf_amd64_06170919fa54ed29'.
+     idb:           Indexed 4 device IDs for 'bthhfenum.inf_amd64_06170919fa54ed29'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:41.060
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:41.060
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_dcc0445e956fcf69\wudfusbcciddriver.inf} 22:39:41.060
+     sto:      Driver Package = wudfusbcciddriver.inf_amd64_dcc0445e956fcf69
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_dcc0445e956fcf69\wudfusbcciddriver.inf} 22:39:41.060
+     idb:           Changing active driver package from 'wudfusbcciddriver.inf_amd64_5c0a61506fb5918d' to 'wudfusbcciddriver.inf_amd64_dcc0445e956fcf69'.
+     cpy:           Unpublished 'wudfusbcciddriver.inf'.
+     idb:           Deindexed 1 driver file for 'wudfusbcciddriver.inf_amd64_5c0a61506fb5918d'.
+     idb:           Deindexed 11 device IDs for 'wudfusbcciddriver.inf_amd64_5c0a61506fb5918d'.
+     cpy:           Published 'wudfusbcciddriver.inf_amd64_dcc0445e956fcf69\wudfusbcciddriver.inf' to 'wudfusbcciddriver.inf'.
+     idb:           Indexed 1 driver file for 'wudfusbcciddriver.inf_amd64_dcc0445e956fcf69'.
+     idb:           Indexed 11 device IDs for 'wudfusbcciddriver.inf_amd64_dcc0445e956fcf69'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:41.216
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:41.216
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_3a98a84dd82f9b0a\hdaudbus.inf} 22:39:41.216
+     sto:      Driver Package = hdaudbus.inf_amd64_3a98a84dd82f9b0a
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_3a98a84dd82f9b0a\hdaudbus.inf} 22:39:41.216
+     idb:           Changing active driver package from 'hdaudbus.inf_amd64_59e464503a2b3653' to 'hdaudbus.inf_amd64_3a98a84dd82f9b0a'.
+     cpy:           Unpublished 'hdaudbus.inf'.
+     idb:           Deindexed 1 driver file for 'hdaudbus.inf_amd64_59e464503a2b3653'.
+     idb:           Deindexed 3 device IDs for 'hdaudbus.inf_amd64_59e464503a2b3653'.
+     cpy:           Published 'hdaudbus.inf_amd64_3a98a84dd82f9b0a\hdaudbus.inf' to 'hdaudbus.inf'.
+     idb:           Indexed 1 driver file for 'hdaudbus.inf_amd64_3a98a84dd82f9b0a'.
+     idb:           Indexed 3 device IDs for 'hdaudbus.inf_amd64_3a98a84dd82f9b0a'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:41.402
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:41.402
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\wdmaudio.inf} 22:39:41.402
+     sto:      Driver Package = wdmaudio.inf_amd64_58b3142a36627a91
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\wdmaudio.inf} 22:39:41.402
+     idb:           Changing active driver package from 'wdmaudio.inf_amd64_256ad046a471df0d' to 'wdmaudio.inf_amd64_58b3142a36627a91'.
+     cpy:           Unpublished 'wdmaudio.inf'.
+     idb:           Deindexed 6 driver files for 'wdmaudio.inf_amd64_256ad046a471df0d'.
+     idb:           Deindexed 3 device IDs for 'wdmaudio.inf_amd64_256ad046a471df0d'.
+     cpy:           Published 'wdmaudio.inf_amd64_58b3142a36627a91\wdmaudio.inf' to 'wdmaudio.inf'.
+     idb:           Indexed 6 driver files for 'wdmaudio.inf_amd64_58b3142a36627a91'.
+     idb:           Indexed 3 device IDs for 'wdmaudio.inf_amd64_58b3142a36627a91'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:41.466
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:41.466
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_9b7a5db27f6d6cbd\hdaudio.inf} 22:39:41.466
+     sto:      Driver Package = hdaudio.inf_amd64_9b7a5db27f6d6cbd
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_9b7a5db27f6d6cbd\hdaudio.inf} 22:39:41.466
+     idb:           Changing active driver package from 'hdaudio.inf_amd64_dab2294dc8af0030' to 'hdaudio.inf_amd64_9b7a5db27f6d6cbd'.
+     cpy:           Unpublished 'hdaudio.inf'.
+     idb:           Deindexed 1 driver file for 'hdaudio.inf_amd64_dab2294dc8af0030'.
+     idb:           Deindexed 2 device IDs for 'hdaudio.inf_amd64_dab2294dc8af0030'.
+     cpy:           Published 'hdaudio.inf_amd64_9b7a5db27f6d6cbd\hdaudio.inf' to 'hdaudio.inf'.
+     idb:           Indexed 1 driver file for 'hdaudio.inf_amd64_9b7a5db27f6d6cbd'.
+     idb:           Indexed 2 device IDs for 'hdaudio.inf_amd64_9b7a5db27f6d6cbd'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:41.592
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:41.592
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_8e17ee2826ff2b07\netrtwlane_13.inf} 22:39:41.592
+     sto:      Driver Package = netrtwlane_13.inf_amd64_8e17ee2826ff2b07
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_8e17ee2826ff2b07\netrtwlane_13.inf} 22:39:41.592
+     idb:           Changing active driver package from 'netrtwlane_13.inf_amd64_08862ceb4cd44db9' to 'netrtwlane_13.inf_amd64_8e17ee2826ff2b07'.
+     cpy:           Unpublished 'netrtwlane_13.inf'.
+     idb:           Deindexed 1 driver file for 'netrtwlane_13.inf_amd64_08862ceb4cd44db9'.
+     idb:           Deindexed 180 device IDs for 'netrtwlane_13.inf_amd64_08862ceb4cd44db9'.
+     cpy:           Published 'netrtwlane_13.inf_amd64_8e17ee2826ff2b07\netrtwlane_13.inf' to 'netrtwlane_13.inf'.
+     idb:           Indexed 1 driver file for 'netrtwlane_13.inf_amd64_8e17ee2826ff2b07'.
+     idb:           Indexed 178 device IDs for 'netrtwlane_13.inf_amd64_8e17ee2826ff2b07'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:41.780
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:41.795
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_ed51114936bfc236\netwmbclass.inf} 22:39:41.795
+     sto:      Driver Package = netwmbclass.inf_amd64_ed51114936bfc236
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_ed51114936bfc236\netwmbclass.inf} 22:39:41.795
+     idb:           Changing active driver package from 'netwmbclass.inf_amd64_828a7d91ae6b1b6a' to 'netwmbclass.inf_amd64_ed51114936bfc236'.
+     cpy:           Unpublished 'netwmbclass.inf'.
+     idb:           Deindexed 1 driver file for 'netwmbclass.inf_amd64_828a7d91ae6b1b6a'.
+     idb:           Deindexed 3 device IDs for 'netwmbclass.inf_amd64_828a7d91ae6b1b6a'.
+     cpy:           Published 'netwmbclass.inf_amd64_ed51114936bfc236\netwmbclass.inf' to 'netwmbclass.inf'.
+     idb:           Indexed 1 driver file for 'netwmbclass.inf_amd64_ed51114936bfc236'.
+     idb:           Indexed 3 device IDs for 'netwmbclass.inf_amd64_ed51114936bfc236'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:41.876
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:41.876
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_609a0bb012179987\netrndis.inf} 22:39:41.876
+     sto:      Driver Package = netrndis.inf_amd64_609a0bb012179987
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_609a0bb012179987\netrndis.inf} 22:39:41.876
+     idb:           Changing active driver package from 'netrndis.inf_amd64_15559e68f1d2f050' to 'netrndis.inf_amd64_609a0bb012179987'.
+     cpy:           Unpublished 'netrndis.inf'.
+     idb:           Deindexed 4 driver files for 'netrndis.inf_amd64_15559e68f1d2f050'.
+     idb:           Deindexed 3 device IDs for 'netrndis.inf_amd64_15559e68f1d2f050'.
+     cpy:           Published 'netrndis.inf_amd64_609a0bb012179987\netrndis.inf' to 'netrndis.inf'.
+     idb:           Indexed 4 driver files for 'netrndis.inf_amd64_609a0bb012179987'.
+     idb:           Indexed 3 device IDs for 'netrndis.inf_amd64_609a0bb012179987'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:41.996
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:41.996
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_73e8526b6d7c748c\prnms003.inf} 22:39:41.996
+     sto:      Driver Package = prnms003.inf_amd64_73e8526b6d7c748c
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_73e8526b6d7c748c\prnms003.inf} 22:39:41.996
+     idb:           Changing active driver package from 'prnms003.inf_amd64_827219ff41f9ea64' to 'prnms003.inf_amd64_73e8526b6d7c748c'.
+     cpy:           Unpublished 'prnms003.inf'.
+     idb:           Deindexed 3 driver files for 'prnms003.inf_amd64_827219ff41f9ea64'.
+     idb:           Deindexed 2 device IDs for 'prnms003.inf_amd64_827219ff41f9ea64'.
+     cpy:           Published 'prnms003.inf_amd64_73e8526b6d7c748c\prnms003.inf' to 'prnms003.inf'.
+     idb:           Indexed 3 driver files for 'prnms003.inf_amd64_73e8526b6d7c748c'.
+     idb:           Indexed 2 device IDs for 'prnms003.inf_amd64_73e8526b6d7c748c'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.074
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.074
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_dc355e772d68650c\prnms004.inf} 22:39:42.074
+     sto:      Driver Package = prnms004.inf_amd64_dc355e772d68650c
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_dc355e772d68650c\prnms004.inf} 22:39:42.074
+     idb:           Changing active driver package from 'prnms004.inf_amd64_8b38d267bd5fdbd9' to 'prnms004.inf_amd64_dc355e772d68650c'.
+     cpy:           Unpublished 'prnms004.inf'.
+     idb:           Deindexed 3 driver files for 'prnms004.inf_amd64_8b38d267bd5fdbd9'.
+     idb:           Deindexed 2 device IDs for 'prnms004.inf_amd64_8b38d267bd5fdbd9'.
+     cpy:           Published 'prnms004.inf_amd64_dc355e772d68650c\prnms004.inf' to 'prnms004.inf'.
+     idb:           Indexed 3 driver files for 'prnms004.inf_amd64_dc355e772d68650c'.
+     idb:           Indexed 2 device IDs for 'prnms004.inf_amd64_dc355e772d68650c'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.106
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.106
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\ntprint.inf} 22:39:42.106
+     sto:      Driver Package = ntprint.inf_amd64_f9aae5bf86267495
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\ntprint.inf} 22:39:42.106
+     idb:           Changing active driver package from 'ntprint.inf_amd64_08e757f7c012ea27' to 'ntprint.inf_amd64_f9aae5bf86267495'.
+     cpy:           Unpublished 'ntprint.inf'.
+     idb:           Deindexed 28 driver files for 'ntprint.inf_amd64_08e757f7c012ea27'.
+     idb:           Deindexed 6 device IDs for 'ntprint.inf_amd64_08e757f7c012ea27'.
+     cpy:           Published 'ntprint.inf_amd64_f9aae5bf86267495\ntprint.inf' to 'ntprint.inf'.
+     idb:           Indexed 28 driver files for 'ntprint.inf_amd64_f9aae5bf86267495'.
+     idb:           Indexed 6 device IDs for 'ntprint.inf_amd64_f9aae5bf86267495'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.172
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.172
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\ntprint4.inf} 22:39:42.172
+     sto:      Driver Package = ntprint4.inf_amd64_34fc089922f9b11d
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\ntprint4.inf} 22:39:42.172
+     idb:           Changing active driver package from 'ntprint4.inf_amd64_7373a688eceb5d01' to 'ntprint4.inf_amd64_34fc089922f9b11d'.
+     cpy:           Unpublished 'ntprint4.inf'.
+     idb:           Deindexed 6 driver files for 'ntprint4.inf_amd64_7373a688eceb5d01'.
+     idb:           Deindexed 2 device IDs for 'ntprint4.inf_amd64_7373a688eceb5d01'.
+     cpy:           Published 'ntprint4.inf_amd64_34fc089922f9b11d\ntprint4.inf' to 'ntprint4.inf'.
+     idb:           Indexed 6 driver files for 'ntprint4.inf_amd64_34fc089922f9b11d'.
+     idb:           Indexed 2 device IDs for 'ntprint4.inf_amd64_34fc089922f9b11d'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.216
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.216
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\ntprint.inf} 22:39:42.216
+     sto:      Driver Package = ntprint.inf_x86_f9aae5bf86267495
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\ntprint.inf} 22:39:42.216
+     idb:           Driver package 'ntprint.inf_amd64_f9aae5bf86267495' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.216
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.216
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_157f2e5194701963\prnms003.inf} 22:39:42.216
+     sto:      Driver Package = prnms003.inf_x86_157f2e5194701963
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_157f2e5194701963\prnms003.inf} 22:39:42.216
+     idb:           Driver package 'prnms003.inf_amd64_73e8526b6d7c748c' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.216
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.216
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_86bd71749200d4fb\ucmucsi.inf} 22:39:42.216
+     sto:      Driver Package = ucmucsi.inf_amd64_86bd71749200d4fb
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_86bd71749200d4fb\ucmucsi.inf} 22:39:42.216
+     idb:           Changing active driver package from 'ucmucsi.inf_amd64_836de75251bf9189' to 'ucmucsi.inf_amd64_86bd71749200d4fb'.
+     cpy:           Unpublished 'ucmucsi.inf'.
+     idb:           Deindexed 1 driver file for 'ucmucsi.inf_amd64_836de75251bf9189'.
+     idb:           Deindexed 3 device IDs for 'ucmucsi.inf_amd64_836de75251bf9189'.
+     cpy:           Published 'ucmucsi.inf_amd64_86bd71749200d4fb\ucmucsi.inf' to 'ucmucsi.inf'.
+     idb:           Indexed 1 driver file for 'ucmucsi.inf_amd64_86bd71749200d4fb'.
+     idb:           Indexed 3 device IDs for 'ucmucsi.inf_amd64_86bd71749200d4fb'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.294
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.294
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_61ccd5db98b3abf1\pci.inf} 22:39:42.294
+     sto:      Driver Package = pci.inf_amd64_61ccd5db98b3abf1
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_61ccd5db98b3abf1\pci.inf} 22:39:42.311
+     idb:           Changing active driver package from 'pci.inf_amd64_e13dd3a79d516ff2' to 'pci.inf_amd64_61ccd5db98b3abf1'.
+     cpy:           Unpublished 'pci.inf'.
+     idb:           Deindexed 1 driver file for 'pci.inf_amd64_e13dd3a79d516ff2'.
+     idb:           Deindexed 9 device IDs for 'pci.inf_amd64_e13dd3a79d516ff2'.
+     cpy:           Published 'pci.inf_amd64_61ccd5db98b3abf1\pci.inf' to 'pci.inf'.
+     idb:           Indexed 1 driver file for 'pci.inf_amd64_61ccd5db98b3abf1'.
+     idb:           Indexed 9 device IDs for 'pci.inf_amd64_61ccd5db98b3abf1'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.374
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.374
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_5de2576d6f02918e\usbser.inf} 22:39:42.374
+     sto:      Driver Package = usbser.inf_amd64_5de2576d6f02918e
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_5de2576d6f02918e\usbser.inf} 22:39:42.374
+     idb:           Changing active driver package from 'usbser.inf_amd64_827db80716f312be' to 'usbser.inf_amd64_5de2576d6f02918e'.
+     cpy:           Unpublished 'usbser.inf'.
+     idb:           Deindexed 1 driver file for 'usbser.inf_amd64_827db80716f312be'.
+     idb:           Deindexed 3 device IDs for 'usbser.inf_amd64_827db80716f312be'.
+     cpy:           Published 'usbser.inf_amd64_5de2576d6f02918e\usbser.inf' to 'usbser.inf'.
+     idb:           Indexed 1 driver file for 'usbser.inf_amd64_5de2576d6f02918e'.
+     idb:           Indexed 3 device IDs for 'usbser.inf_amd64_5de2576d6f02918e'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.418
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.418
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_5ffb10fc0bbc4ac0\stornvme.inf} 22:39:42.418
+     sto:      Driver Package = stornvme.inf_amd64_5ffb10fc0bbc4ac0
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_5ffb10fc0bbc4ac0\stornvme.inf} 22:39:42.418
+     idb:           Changing active driver package from 'stornvme.inf_amd64_701b8d7c698c983a' to 'stornvme.inf_amd64_5ffb10fc0bbc4ac0'.
+     cpy:           Unpublished 'stornvme.inf'.
+     idb:           Deindexed 1 driver file for 'stornvme.inf_amd64_701b8d7c698c983a'.
+     idb:           Deindexed 2 device IDs for 'stornvme.inf_amd64_701b8d7c698c983a'.
+     cpy:           Published 'stornvme.inf_amd64_5ffb10fc0bbc4ac0\stornvme.inf' to 'stornvme.inf'.
+     idb:           Indexed 1 driver file for 'stornvme.inf_amd64_5ffb10fc0bbc4ac0'.
+     idb:           Indexed 2 device IDs for 'stornvme.inf_amd64_5ffb10fc0bbc4ac0'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.451
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.451
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\msports.inf} 22:39:42.451
+     sto:      Driver Package = msports.inf_amd64_46e9747fe38474e5
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\msports.inf} 22:39:42.451
+     idb:           Changing active driver package from 'msports.inf_amd64_db43c0c39a11ad06' to 'msports.inf_amd64_46e9747fe38474e5'.
+     cpy:           Unpublished 'msports.inf'.
+     idb:           Deindexed 3 driver files for 'msports.inf_amd64_db43c0c39a11ad06'.
+!    inf:           Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 128
+!    inf:           Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 133
+!    inf:           Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 220
+!    idb:           Unable to find driver INF match for 'msports.inf' under '*PNP0500'.
+!    idb:           Unable to find driver INF match for 'msports.inf' under '*PNP0501'.
+!    inf:           Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 248
+     idb:           Deindexed 28 device IDs for 'msports.inf_amd64_db43c0c39a11ad06'.
+     cpy:           Published 'msports.inf_amd64_46e9747fe38474e5\msports.inf' to 'msports.inf'.
+     idb:           Indexed 3 driver files for 'msports.inf_amd64_46e9747fe38474e5'.
+!    inf:           Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 128
+!    inf:           Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 133
+!    inf:           Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 220
+!    inf:           Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 248
+     idb:           Indexed 28 device IDs for 'msports.inf_amd64_46e9747fe38474e5'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.560
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.560
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_b210406b0d8c4695\buttonconverter.inf} 22:39:42.560
+     sto:      Driver Package = buttonconverter.inf_amd64_b210406b0d8c4695
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_b210406b0d8c4695\buttonconverter.inf} 22:39:42.560
+     idb:           Changing active driver package from 'buttonconverter.inf_amd64_3e28164cce51d5a9' to 'buttonconverter.inf_amd64_b210406b0d8c4695'.
+     cpy:           Unpublished 'buttonconverter.inf'.
+     idb:           Deindexed 1 driver file for 'buttonconverter.inf_amd64_3e28164cce51d5a9'.
+     idb:           Deindexed 4 device IDs for 'buttonconverter.inf_amd64_3e28164cce51d5a9'.
+     cpy:           Published 'buttonconverter.inf_amd64_b210406b0d8c4695\buttonconverter.inf' to 'buttonconverter.inf'.
+     idb:           Indexed 1 driver file for 'buttonconverter.inf_amd64_b210406b0d8c4695'.
+     idb:           Indexed 4 device IDs for 'buttonconverter.inf_amd64_b210406b0d8c4695'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.624
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.640
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\mrvlpcie8897.inf_amd64_f68a8d902ea4d964\mrvlpcie8897.inf} 22:39:42.640
+     sto:      Driver Package = mrvlpcie8897.inf_amd64_f68a8d902ea4d964
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\mrvlpcie8897.inf_amd64_f68a8d902ea4d964\mrvlpcie8897.inf} 22:39:42.640
+     idb:           Driver package 'mrvlpcie8897.inf_amd64_f68a8d902ea4d964' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.640
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.640
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_b486fbf51614c321\vhdmp.inf} 22:39:42.640
+     sto:      Driver Package = vhdmp.inf_amd64_b486fbf51614c321
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_b486fbf51614c321\vhdmp.inf} 22:39:42.640
+     idb:           Changing active driver package from 'vhdmp.inf_amd64_33db47aeb773aeab' to 'vhdmp.inf_amd64_b486fbf51614c321'.
+     cpy:           Unpublished 'vhdmp.inf'.
+     idb:           Deindexed 1 driver file for 'vhdmp.inf_amd64_33db47aeb773aeab'.
+     idb:           Deindexed 2 device IDs for 'vhdmp.inf_amd64_33db47aeb773aeab'.
+     cpy:           Published 'vhdmp.inf_amd64_b486fbf51614c321\vhdmp.inf' to 'vhdmp.inf'.
+     idb:           Indexed 1 driver file for 'vhdmp.inf_amd64_b486fbf51614c321'.
+     idb:           Indexed 2 device IDs for 'vhdmp.inf_amd64_b486fbf51614c321'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.762
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.762
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_4563c8367012234f\msgpiowin32.inf} 22:39:42.762
+     sto:      Driver Package = msgpiowin32.inf_amd64_4563c8367012234f
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_4563c8367012234f\msgpiowin32.inf} 22:39:42.762
+     idb:           Changing active driver package from 'msgpiowin32.inf_amd64_a183375586623a76' to 'msgpiowin32.inf_amd64_4563c8367012234f'.
+     cpy:           Unpublished 'msgpiowin32.inf'.
+     idb:           Deindexed 1 driver file for 'msgpiowin32.inf_amd64_a183375586623a76'.
+     idb:           Deindexed 5 device IDs for 'msgpiowin32.inf_amd64_a183375586623a76'.
+     cpy:           Published 'msgpiowin32.inf_amd64_4563c8367012234f\msgpiowin32.inf' to 'msgpiowin32.inf'.
+     idb:           Indexed 1 driver file for 'msgpiowin32.inf_amd64_4563c8367012234f'.
+     idb:           Indexed 5 device IDs for 'msgpiowin32.inf_amd64_4563c8367012234f'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.824
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.824
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\wpdmtp.inf} 22:39:42.824
+     sto:      Driver Package = wpdmtp.inf_amd64_5bffa673ab8cb4d4
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\wpdmtp.inf} 22:39:42.824
+     idb:           Changing active driver package from 'wpdmtp.inf_amd64_bc644fccce0afbb3' to 'wpdmtp.inf_amd64_5bffa673ab8cb4d4'.
+     cpy:           Unpublished 'wpdmtp.inf'.
+     idb:           Deindexed 5 driver files for 'wpdmtp.inf_amd64_bc644fccce0afbb3'.
+!    inf:           Legacy directive 'RegisterDlls' will be ignored. Code = 2222, Line = 109
+!    inf:           Legacy directive 'RegisterDlls' will be ignored. Code = 2222, Line = 190
+!    inf:           Legacy directive 'RegisterDlls' will be ignored. Code = 2222, Line = 217
+     idb:           Deindexed 9 device IDs for 'wpdmtp.inf_amd64_bc644fccce0afbb3'.
+     cpy:           Published 'wpdmtp.inf_amd64_5bffa673ab8cb4d4\wpdmtp.inf' to 'wpdmtp.inf'.
+     idb:           Indexed 5 driver files for 'wpdmtp.inf_amd64_5bffa673ab8cb4d4'.
+!    inf:           Legacy directive 'RegisterDlls' will be ignored. Code = 2222, Line = 109
+!    inf:           Legacy directive 'RegisterDlls' will be ignored. Code = 2222, Line = 190
+!    inf:           Legacy directive 'RegisterDlls' will be ignored. Code = 2222, Line = 217
+     idb:           Indexed 9 device IDs for 'wpdmtp.inf_amd64_5bffa673ab8cb4d4'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.903
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.903
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_b01c6baade1c797a\tsusbhub.inf} 22:39:42.903
+     sto:      Driver Package = tsusbhub.inf_amd64_b01c6baade1c797a
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_b01c6baade1c797a\tsusbhub.inf} 22:39:42.903
+     idb:           Changing active driver package from 'tsusbhub.inf_amd64_35185b4c0664e5a3' to 'tsusbhub.inf_amd64_b01c6baade1c797a'.
+     cpy:           Unpublished 'tsusbhub.inf'.
+     idb:           Deindexed 1 driver file for 'tsusbhub.inf_amd64_35185b4c0664e5a3'.
+     idb:           Deindexed 3 device IDs for 'tsusbhub.inf_amd64_35185b4c0664e5a3'.
+     cpy:           Published 'tsusbhub.inf_amd64_b01c6baade1c797a\tsusbhub.inf' to 'tsusbhub.inf'.
+     idb:           Indexed 1 driver file for 'tsusbhub.inf_amd64_b01c6baade1c797a'.
+     idb:           Indexed 3 device IDs for 'tsusbhub.inf_amd64_b01c6baade1c797a'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:39:42.949
+     sto: {Publish Driver Package: exit(0x00000000)} 22:39:42.949
+     sto: {Cache Device Nodes} 22:39:42.949
+     sto:      Cached 59 device nodes. Time = 47ms
+     sto: {Cache Device Nodes: exit(0x00000000)} 22:39:42.996
+     sto: No effective section names for 'miradisp.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_01ce808b39cab47d\miradisp.inf}
+     inf:      Class GUID     = {d421b08e-6d16-41ca-9c4d-9147e5ac98e0}
+     inf:      Class Options  = Configurable
+     idb:      Driver packages:
+     idb:           miradisp.inf_amd64_01ce808b39cab47d (active)
+     idb:           miradisp.inf_amd64_1ae5c465b296b702
+     idb:      {Configure Device Setup Class: {d421b08e-6d16-41ca-9c4d-9147e5ac98e0}}
+     idb:           Updating existing class.
+     idb:           Class Name = Miracast
+     idb:      {Configure Device Setup Class: exit(0x00000000)}
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'hidscanner.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_a4bdb031f38afa10\hidscanner.inf}
+     inf:      Class GUID     = {8c78b96c-9120-4da4-a144-ff427f2cf132}
+     inf:      Class Options  = Configurable
+     idb:      Driver packages:
+     idb:           hidscanner.inf_amd64_a4bdb031f38afa10 (active)
+     idb:           hidscanner.inf_amd64_59c6e34e5bb0339a
+     idb:      {Configure Device Setup Class: {8c78b96c-9120-4da4-a144-ff427f2cf132}}
+     idb:           Updating existing class.
+     idb:           Class Name = BarcodeScanner
+     idb:      {Configure Device Setup Class: exit(0x00000000)}
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'xusb22.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_74d42d005ba12dd5\xusb22.inf}
+     inf:      Class GUID     = {d61ca365-5af4-4486-998b-9db4734c6ca3}
+     inf:      Class Options  = Configurable
+     idb:      Driver packages:
+     idb:           xusb22.inf_amd64_74d42d005ba12dd5 (active)
+     idb:           xusb22.inf_amd64_438b7c551e424b28
+     idb:      {Configure Device Setup Class: {d61ca365-5af4-4486-998b-9db4734c6ca3}}
+     idb:           Updating existing class.
+     idb:           Class Name = XnaComposite
+     idb:      {Configure Device Setup Class: exit(0x00000000)}
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Devices using 'acpi.inf':
+     sto:      ACPI_HAL\PNP0C08\0 -> *PNP0C08 [ACPI_Inst.NT]
+     sto: Installed section names:
+     sto:      ACPI_Inst.NT
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_19a61be22ae9944e\acpi.inf}
+     inf:      Class GUID     = {4d36e97d-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           acpi.inf_amd64_19a61be22ae9944e (active)
+     idb:           acpi.inf_amd64_ad65e307b13e6893
+     inf:      {Configure Driver: Microsoft ACPI-Compliant System}
+     inf:           Section Name = ACPI_Inst.NT
+     inf:           {Add Service: ACPI}
+     inf:                Start Type    = 0
+     inf:                Service Type  = 1
+     inf:                Error Control = 3
+     inf:                Image Path    = System32\drivers\ACPI.sys
+     inf:                Display Name  = Microsoft ACPI Driver
+     inf:                Updated service 'ACPI'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = *pnp0c08
+     inf:           {Configure Driver Configuration: ACPI_Inst.NT}
+     inf:                Service Name  = ACPI
+     inf:                Reboot Required
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Microsoft ACPI-Compliant System}
+     inf:           Section Name = ACPI_Inst.NT
+     inf:           Hardware Id  = pnp0c08
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_19a61be22ae9944e\acpi.sys' to 'C:\Windows\System32\drivers\acpi.sys'.
+     idb:      Last driver package 'acpi.inf_amd64_ad65e307b13e6893' to copy 'C:\Windows\System32\drivers\acpi.sys' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'wfcvsc.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_f146c688c52c6479\wfcvsc.inf}
+     inf:      Class GUID     = {4d36e97b-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           wfcvsc.inf_amd64_f146c688c52c6479 (active)
+     idb:           wfcvsc.inf_amd64_f049c0f8aa802928
+     inf:      {Configure Driver: Microsoft Hyper-V Fibre Channel HBA (not supported)}
+     inf:           Section Name = fcvscDriveInstall_NULL
+     inf:           Hardware Id  = VMBUS\{2f9bcc4a-0069-4af3-b76b-6fd0be528cda}
+     inf:           {Configure Driver Configuration: fcvscDriveInstall_NULL}
+     inf:                Service Name  = <none>
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'sensorshidclassdriver.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_57265cb2d2642968\sensorshidclassdriver.inf}
+     inf:      Class GUID     = {5175d334-c371-4806-b3ba-71fd53c9258d}
+     idb:      Driver packages:
+     idb:           sensorshidclassdriver.inf_amd64_57265cb2d2642968 (active)
+     idb:           sensorshidclassdriver.inf_amd64_63666a8e1afcc522
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'bth.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\bth.inf}
+     inf:      Class GUID     = {e0cbf06c-cd8b-4647-bb8a-263b43f0f974}
+     idb:      Driver packages:
+     idb:           bth.inf_amd64_97f04f59eaecdf7a (active)
+     idb:           bth.inf_amd64_6e5d1d4c2e1fa2ec
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'bthleenum.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_0dabadc4461923c4\bthleenum.inf}
+     inf:      Class GUID     = {e0cbf06c-cd8b-4647-bb8a-263b43f0f974}
+     idb:      Driver packages:
+     idb:           bthleenum.inf_amd64_0dabadc4461923c4 (active)
+     idb:           bthleenum.inf_amd64_91c9f1f9f9c90133
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'genericusbfn.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_d519ce9ec210da10\genericusbfn.inf}
+     inf:      Class GUID     = {36fc9e60-c465-11cf-8056-444553540000}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           genericusbfn.inf_amd64_d519ce9ec210da10 (active)
+     idb:           genericusbfn.inf_amd64_74a699053034b56d
+     inf:      {Configure Driver: Generic USB Function Class}
+     inf:           Section Name = genericusbfn.Install.NT
+     inf:           {Add Service: genericusbfn}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\genericusbfn.sys
+     inf:                Display Name  = Generic USB Function Class
+     inf:                Group         = Base
+     inf:                Updated service 'genericusbfn'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = USBFN\GENERICUSBFN
+     inf:           {Configure Driver Configuration: genericusbfn.Install.NT}
+     inf:                Service Name  = genericusbfn
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Generic USB Function Class}
+     inf:           Section Name = genericusbfn.InstallSecure.NT
+     inf:           Hardware Id  = USBFN\MTP
+     inf:           {Configure Driver Configuration: genericusbfn.InstallSecure.NT}
+     inf:                Service Name  = genericusbfn
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Generic USB Function Class}
+     inf:           Section Name = genericusbfn.InstallSecure.NT
+     inf:           Hardware Id  = USBFN\IpOverUSB
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Generic USB Function Class}
+     inf:           Section Name = genericusbfn.Install.NT
+     inf:           Hardware Id  = USBFN\UOSFlashing
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Generic USB Function Class}
+     inf:           Section Name = genericusbfn.Install.NT
+     inf:           Hardware Id  = USBFN\MainOSFlashing
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_d519ce9ec210da10\genericusbfn.sys' to 'C:\Windows\System32\drivers\genericusbfn.sys'.
+     idb:      Last driver package 'genericusbfn.inf_amd64_74a699053034b56d' to copy 'C:\Windows\System32\drivers\genericusbfn.sys' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'usbstor.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_2780d7dc6ecda26e\usbstor.inf}
+     inf:      Class GUID     = {36fc9e60-c465-11cf-8056-444553540000}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           usbstor.inf_amd64_2780d7dc6ecda26e (active)
+     idb:           usbstor.inf_amd64_8c69d27bb757b62d
+     inf:      {Configure Driver: USB Mass Storage Device}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           {Add Service: USBSTOR}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\USBSTOR.SYS
+     inf:                Display Name  = USB Mass Storage Driver
+     inf:                Updated service 'USBSTOR'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = USB\Class_08&SubClass_02&Prot_50
+     inf:           {Configure Driver Configuration: USBSTOR_BULK.NT}
+     inf:                Service Name  = USBSTOR
+     inf:                Included INFs = machine.inf
+     inf:                                pci.inf
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB Mass Storage Device}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\Class_08&SubClass_05&Prot_50
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB Mass Storage Device}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\Class_08&SubClass_06&Prot_50
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB Mass Storage Device}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\Class_08&SubClass_08&Prot_50
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB Mass Storage Device}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\Class_08&SubClass_08&Prot_52
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Mitsumi USB CD-R/RW Drive}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_03EE&PID_0000
+     inf:           {Configure Driver Configuration: USBSTOR_CBI.NT}
+     inf:                Service Name  = USBSTOR
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Mitsumi USB Floppy}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_03EE&PID_6901
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: HP USB CD-Writer Plus}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_03F0&PID_0107
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: HP USB Floppy}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_03F0&PID_2001
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Hewlett-Packard Digital Camera}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_03F0&PID_4002
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Hewlett-Packard Digital Camera}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_03F0&PID_6102
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: NEC Clik!-USB Drive}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_0409&PID_002C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: NEC USB Floppy}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_0409&PID_0040
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: IBM USB CD-ROM Drive}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_04B3&PID_4427
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB Storage Device}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_04BB&PID_0301
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: FujiFilm FinePix Digital Camera}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_04CB&PID_0100
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: ScanLogic USB Storage Device}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_04CE&PID_0002
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Panasonic USB CD-R/RW Drive}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_04DA&PID_0B01
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB Reader Writer for SD Memory Card}
+     inf:           Section Name = USBSTOR_CB.NT
+     inf:           Hardware Id  = USB\VID_04DA&PID_1B00
+     inf:           {Configure Driver Configuration: USBSTOR_CB.NT}
+     inf:                Service Name  = USBSTOR
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Panasonic USB SuperDisk 240MB}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_04DA&PID_0B03
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB ATAPI Storage Device}
+     inf:           Section Name = USBSTOR_CB.NT
+     inf:           Hardware Id  = USB\VID_04E6&PID_0001
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB SCSI Storage Device}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_04E6&PID_0002
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB CompactFlash Reader}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_04E6&PID_000A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB ATAPI Storage Device}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_04E6&PID_0101
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Sony USB HiFD Drive}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_054C&PID_0022
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Sony USB CD-R/RW Drive}
+     inf:           Section Name = USBSTOR_CB.NT
+     inf:           Hardware Id  = USB\VID_054C&PID_0023
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Sony Mavica Digital Still Camera}
+     inf:           Section Name = USBSTOR_CB.NT
+     inf:           Hardware Id  = USB\VID_054C&PID_0024
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Sony USB Memory Stick Walkman}
+     inf:           Section Name = USBSTOR_CB.NT
+     inf:           Hardware Id  = USB\VID_054C&PID_0025
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Sony USB Floppy}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_054C&PID_002C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Sony Memory Stick Reader/Writer}
+     inf:           Section Name = USBSTOR_CBI_NR.NT
+     inf:           Hardware Id  = USB\VID_054C&PID_0032
+     inf:           {Configure Driver Configuration: USBSTOR_CBI_NR.NT}
+     inf:                Service Name  = USBSTOR
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Sony MG Memory Stick Reader/Writer}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_054C&PID_0037
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Sony USB Network Walkman}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_054C&PID_0046
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Sony USB Memory Stick Hi-Fi System}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_054C&PID_004A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Sony MG Memory Stick Reader/Writer}
+     inf:           Section Name = USBSTOR_CBI_NR.NT
+     inf:           Hardware Id  = USB\VID_054C&PID_0056
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Sony MG Memory Stick CLIE}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_054C&PID_0058
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Sony Memory Stick Reader/Writer}
+     inf:           Section Name = USBSTOR_CBI_NR.NT
+     inf:           Hardware Id  = USB\VID_054C&PID_0069
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Y-E Data USB Floppy}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_057B&PID_0000
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Y-E Data USB Floppy}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_057B&PID_0001
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Y-E Data USB Memory Stick Reader}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_057B&PID_0010
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Iomega USB Zip 100}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_059B&PID_0001
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Iomega USB Zip 250}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_059B&PID_0030
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Iomega USB Zip 100}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_059B&PID_0031
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Iomega USB Bus Powered Zip 250}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_059B&PID_0032
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Iomega USB Click!Dock}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_059B&PID_0060
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: LaCie USB Hard Drive}
+     inf:           Section Name = USBSTOR_CB.NT
+     inf:           Hardware Id  = USB\VID_059F&PID_A601
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: LaCie USB CD-R/RW Drive}
+     inf:           Section Name = USBSTOR_CB.NT
+     inf:           Hardware Id  = USB\VID_059F&PID_A602
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: TEAC USB Floppy}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_0644&PID_0000
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: TEAC USB CD-ROM Drive}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_0644&PID_1000
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB SmartMedia Reader/Writer}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_0693&PID_0002
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB CompactFlash Reader/Writer}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_0693&PID_0003
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB Dual Slot Reader/Writer}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_0693&PID_0005
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB SM PCCard R/W and SPD}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_0693&PID_0006
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: FlashGate ME (Authenticated)}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_0693&PID_0007&MI_00
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB SDCard/MMC Reader/Writer}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_0693&PID_000A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Imation SuperDisk USB 120MB}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_0718&PID_0002
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Imation SuperDisk USB 120MB (Authenticated)}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_0718&PID_0003&MI_00
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SanDisk USB ImageMate}
+     inf:           Section Name = USBSTOR_CB.NT
+     inf:           Hardware Id  = USB\VID_0781&PID_0001
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SanDisk USB ImageMate (Authenticated)}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_0781&PID_0002&MI_00
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SanDisk USB ImageMate Multimedia Card Reader}
+     inf:           Section Name = USBSTOR_CB.NT
+     inf:           Hardware Id  = USB\VID_0781&PID_0100
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Samsung Digimax 220}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_0839&PID_1005
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: DioGraphy USB Smartdio Reader/Writer}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_0892&PID_0101
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: DiskOnKey USB personal storage device}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_08EC&PID_0010
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Addonics USB Storage Device}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_0BF6&PID_1234
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Addonics USB Storage Device}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_0BF6&PID_0103
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB SuperDisk}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_55AA&PID_0102
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: OnSpec USB IDE Hard Drive}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_55AA&PID_0103
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: OnSpec USB CD-R/RW Drive}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_55AA&PID_1234
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: OnSpec USB MMC/SD Reader/Writer}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_55AA&PID_B004
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: OnSpec USB Compact Flash Reader (Authenticated)}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_55AA&PID_B200&MI_00
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: OnSpec USB MMC/ SD Reader (Authenticated)}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_55AA&PID_B204&MI_00
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: OnSpec USB Memory Stick Reader (Authenticated)}
+     inf:           Section Name = USBSTOR_BULK.NT
+     inf:           Hardware Id  = USB\VID_55AA&PID_B207&MI_00
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SMSC USB Floppy}
+     inf:           Section Name = USBSTOR_CBI.NT
+     inf:           Hardware Id  = USB\VID_0424&PID_0FDC
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_2780d7dc6ecda26e\USBSTOR.SYS' to 'C:\Windows\system32\drivers\USBSTOR.SYS'.
+     idb:      Last driver package 'usbstor.inf_amd64_8c69d27bb757b62d' to copy 'C:\Windows\system32\drivers\USBSTOR.SYS' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Devices using 'usbport.inf':
+     sto:      PCI\VEN_106B&DEV_003F&SUBSYS_00000000&REV_00\3&267a616a&1&30 -> PCI\CC_0C0310 [OHCI.Dev.NT]
+     sto:      PCI\VEN_8086&DEV_265C&SUBSYS_00000000&REV_00\3&267a616a&1&58 -> PCI\VEN_8086&DEV_265C [EHCI.Dev.NT]
+     sto:      USB\ROOT_HUB\4&159a73f4&0 -> USB\ROOT_HUB [ROOTHUB.Dev.NT]
+     sto:      USB\ROOT_HUB20\4&3749a296&0 -> USB\ROOT_HUB20 [ROOTHUB.Dev.NT]
+     sto: Installed section names:
+     sto:      OHCI.Dev.NT
+     sto:      EHCI.Dev.NT
+     sto:      ROOTHUB.Dev.NT
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbport.inf}
+     inf:      Class GUID     = {36fc9e60-c465-11cf-8056-444553540000}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           usbport.inf_amd64_4215f546c8e8f9d6 (active)
+     idb:           usbport.inf_amd64_1e58ad6583f1ecab
+     inf:      {Configure Driver: ULi USB 2.0 Enhanced Host Controller}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           {Add Service: usbehci}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\usbehci.sys
+     inf:                Display Name  = Microsoft USB 2.0 Enhanced Host Controller Miniport Driver
+     inf:                Group         = Base
+     inf:                Updated service 'usbehci'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = PCI\VEN_10B9&DEV_5239&CC_0C0320
+     inf:           {Configure Driver Configuration: EHCI.Dev.NT}
+     inf:                Service Name  = usbehci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: ATI I/O Communications Processor USB 2.0 EHCI controller}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\Ven_1002&Dev_4373
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: ATI I/O Communications Processor USB 1.1 OHCI controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           {Add Service: usbohci}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\usbohci.sys
+     inf:                Display Name  = Microsoft USB Open Host Controller Miniport Driver
+     inf:                Group         = Base
+     inf:                Updated service 'usbohci'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = PCI\Ven_1002&Dev_4374
+     inf:           {Configure Driver Configuration: OHCI.Dev.NT}
+     inf:                Service Name  = usbohci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: ATI I/O Communications Processor USB 1.1 OHCI controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\Ven_1002&Dev_4375
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: CMD USB0670 PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1095&DEV_0670&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: CMD USB0673 PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1095&DEV_0673&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Standard OpenHCD USB Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Standard Enhanced PCI to USB Host Controller}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\CC_0C0320
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB Root Hub}
+     inf:           Section Name = ROOTHUB.Dev.NT
+     inf:           {Add Service: usbhub}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\usbhub.sys
+     inf:                Display Name  = Microsoft USB Standard Hub Driver
+     inf:                Group         = Base
+     inf:                Updated service 'usbhub'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = USB\ROOT_HUB
+     inf:           {Configure Driver Configuration: ROOTHUB.Dev.NT}
+     inf:                Service Name  = usbhub
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB Root Hub}
+     inf:           Section Name = ROOTHUB.Dev.NT
+     inf:           Hardware Id  = USB\ROOT_HUB20
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) SM35 Express Chipset USB2 Enhanced Host Controller MPH  - 0806}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_0806
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) SM35 Express Chipset USB2 Enhanced Host Controller SPM  - 0811}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_0811
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 6 Series/C200 Series Chipset Family USB Enhanced Host Controller - 1C26}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_1C26
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 6 Series/C200 Series Chipset Family USB Enhanced Host Controller - 1C2D}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_1C2D
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) C600/X79 series chipset USB2 Enhanced Host Controller #1 - 1D26}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_1D26
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) C600/X79 series chipset USB2 Enhanced Host Controller #2 - 1D2D}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_1D2D
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 7 Series/C216 Chipset Family USB Enhanced Host Controller - 1E26}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_1E26
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 7 Series/C216 Chipset Family USB Enhanced Host Controller - 1E2D}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_1E2D
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: DH89xxCC USB 2.0 Controller 1 - 2334}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2334
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: DH89xxCC USB 2.0 Controller 1 - 2335}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2335
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801DB/DBM USB 2.0 Enhanced Host Controller - 24CD}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24CD&CC_0C0320
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801EB USB2 Enhanced Host Controller - 24DD}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24DD
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 6300ESB USB2 Enhanced Host Controller - 25AD}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_25AD
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801FB/FBM USB2 Enhanced Host Controller - 265C}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_265C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 631xESB/6321ESB/3100 Chipset USB2 Enhanced Host Controller - 268C}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_268C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801G (ICH7 Family) USB2 Enhanced Host Controller - 27CC}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_27CC
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH8 Family USB2 Enhanced Host Controller - 2836}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2836
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH8 Family USB2 Enhanced Host Controller - 283A}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_283A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH9 Family USB2 Enhanced Host Controller - 293A}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_293A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH9 Family USB2 Enhanced Host Controller - 293C}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_293C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Enhanced Host Controller - 3A3A}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A3A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Enhanced Host Controller - 3A3C}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A3C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Enhanced Host Controller - 3A6A}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A6A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Enhanced Host Controller - 3A6C}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A6C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Enhanced Host Controller - 3B34}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B34
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Enhanced Host Controller - 3B3C}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B3C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Platform Controller Hub EG20T USB OHCI Controller #4 - 8804}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_8804
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Platform Controller Hub EG20T USB OHCI Controller #5 - 8805}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_8805
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Platform Controller Hub EG20T USB OHCI Controller #6 - 8806}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_8806
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Platform Controller Hub EG20T USB2 EHCI Controller #2 - 8807}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_8807
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Platform Controller Hub EG20T USB OHCI Controller #1 - 880c}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_880C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Platform Controller Hub EG20T USB OHCI Controller #2 - 880d}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_880D
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Platform Controller Hub EG20T USB OHCI Controller #3 - 880e}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_880E
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Platform Controller Hub EG20T USB2 EHCI Controller #1 - 880f}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_880F
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 8 Series/C220 Series USB EHCI #1 - 8C26}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_8C26
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 8 Series/C220 Series USB EHCI #2 - 8C2D}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_8C2D
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 8 Series USB Enhanced Host Controller #1 - 9C26}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_9C26
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 8 Series USB Enhanced Host Controller #2 - 9C2D}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_9C2D
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Atom(TM) processor C2000 product family USB Enhanced Host Controller - 1F2C}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_1F2C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Lucent USB Open Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_11C1&DEV_5801&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Lucent USB Open Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_11C1&DEV_5802&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Lucent QuadraBus USB Open Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_11C1&DEV_5803&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: NEC PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1033&DEV_0035&REV_41
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: NEC PCI to USB Enhanced Host Controller (B0)}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1033&DEV_00E0&REV_01
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: NEC PCI to USB Enhanced Host Controller (B1)}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1033&DEV_00E0&REV_02
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: ServerWorks (RCC) PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1166&DEV_0220&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SMSC SLC90E66 PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1055&DEV_9462
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA USB Enhanced Host Controller}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3104
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: AMD 756 PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_HYDRA.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1022&DEV_740C&CC_0C0310
+     inf:           {Configure Driver Configuration: OHCI_HYDRA.Dev.NT}
+     inf:                Service Name  = usbohci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: AMD PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_NOSS.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1022&DEV_7464&REV_08
+     inf:           {Configure Driver Configuration: OHCI_NOSS.Dev.NT}
+     inf:                Service Name  = usbohci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: AMD PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_NOSS.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1022&DEV_7464&REV_09
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: AMD PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_NOSS.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1022&DEV_7464&REV_0B
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: ULi PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_HYDRA.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_10B9&DEV_5237&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Compaq PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_HYDRA.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_0E11&DEV_A0F8&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Cypress USB Open Host Controller}
+     inf:           Section Name = OHCI_HYDRA.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1080&DEV_C693&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Standard Universal PCI to USB Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           {Add Service: usbuhci}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\usbuhci.sys
+     inf:                Display Name  = Microsoft USB Universal Host Controller Miniport Driver
+     inf:                Group         = Base
+     inf:                Updated service 'usbuhci'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = PCI\CC_0C0300
+     inf:           {Configure Driver Configuration: UHCI.Dev.NT}
+     inf:                Service Name  = usbuhci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Standard EHCI-compliant Host Controller}
+     inf:           Section Name = EHCI_SOC.Dev.NT
+     inf:           Hardware Id  = *PNP0D20
+     inf:           {Configure Driver Configuration: EHCI_SOC.Dev.NT}
+     inf:                Service Name  = usbehci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Standard EHCI-compliant Host Controller}
+     inf:           Section Name = EHCI_SOC.Dev.NT
+     inf:           Hardware Id  = ACPI\PNP0D20
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Standard EHCI-compliant Host Controller}
+     inf:           Section Name = EHCI_SOC.Dev.NT
+     inf:           Hardware Id  = *PNP0FFC
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: DH89xxCC USB EHCI virtual HC #1 - 2359}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2359
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: DH89xxCC USB EHCI virtual HC #2 - 235A}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_235A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801AA USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2412&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801AB USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2422&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801BA/BAM USB Universal Host Controller - 2442}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2442&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801BA/BAM USB Universal Host Controller - 2444}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2444&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801CA/CAM USB Universal Host Controller - 2482}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2482
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801CA/CAM USB Universal Host Controller - 2484}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2484
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801CA/CAM USB Universal Host Controller - 2487}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2487
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801DB/DBM USB Universal Host Controller - 24C2}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24C2&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801DB/DBM USB Universal Host Controller - 24C4}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24C4&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801DB/DBM USB Universal Host Controller - 24C7}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24C7&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801EB USB Universal Host Controller - 24D2}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24D2
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801EB USB Universal Host Controller - 24D4}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24D4
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801EB USB Universal Host Controller - 24D7}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24D7
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801EB USB Universal Host Controller - 24DE}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24DE
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 6300ESB USB Universal Host Controller - 25A9}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_25A9
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 6300ESB USB Universal Host Controller - 25AA}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_25AA
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801FB/FBM USB Universal Host Controller - 2658}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2658
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801FB/FBM USB Universal Host Controller - 2659}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2659
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801FB/FBM USB Universal Host Controller - 265A}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_265A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801FB/FBM USB Universal Host Controller - 265B}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_265B
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 631xESB/6321ESB/3100 Chipset USB Universal Host Controller - 2688}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2688
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 631xESB/6321ESB/3100 Chipset USB Universal Host Controller - 2689}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2689
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 631xESB/6321ESB/3100 Chipset USB Universal Host Controller - 268A}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_268A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 631xESB/6321ESB/3100 Chipset USB Universal Host Controller - 268B}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_268B
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801G (ICH7 Family) USB Universal Host Controller - 27C8}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_27C8
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801G (ICH7 Family) USB Universal Host Controller - 27C9}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_27C9
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801G (ICH7 Family) USB Universal Host Controller - 27CA}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_27CA
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801G (ICH7 Family) USB Universal Host Controller - 27CB}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_27CB
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH8 Family USB Universal Host Controller - 2830}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2830
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH8 Family USB Universal Host Controller - 2831}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2831
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH8 Family USB Universal Host Controller - 2832}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2832
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH8 Family USB Universal Host Controller - 2834}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2834
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH8 Family USB Universal Host Controller - 2835}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2835
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH9 Family USB Universal Host Controller - 2934}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2934
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH9 Family USB Universal Host Controller - 2935}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2935
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH9 Family USB Universal Host Controller - 2936}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2936
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH9 Family USB Universal Host Controller - 2937}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2937
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH9 Family USB Universal Host Controller - 2938}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2938
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH9 Family USB Universal Host Controller - 2939}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2939
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A34}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A34
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A35}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A35
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A36}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A36
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A37}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A37
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A38}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A38
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A39}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A39
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A64}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A64
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A65}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A65
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A66}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A66
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A67}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A67
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A68}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A68
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A69}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A69
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B36}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B36
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B37}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B37
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B38}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B38
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B39}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B39
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B3A}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B3A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B3B}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B3B
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B3E}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B3E
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B3F}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B3F
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B40}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B40
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82371SB PCI to USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_7020&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82371AB/EB PCI to USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_7112&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82440MX USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_719A&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82372FB PCI to USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_7602&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: NEC PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_NEC.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1033&DEV_0035&CC_0C0310
+     inf:           {Configure Driver Configuration: OHCI_NEC.Dev.NT}
+     inf:                Service Name  = usbohci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: NEC PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_NEC.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1033&DEV_0035&REV_02
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: NEC PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_NOCC.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1033&DEV_0035&SUBSYS_00011179&REV_41
+     inf:           {Configure Driver Configuration: OHCI_NOCC.Dev.NT}
+     inf:                Service Name  = usbohci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: OPTi 82C861 PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_HYDRA.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1045&DEV_C861&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SiS 7001 PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_HYDRA.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1039&DEV_7001&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Symbios Logic SYM61C102 USB Host Controller}
+     inf:           Section Name = OHCI_HYDRA.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1000&DEV_0901&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 0 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&SUBSYS_12340925&REV_00
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 0 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&REV_00
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 1 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&SUBSYS_12340925&REV_01
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 1 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&REV_01
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 2 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&SUBSYS_12340925&REV_02
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 2 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&REV_02
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 3 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&SUBSYS_12340925&REV_03
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 3 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&REV_03
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 4 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&SUBSYS_12340925&REV_04
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 4 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&REV_04
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 5 or later USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 5 or later USB Universal Host Companion Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&SUBSYS_12340925&REV_50
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 5 or later USB Universal Host Companion Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&REV_50
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Unsupported Device}
+     inf:           Section Name = EHCI.UnsupportedDev.NT
+     inf:           {Configure Driver Configuration: EHCI.UnsupportedDev.NT}
+     inf:                Service Name  = <none>
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Unsupported Device}
+     inf:           Section Name = OHCI.UnsupportedDev.NT
+     inf:           {Configure Driver Configuration: OHCI.UnsupportedDev.NT}
+     inf:                Service Name  = <none>
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Unsupported Device}
+     inf:           Section Name = UHCI.UnsupportedDev.NT
+     inf:           {Configure Driver Configuration: UHCI.UnsupportedDev.NT}
+     inf:                Service Name  = <none>
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbehci.sys' to 'C:\Windows\system32\drivers\usbehci.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\usbehci.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbport.sys' to 'C:\Windows\system32\drivers\usbport.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\usbport.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbhub.sys' to 'C:\Windows\system32\drivers\usbhub.sys'.
+     idb:      Last driver package 'usbport.inf_amd64_1e58ad6583f1ecab' to copy 'C:\Windows\system32\drivers\usbhub.sys' needs reconfiguration.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbohci.sys' to 'C:\Windows\system32\drivers\usbohci.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\usbohci.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbd.sys' to 'C:\Windows\system32\drivers\usbd.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\usbd.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbuhci.sys' to 'C:\Windows\system32\drivers\usbuhci.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\usbuhci.sys' remains unchanged.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'usbhub3.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_caa57285880769f4\usbhub3.inf}
+     inf:      Class GUID     = {36fc9e60-c465-11cf-8056-444553540000}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           usbhub3.inf_amd64_caa57285880769f4 (active)
+     idb:           usbhub3.inf_amd64_8c7cb6330f81414a
+     inf:      {Configure Driver: USB Root Hub (xHCI)}
+     inf:           Section Name = Generic.Install.NT
+     inf:           {Add Service: USBHUB3}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\UsbHub3.sys
+     inf:                Display Name  = SuperSpeed Hub
+     inf:                Group         = Base
+     inf:                Updated service 'USBHUB3'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = USB\ROOT_HUB30
+     inf:           {Configure Driver Configuration: Generic.Install.NT}
+     inf:                Service Name  = USBHUB3
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Generic SuperSpeed USB Hub}
+     inf:           Section Name = Generic.Install.NT
+     inf:           Hardware Id  = USB\USB30_HUB
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Generic USB Hub}
+     inf:           Section Name = Generic.Install.NT
+     inf:           Hardware Id  = USB\USB20_HUB
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_caa57285880769f4\USBHUB3.SYS' to 'C:\Windows\System32\drivers\USBHUB3.SYS'.
+     idb:      Last driver package 'usbhub3.inf_amd64_8c7cb6330f81414a' to copy 'C:\Windows\System32\drivers\USBHUB3.SYS' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'usbxhci.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_7b59c1e1fa52c844\usbxhci.inf}
+     inf:      Class GUID     = {36fc9e60-c465-11cf-8056-444553540000}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           usbxhci.inf_amd64_7b59c1e1fa52c844 (active)
+     idb:           usbxhci.inf_amd64_57248f1a8744b4fc
+     inf:      {Configure Driver: USB xHCI Compliant Host Controller}
+     inf:           Section Name = Generic.Install.NT
+     inf:           {Add Service: USBXHCI}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\USBXHCI.SYS
+     inf:                Display Name  = USB xHCI Compliant Host Controller
+     inf:                Dependencies  = Ucx01000
+     inf:                Updated service 'USBXHCI'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = PCI\CC_0C0330
+     inf:           {Configure Driver Configuration: Generic.Install.NT}
+     inf:                Service Name  = USBXHCI
+     inf:                Exclude IDs   = PCI\VEN_1B73&DEV_1000&CC_0C0330
+     inf:                                PCI\VEN_1B73&DEV_1400&CC_0C0330
+     inf:                                PCI\VEN_1B73&DEV_1009&REV_00
+     inf:                Included INFs = machine.inf
+     inf:                                pci.inf
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB xHCI Compliant Host Controller}
+     inf:           Section Name = Generic.Install.NT
+     inf:           Hardware Id  = ACPI\PNP0D10
+     inf:      {Configure Driver: exit(0x00000000)}
+!    inf:      Needed section [PciD3ColdSupported] found in included INF "pci.inf", not referenced from [Generic_NoDebug.Install.NT.Hw]. Code = 1313, Line = 102
+     inf:      {Configure Driver: USB xHCI Compliant Host Controller}
+     inf:           Section Name = Generic_NoDebug.Install.NT
+     inf:           Hardware Id  = ACPI\PNP0D15
+     inf:           {Configure Driver Configuration: Generic_NoDebug.Install.NT}
+     inf:                Service Name  = USBXHCI
+     inf:                Included INFs = machine.inf
+     inf:                                pci.inf
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_7b59c1e1fa52c844\USBXHCI.SYS' to 'C:\Windows\System32\drivers\USBXHCI.SYS'.
+     idb:      Last driver package 'usbxhci.inf_amd64_57248f1a8744b4fc' to copy 'C:\Windows\System32\drivers\USBXHCI.SYS' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'sdbus.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_b33128a95ba9fe0b\sdbus.inf}
+     inf:      Class GUID     = {a0a588a4-c46f-4b37-b7ea-c82fe89870c6}
+     inf:      Class Options  = Configurable BootCritical
+     inf:      Driver package is boot critical.
+     idb:      Driver packages:
+     idb:           sdbus.inf_amd64_b33128a95ba9fe0b (active)
+     idb:           sdbus.inf_amd64_7fb86acc31fcdbad
+     inf:      {Configure Driver: SDA Standard Compliant SD Host Controller}
+     inf:           Section Name = SDHost
+     inf:           {Add Service: sdbus}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\sdbus.sys
+     inf:                Group         = System Bus Extender
+     inf:                Updated service 'sdbus'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = PCI\CC_080500
+     inf:           {Configure Driver Configuration: SDHost}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SDA Standard Compliant SD Host Controller}
+     inf:           Section Name = SDHost
+     inf:           Hardware Id  = PCI\CC_080501
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SDA Standard Compliant SD Host Controller}
+     inf:           Section Name = SDHost
+     inf:           Hardware Id  = ACPI\PNP0D40
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Tokyo Electron SD Standard host controller}
+     inf:           Section Name = SDHost
+     inf:           Hardware Id  = PCI\VEN_1679&DEV_3000
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Texas Instruments Secure Digital host controller}
+     inf:           Section Name = SDHost
+     inf:           Hardware Id  = PCI\VEN_104C&DEV_AC9F
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SDA Standard Compliant SD Host Controller}
+     inf:           Section Name = SDHostRicoh_1
+     inf:           Hardware Id  = PCI\VEN_1180&DEV_0822&SUBSYS_833810F7
+     inf:           {Configure Driver Configuration: SDHostRicoh_1}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Ricoh Secure Digital host controller R5C841}
+     inf:           Section Name = SDHostRicoh
+     inf:           Hardware Id  = PCI\VEN_1180&DEV_0822&SUBSYS_C01A144D&REV_17
+     inf:           {Configure Driver Configuration: SDHostRicoh}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Secure Digital host controller}
+     inf:           Section Name = SDHost
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_365B
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Secure Digital host controller}
+     inf:           Section Name = SDHost
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_401B
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Secure Digital host controller}
+     inf:           Section Name = SDHost
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_95D0
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SDA Standard Compliant SD Host Controller}
+     inf:           Section Name = SDHostMSI
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_811C&SUBSYS_10101462
+     inf:           {Configure Driver Configuration: SDHostMSI}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SDA Standard Compliant SD Host Controller}
+     inf:           Section Name = SDHostMSI
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_811E&SUBSYS_10101462
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SDA Standard Compliant SD Host Controller}
+     inf:           Section Name = SDHostJMicron
+     inf:           Hardware Id  = PCI\VEN_197B&DEV_2381&REV_00
+     inf:           {Configure Driver Configuration: SDHostJMicron}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel SD Host Controller (deprecated)}
+     inf:           Section Name = SDHostMedfield
+     inf:           Hardware Id  = ACPI\PNP0FFF
+     inf:           {Configure Driver Configuration: SDHostMedfield}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel SD Host Controller}
+     inf:           Section Name = SDHostIntelEMMC
+     inf:           Hardware Id  = ACPI\VEN_INT&DEV_33BA&REV_0001
+     inf:           {Configure Driver Configuration: SDHostIntelEMMC}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel SD Host Controller}
+     inf:           Section Name = SDHostIntelSDIO1
+     inf:           Hardware Id  = ACPI\VEN_INT&DEV_33BB&REV_0001
+     inf:           {Configure Driver Configuration: SDHostIntelSDIO1}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel SD Host Controller}
+     inf:           Section Name = SDHostIntelSDIO2
+     inf:           Hardware Id  = ACPI\VEN_INT&DEV_33BB&REV_0002
+     inf:           {Configure Driver Configuration: SDHostIntelSDIO2}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel SD Host Controller}
+     inf:           Section Name = SDHostIntelSDIO3
+     inf:           Hardware Id  = ACPI\VEN_INT&DEV_33BB&REV_0003
+     inf:           {Configure Driver Configuration: SDHostIntelSDIO3}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel SD Host Controller}
+     inf:           Section Name = SDHostIntelBayTrail
+     inf:           Hardware Id  = ACPI\VEN_8086&DEV_0F14
+     inf:           {Configure Driver Configuration: SDHostIntelBayTrail}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel SD Host Controller}
+     inf:           Section Name = SDHostIntelCherryTrail
+     inf:           Hardware Id  = ACPI\VEN_8086&DEV_0F14&REV_0001
+     inf:           {Configure Driver Configuration: SDHostIntelCherryTrail}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel SD Host Controller}
+     inf:           Section Name = SDHostIntelCherryTrail
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_9D2B
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel SD Host Controller}
+     inf:           Section Name = SDHostIntelCherryTrail
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_9D2C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel SD Host Controller}
+     inf:           Section Name = SDHostIntelCherryTrail
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_9D2D
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Qualcomm SoC Secure Digital host controller}
+     inf:           Section Name = SDHostQualcomm
+     inf:           Hardware Id  = ACPI\QCOM7002
+     inf:           {Configure Driver Configuration: SDHostQualcomm}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Qualcomm SoC Secure Digital host controller}
+     inf:           Section Name = SDHostQualcomm8974
+     inf:           Hardware Id  = ACPI\QCOM2465
+     inf:           {Configure Driver Configuration: SDHostQualcomm8974}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Qualcomm SoC Secure Digital host controller}
+     inf:           Section Name = SDHostQualcomm8974Std
+     inf:           Hardware Id  = ACPI\QCOM2466
+     inf:           {Configure Driver Configuration: SDHostQualcomm8974Std}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Qualcomm SoC Secure Digital host controller}
+     inf:           Section Name = SDHostQualcomm8994Std
+     inf:           Hardware Id  = ACPI\QCOM24BF
+     inf:           {Configure Driver Configuration: SDHostQualcomm8994Std}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: ARM Holdings PL180 Secure Digital host controller}
+     inf:           Section Name = SDHostARMHPL180
+     inf:           Hardware Id  = ACPI\ARMH0180
+     inf:           {Configure Driver Configuration: SDHostARMHPL180}
+     inf:                Service Name  = sdbus
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_b33128a95ba9fe0b\sdbus.sys' to 'C:\Windows\System32\drivers\sdbus.sys'.
+     idb:      Last driver package 'sdbus.inf_amd64_7fb86acc31fcdbad' to copy 'C:\Windows\System32\drivers\sdbus.sys' needs reconfiguration.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_b33128a95ba9fe0b\dumpsd.sys' to 'C:\Windows\System32\drivers\dumpsd.sys'.
+     cpy:      Existing file 'C:\Windows\System32\drivers\dumpsd.sys' remains unchanged.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'mdmbtmdm.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_57032036ac5b3f02\mdmbtmdm.inf}
+     inf:      Class GUID     = {4d36e96d-e325-11ce-bfc1-08002be10318}
+     idb:      Driver packages:
+     idb:           mdmbtmdm.inf_amd64_57032036ac5b3f02 (active)
+     idb:           mdmbtmdm.inf_amd64_a39b901bc01403cc
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'bthaudhid.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_aaeb679851734af2\bthaudhid.inf}
+     inf:      Class GUID     = {745a17a0-74d3-11d0-b6fe-00a0c90f57da}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           bthaudhid.inf_amd64_aaeb679851734af2 (active)
+     idb:           bthaudhid.inf_amd64_b9a1f939467681b0
+     inf:      {Configure Driver: Bluetooth Hands-Free Call Control HID}
+     inf:           Section Name = BthAudioHFHid
+     inf:           {Add Service: bthhfhid}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\BthHFHid.sys
+     inf:                Display Name  = Bluetooth Hands-Free Call Control HID
+     inf:                Updated service 'bthhfhid'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = BTHHFENUM\BthHFPHID
+     inf:           {Configure Driver Configuration: BthAudioHFHid}
+     inf:                Service Name  = bthhfhid
+     inf:                Upper Filters = mshidkmdf
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Bluetooth Audio/Video Remote Control HID}
+     inf:           Section Name = BthAvrcpTg_DDI
+     inf:           {Add Service: BthAvrcpTg}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\BthAvrcpTg.sys
+     inf:                Display Name  = Bluetooth Audio/Video Remote Control HID
+     inf:                Group         = Extended Base
+     inf:                Updated service 'BthAvrcpTg'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = BTHENUM\{0000110E-0000-1000-8000-00805F9B34FB}
+     inf:           {Configure Driver Configuration: BthAvrcpTg_DDI}
+     inf:                Service Name  = BthAvrcpTg
+     inf:                Included INFs = BtaMpm.inf
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Bluetooth Audio/Video Remote Control HID}
+     inf:           Section Name = BthAvrcpTg_DDI
+     inf:           Hardware Id  = BTHENUM\{0000110E-0000-1000-8000-00805F9B34FB}_LOCALMFG&000a
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_aaeb679851734af2\BthhfHid.sys' to 'C:\Windows\System32\drivers\BthhfHid.sys'.
+     cpy:      Existing file 'C:\Windows\System32\drivers\BthhfHid.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_aaeb679851734af2\BthAvrcpTg.sys' to 'C:\Windows\System32\drivers\BthAvrcpTg.sys'.
+     idb:      Last driver package 'bthaudhid.inf_amd64_b9a1f939467681b0' to copy 'C:\Windows\System32\drivers\BthAvrcpTg.sys' needs reconfiguration.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\btampm.inf_amd64_6e15be8bd68ddc6b\BtaMPM.sys' to 'C:\Windows\System32\drivers\BtaMPM.sys'.
+     cpy:      Existing file 'C:\Windows\System32\drivers\BtaMPM.sys' remains unchanged.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'bthhfenum.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_06170919fa54ed29\bthhfenum.inf}
+     inf:      Class GUID     = {4d36e97d-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           bthhfenum.inf_amd64_06170919fa54ed29 (active)
+     idb:           bthhfenum.inf_amd64_40249d17ba142187
+     inf:      {Configure Driver: Bluetooth Hands-Free Audio and Call Control HID Enumerator}
+     inf:           Section Name = BthHfEnum.NT
+     inf:           {Add Service: BthHFEnum}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\bthhfenum.sys
+     inf:                Display Name  = Bluetooth Hands-Free Audio and Call Control HID Enumerator
+     inf:                Group         = Extended Base
+     inf:                Updated service 'BthHFEnum'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           {Add Service: BthHFSrv}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 32
+     inf:                Error Control = 1
+     inf:                Image Path    = %SystemRoot%\System32\svchost.exe -k LocalServiceAndNoImpersonation
+     inf:                Display Name  = @%SystemRoot%\System32\BthHFSrv.dll,-103
+     inf:                Description   = @%SystemRoot%\System32\BthHFSrv.dll,-102
+     inf:                Object Name   = NT AUTHORITY\LocalService
+     inf:                Dependencies  = bthserv
+     inf:                Privileges    = SeChangeNotifyPrivilege
+     inf:                Updated service 'BthHFSrv'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = BTHENUM\{0000111E-0000-1000-8000-00805F9B34FB}
+     inf:           {Configure Driver Configuration: BthHfEnum.NT}
+     inf:                Service Name  = BthHFEnum
+     inf:                Config Flags  = 0x00000400
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Bluetooth Hands-Free Audio and Call Control HID Enumerator}
+     inf:           Section Name = BthHfEnum.NT
+     inf:           Hardware Id  = BTHENUM\{0000111E-0000-1000-8000-00805F9B34FB}_LOCALMFG&000a
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Bluetooth Hands-Free Audio and Call Control HID Enumerator}
+     inf:           Section Name = BthHfEnum.NT
+     inf:           Hardware Id  = BTHENUM\{0000111E-0000-1000-8000-00805F9B34FB}_HCIBYPASS
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_06170919fa54ed29\bthhfenum.sys' to 'C:\Windows\System32\drivers\bthhfenum.sys'.
+     idb:      Last driver package 'bthhfenum.inf_amd64_40249d17ba142187' to copy 'C:\Windows\System32\drivers\bthhfenum.sys' needs reconfiguration.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_06170919fa54ed29\BthHFSrv.dll' to 'C:\Windows\System32\BthHFSrv.dll'.
+!    flq:      A target file was not overwritten. Version of source file: 10.0.10240.16384. Version of target file: 10.0.10240.16384.
+!    flq:      The SPFQNOTIFY_TARGETNEWER flag was set.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'wudfusbcciddriver.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_dcc0445e956fcf69\wudfusbcciddriver.inf}
+     inf:      Class GUID     = {50dd5230-ba8a-11d1-bf5d-0000f805f530}
+     idb:      Driver packages:
+     idb:           wudfusbcciddriver.inf_amd64_dcc0445e956fcf69 (active)
+     idb:           wudfusbcciddriver.inf_amd64_5c0a61506fb5918d
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Devices using 'hdaudbus.inf':
+     sto:      PCI\VEN_8086&DEV_2668&SUBSYS_76808384&REV_01\3&267a616a&1&28 -> PCI\CC_0403 [HDAudio_Device.NT]
+     sto: Installed section names:
+     sto:      HDAudio_Device.NT
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_3a98a84dd82f9b0a\hdaudbus.inf}
+     inf:      Class GUID     = {4d36e97d-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           hdaudbus.inf_amd64_3a98a84dd82f9b0a (active)
+     idb:           hdaudbus.inf_amd64_59e464503a2b3653
+     inf:      {Configure Driver: High Definition Audio Controller}
+     inf:           Section Name = HDAudio_Device.NT
+     inf:           {Add Service: HDAudBus}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\HDAudBus.sys
+     inf:                Display Name  = Microsoft UAA Bus Driver for High Definition Audio
+     inf:                Group         = Extended Base
+     inf:                Updated service 'HDAudBus'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = PCI\CC_0403
+     inf:           {Configure Driver Configuration: HDAudio_Device.NT}
+     inf:                Service Name  = HDAudBus
+     inf:                Included INFs = wdmaudio.inf
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: High Definition Audio Controller}
+     inf:           Section Name = HDAudio_Device.NT
+     inf:           Hardware Id  = ACPI\CLS_0004&SUBCLS_0003
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_3a98a84dd82f9b0a\hdaudbus.sys' to 'C:\Windows\System32\drivers\hdaudbus.sys'.
+     idb:      Last driver package 'hdaudbus.inf_amd64_59e464503a2b3653' to copy 'C:\Windows\System32\drivers\hdaudbus.sys' needs reconfiguration.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\drmk.sys' to 'C:\Windows\system32\drivers\drmk.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\drmk.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\portcls.sys' to 'C:\Windows\system32\drivers\portcls.sys'.
+     idb:      Last driver package 'wdmaudio.inf_amd64_256ad046a471df0d' to copy 'C:\Windows\system32\drivers\portcls.sys' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'wdmaudio.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\wdmaudio.inf}
+     inf:      Class GUID     = {4d36e96c-e325-11ce-bfc1-08002be10318}
+     idb:      Driver packages:
+     idb:           wdmaudio.inf_amd64_58b3142a36627a91 (active)
+     idb:           wdmaudio.inf_amd64_256ad046a471df0d
+     inf:      {Configure Driver: Microsoft Trusted Audio Drivers}
+     inf:           Section Name = WDM_DRMKAUD
+     inf:           {Add Service: drmkaud}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\system32\drivers\drmkaud.sys
+     inf:                Display Name  = Microsoft Trusted Audio Drivers
+     inf:                Updated service 'drmkaud'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\drmk.sys' to 'C:\Windows\system32\drivers\drmk.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\drmk.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\drmkaud.sys' to 'C:\Windows\system32\drivers\drmkaud.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\drmkaud.sys' remains unchanged.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Devices using 'hdaudio.inf':
+     sto:      HDAUDIO\FUNC_01&VEN_8384&DEV_7680&SUBSYS_83847680&REV_1034\4&22a99211&0&0001 -> hdaudio\func_01 [HdAudModel]
+     sto: Installed section names:
+     sto:      HdAudModel
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_9b7a5db27f6d6cbd\hdaudio.inf}
+     inf:      Class GUID     = {4d36e96c-e325-11ce-bfc1-08002be10318}
+     idb:      Driver packages:
+     idb:           hdaudio.inf_amd64_9b7a5db27f6d6cbd (active)
+     idb:           hdaudio.inf_amd64_dab2294dc8af0030
+     inf:      {Configure Driver: High Definition Audio Device}
+     inf:           Section Name = HdAudModel
+     inf:           {Add Service: HdAudAddService}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\HdAudio.sys
+     inf:                Display Name  = Microsoft 1.1 UAA Function Driver for High Definition Audio Service
+     inf:                Updated service 'HdAudAddService'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_9b7a5db27f6d6cbd\HdAudio.sys' to 'C:\Windows\System32\drivers\HdAudio.sys'.
+     idb:      Last driver package 'hdaudio.inf_amd64_dab2294dc8af0030' to copy 'C:\Windows\System32\drivers\HdAudio.sys' needs reconfiguration.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\drmk.sys' to 'C:\Windows\system32\drivers\drmk.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\drmk.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\portcls.sys' to 'C:\Windows\system32\drivers\portcls.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\portcls.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\WMALFXGFXDSP.dll' to 'C:\Windows\system32\WMALFXGFXDSP.dll'.
+     idb:      Last driver package 'wdmaudio.inf_amd64_256ad046a471df0d' to copy 'C:\Windows\system32\WMALFXGFXDSP.dll' needs reconfiguration.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\SysFxUI.dll' to 'C:\Windows\system32\SysFxUI.dll'.
+     cpy:      Existing file 'C:\Windows\system32\SysFxUI.dll' remains unchanged.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'netrtwlane_13.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_8e17ee2826ff2b07\netrtwlane_13.inf}
+     inf:      Class GUID     = {4d36e972-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = Configurable
+     idb:      Driver packages:
+     idb:           netrtwlane_13.inf_amd64_8e17ee2826ff2b07 (active)
+     idb:           netrtwlane_13.inf_amd64_08862ceb4cd44db9
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'netwmbclass.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_ed51114936bfc236\netwmbclass.inf}
+     inf:      Class GUID     = {4d36e972-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = Configurable
+     idb:      Driver packages:
+     idb:           netwmbclass.inf_amd64_ed51114936bfc236 (active)
+     idb:           netwmbclass.inf_amd64_828a7d91ae6b1b6a
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'netrndis.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_609a0bb012179987\netrndis.inf}
+     inf:      Class GUID     = {4d36e972-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = Configurable
+     idb:      Driver packages:
+     idb:           netrndis.inf_amd64_609a0bb012179987 (active)
+     idb:           netrndis.inf_amd64_15559e68f1d2f050
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'prnms003.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_73e8526b6d7c748c\prnms003.inf}
+     inf:      Class GUID     = {4d36e979-e325-11ce-bfc1-08002be10318}
+     idb:      Driver packages:
+     idb:           prnms003.inf_x86_157f2e5194701963
+     idb:           prnms003.inf_x86_c42df827ba78f834
+     idb:           prnms003.inf_amd64_73e8526b6d7c748c (active)
+     idb:           prnms003.inf_amd64_827219ff41f9ea64
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'prnms004.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_dc355e772d68650c\prnms004.inf}
+     inf:      Class GUID     = {4d36e979-e325-11ce-bfc1-08002be10318}
+     idb:      Driver packages:
+     idb:           prnms004.inf_amd64_dc355e772d68650c (active)
+     idb:           prnms004.inf_amd64_8b38d267bd5fdbd9
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'ntprint.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\ntprint.inf}
+     inf:      Class GUID     = {4d36e979-e325-11ce-bfc1-08002be10318}
+     idb:      Driver packages:
+     idb:           ntprint.inf_x86_f9aae5bf86267495
+     idb:           ntprint.inf_x86_08e757f7c012ea27
+     idb:           ntprint.inf_amd64_f9aae5bf86267495 (active)
+     idb:           ntprint.inf_amd64_08e757f7c012ea27
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'ntprint4.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\ntprint4.inf}
+     inf:      Class GUID     = {4d36e979-e325-11ce-bfc1-08002be10318}
+     idb:      Driver packages:
+     idb:           ntprint4.inf_amd64_34fc089922f9b11d (active)
+     idb:           ntprint4.inf_amd64_7373a688eceb5d01
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Skipping non-native x86 driver package 'ntprint.inf' on amd64.
+     sto: Skipping non-native x86 driver package 'prnms003.inf' on amd64.
+     sto: No effective section names for 'ucmucsi.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_86bd71749200d4fb\ucmucsi.inf}
+     inf:      Class GUID     = {36fc9e60-c465-11cf-8056-444553540000}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           ucmucsi.inf_amd64_86bd71749200d4fb (active)
+     idb:           ucmucsi.inf_amd64_836de75251bf9189
+     inf:      {Configure Driver: UCSI USB Connector Manager}
+     inf:           Section Name = UcmUcsi.Install.NT
+     inf:           {Add Service: UcmUcsi}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\UcmUcsi.sys
+     inf:                Display Name  = USB Connector Manager UCSI Client
+     inf:                Dependencies  = UcmCx
+     inf:                Updated service 'UcmUcsi'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = ACPI\USBC000
+     inf:           Compatible Id = ACPI\PNP0CA0
+     inf:           {Configure Driver Configuration: UcmUcsi.Install.NT}
+     inf:                Service Name  = UcmUcsi
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_86bd71749200d4fb\UcmUcsi.sys' to 'C:\Windows\System32\drivers\UcmUcsi.sys'.
+     idb:      Last driver package 'ucmucsi.inf_amd64_836de75251bf9189' to copy 'C:\Windows\System32\drivers\UcmUcsi.sys' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Devices using 'pci.inf':
+     sto:      ACPI\PNP0A03\0 -> *PNP0A03 [PCI_ROOT]
+     sto: Installed section names:
+     sto:      PCI_ROOT
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_61ccd5db98b3abf1\pci.inf}
+     inf:      Class GUID     = {4d36e97d-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           pci.inf_amd64_61ccd5db98b3abf1 (active)
+     idb:           pci.inf_amd64_e13dd3a79d516ff2
+     inf:      {Configure Driver: PCI Bus}
+     inf:           Section Name = PCI_ROOT
+     inf:           {Add Service: pci}
+     inf:                Start Type    = 0
+     inf:                Service Type  = 1
+     inf:                Error Control = 3
+     inf:                Image Path    = System32\drivers\pci.sys
+     inf:                Display Name  = PCI Bus Driver
+     inf:                Group         = Boot Bus Extender
+     inf:                Updated service 'pci'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = *PNP0A03
+     inf:           {Configure Driver Configuration: PCI_ROOT}
+     inf:                Service Name  = pci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: PCI Express Root Complex}
+     inf:           Section Name = PCI_ROOT
+     inf:           Hardware Id  = *PNP0A08
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: PCI-to-PCI Bridge}
+     inf:           Section Name = PCI_BRIDGE
+     inf:           Hardware Id  = PCI\CC_0604
+     inf:           {Configure Driver Configuration: PCI_BRIDGE}
+     inf:                Service Name  = pci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: PCI Express Root Port}
+     inf:           Section Name = PCI_BRIDGE
+     inf:           Hardware Id  = PCI\CC_0604&DT_4
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: PCI Express Upstream Switch Port}
+     inf:           Section Name = PCI_BRIDGE
+     inf:           Hardware Id  = PCI\CC_0604&DT_5
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: PCI Express Downstream Switch Port}
+     inf:           Section Name = PCI_BRIDGE
+     inf:           Hardware Id  = PCI\CC_0604&DT_6
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: PCI Express to PCI/PCI-X Bridge}
+     inf:           Section Name = PCI_BRIDGE
+     inf:           Hardware Id  = PCI\CC_0604&DT_7
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: PCI/PCI-X to PCI Express Bridge}
+     inf:           Section Name = PCI_BRIDGE
+     inf:           Hardware Id  = PCI\CC_0604&DT_8
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: PCI Device Setting}
+     inf:           Section Name = PciIoSpaceNotRequired
+     inf:           {Configure Driver Configuration: PciIoSpaceNotRequired}
+     inf:                No associated service.
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: PCI Device Setting}
+     inf:           Section Name = PciSriovSupported
+     inf:           {Configure Driver Configuration: PciSriovSupported}
+     inf:                No associated service.
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: PCI Device Setting}
+     inf:           Section Name = PciAcsNotRequired
+     inf:           {Configure Driver Configuration: PciAcsNotRequired}
+     inf:                No associated service.
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: PCI Device Setting}
+     inf:           Section Name = PciASPMOptIn
+     inf:           {Configure Driver Configuration: PciASPMOptIn}
+     inf:                No associated service.
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: PCI Device Setting}
+     inf:           Section Name = PciASPMOptOut
+     inf:           {Configure Driver Configuration: PciASPMOptOut}
+     inf:                No associated service.
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: PCI Device Setting}
+     inf:           Section Name = PciD3ColdSupported
+     inf:           {Configure Driver Configuration: PciD3ColdSupported}
+     inf:                No associated service.
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: PCI Device Setting}
+     inf:           Section Name = PciDoNotUseAcs
+     inf:           {Configure Driver Configuration: PciDoNotUseAcs}
+     inf:                No associated service.
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: PCI Device Setting}
+     inf:           Section Name = PciEnableAllBridgeInterrupts
+     inf:           {Configure Driver Configuration: PciEnableAllBridgeInterrupts}
+     inf:                No associated service.
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: PCI Device Setting}
+     inf:           Section Name = PciAtomicsOptIn
+     inf:           {Configure Driver Configuration: PciAtomicsOptIn}
+     inf:                No associated service.
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_61ccd5db98b3abf1\pci.sys' to 'C:\Windows\System32\drivers\pci.sys'.
+     idb:      Last driver package 'pci.inf_amd64_e13dd3a79d516ff2' to copy 'C:\Windows\System32\drivers\pci.sys' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'usbser.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_5de2576d6f02918e\usbser.inf}
+     inf:      Class GUID     = {4d36e978-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = BootCritical
+     idb:      Driver packages:
+     idb:           usbser.inf_amd64_5de2576d6f02918e (active)
+     idb:           usbser.inf_amd64_827db80716f312be
+     inf:      {Configure Driver: USB Serial Device}
+     inf:           Section Name = UsbSerial_Install.NT
+     inf:           {Add Service: usbser}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\usbser.sys
+     inf:                Display Name  = Microsoft USB Serial Driver
+     inf:                Updated service 'usbser'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = USB\Class_02&SubClass_02&Prot_01
+     inf:           {Configure Driver Configuration: UsbSerial_Install.NT}
+     inf:                Service Name  = usbser
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB Serial Device}
+     inf:           Section Name = UsbSerial_Install.NT
+     inf:           Hardware Id  = USB\Class_02&SubClass_02
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_5de2576d6f02918e\usbser.sys' to 'C:\Windows\System32\drivers\usbser.sys'.
+     idb:      Last driver package 'usbser.inf_amd64_827db80716f312be' to copy 'C:\Windows\System32\drivers\usbser.sys' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'stornvme.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_5ffb10fc0bbc4ac0\stornvme.inf}
+     inf:      Class GUID     = {4d36e97b-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           stornvme.inf_amd64_5ffb10fc0bbc4ac0 (active)
+     idb:           stornvme.inf_amd64_701b8d7c698c983a
+     inf:      {Configure Driver: Standard NVM Express Controller}
+     inf:           Section Name = Stornvme_Inst
+     inf:           {Add Service: stornvme}
+     inf:                Start Type    = 0
+     inf:                Service Type  = 1
+     inf:                Error Control = 3
+     inf:                Image Path    = System32\drivers\stornvme.sys
+     inf:                Display Name  = Microsoft Standard NVM Express Driver
+     inf:                Group         = SCSI Miniport
+     inf:                Updated service 'stornvme'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = PCI\CC_010802
+     inf:           {Configure Driver Configuration: Stornvme_Inst}
+     inf:                Service Name  = stornvme
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_5ffb10fc0bbc4ac0\stornvme.sys' to 'C:\Windows\System32\drivers\stornvme.sys'.
+     idb:      Last driver package 'stornvme.inf_amd64_701b8d7c698c983a' to copy 'C:\Windows\System32\drivers\stornvme.sys' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Devices using 'msports.inf':
+     sto:      ACPI\PNP0400\4&e03a844&0 -> *pnp0400 [LptPort.NT]
+     sto: Installed section names:
+     sto:      LptPort.NT
+!    inf: Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 128
+!    inf: Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 133
+!    inf: Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 220
+!    inf: Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 248
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\msports.inf}
+     inf:      Class GUID     = {4d36e978-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = BootCritical
+     idb:      Driver packages:
+     idb:           msports.inf_amd64_46e9747fe38474e5 (active)
+     idb:           msports.inf_amd64_db43c0c39a11ad06
+!    inf:      Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 128
+     inf:      {Configure Driver: Printer Port}
+     inf:           Section Name = LptPort.NT
+     inf:           {Add Service: Parport}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 0
+     inf:                Image Path    = \SystemRoot\System32\drivers\parport.sys
+     inf:                Display Name  = Parallel port driver
+     inf:                Group         = Parallel arbitrator
+     inf:                Updated service 'Parport'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = *PNP0400
+     inf:           {Configure Driver Configuration: LptPort.NT}
+     inf:                Service Name  = Parport
+     inf:                Config Flags  = 0x00000400
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+!    inf:      Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 133
+!    inf:      Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 220
+!    inf:      Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 248
+     inf:      {Configure Driver: ECP Printer Port}
+     inf:           Section Name = EcpPort.NT
+     inf:           Hardware Id  = *PNP0401
+     inf:           {Configure Driver Configuration: EcpPort.NT}
+     inf:                Service Name  = Parport
+     inf:                Config Flags  = 0x00000400
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Communications Port}
+     inf:           Section Name = ComPort.NT
+     inf:           {Add Service: Serial}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 0
+     inf:                Image Path    = \SystemRoot\System32\drivers\serial.sys
+     inf:                Display Name  = Serial port driver
+     inf:                Group         = Extended base
+     inf:                Updated service 'Serial'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           {Add Service: Serenum}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\serenum.sys
+     inf:                Display Name  = Serenum Filter Driver
+     inf:                Group         = PNP Filter
+     inf:                Updated service 'Serenum'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = *PNP0500
+     inf:           Compatible Id = *PNP0501
+     inf:           {Configure Driver Configuration: ComPort.NT}
+     inf:                Service Name  = Serial
+     inf:                Upper Filters = serenum
+     inf:                Config Flags  = 0x00000400
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Communications Port}
+     inf:           Section Name = ComPort.NT
+     inf:           Hardware Id  = *PNP0501
+     inf:           Compatible Id = *PNP0500
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Multiport Communications Port}
+     inf:           Section Name = MultiComPort.NT
+     inf:           Hardware Id  = *PNP0502
+     inf:           {Configure Driver Configuration: MultiComPort.NT}
+     inf:                Service Name  = Serial
+     inf:                Upper Filters = serenum
+     inf:                Config Flags  = 0x00000400
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Communications Port}
+     inf:           Section Name = ComPort.NT
+     inf:           Hardware Id  = *CPQA0D9
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: HP Communications Port}
+     inf:           Section Name = ComPort.NT
+     inf:           Hardware Id  = MF\EISA_HWP1C10_DEV0
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Socket PCMCIA Serial Adapter}
+     inf:           Section Name = ComPort.NT
+     inf:           Hardware Id  = PCMCIA\SOCKET_COMMUNICATIONS_INC-SOCKET_IO_PCMCIA_SERIAL_PORT_ADAPTER_REVISION_A-0484
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Socket PCMCIA Serial Adapter}
+     inf:           Section Name = ComPort.NT
+     inf:           Hardware Id  = PCMCIA\SOCKET_COMMUNICATIONS_INC-SOCKET_IO_PCMCIA_SERIAL_PORT_ADAPTER_REVISION_B-12F8
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Socket PCMCIA Serial Adapter}
+     inf:           Section Name = ComPort.NT
+     inf:           Hardware Id  = PCMCIA\Socket_Communications_Inc-Serial_Port_Adapter_Revision_B-5E3E
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Socket PCMCIA Serial Device}
+     inf:           Section Name = ComPort.NT
+     inf:           Hardware Id  = MF\SOCKETDUAL_DEV0
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Socket PCMCIA Serial Device}
+     inf:           Section Name = ComPort.NT
+     inf:           Hardware Id  = MF\SOCKETDUAL_DEV1
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Socket PCMCIA Serial Adapter}
+     inf:           Section Name = ComPort.NT
+     inf:           Hardware Id  = PCMCIA\socket-serial_port_card_rev_2.3-e88f
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Socket PCMCIA PageCard V3.0}
+     inf:           Section Name = NonPort.NT
+     inf:           Hardware Id  = PCMCIA\SOCKET_COMMUNICATIONS_INC-PAGECARD_REVISION_A-FA29
+     inf:           {Configure Driver Configuration: NonPort.NT}
+     inf:                No associated service.
+     inf:                Config Flags  = 0x00000400
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Socket PCMCIA GPS Adapter (Rev. B)}
+     inf:           Section Name = NonPort.NT
+     inf:           Hardware Id  = PCMCIA\SOCKET_COMMUNICATIONS_INC-SOCKET_GPS_PCMCIA_GLOBAL_POSITIONING_SYSTEM_REVISION_B-AF8A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Socket PCMCIA GPS Adapter (Rev. C)}
+     inf:           Section Name = NonPort.NT
+     inf:           Hardware Id  = PCMCIA\SOCKET_COMMUNICATIONS_INC-MOBILE_GPS_REVISION_C-66D0
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: DBC SignalCard}
+     inf:           Section Name = NonPort.NT
+     inf:           Hardware Id  = PCMCIA\DATA_BROADCASTING_CORP-SIGNALCARD_RECEIVER-4E9B
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Rockwell NavCard}
+     inf:           Section Name = NonPort.NT
+     inf:           Hardware Id  = PCMCIA\ROCKWELL-NAVCARD-64B7
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Trimble PCMCIA GPS Adapter (Rev. B)}
+     inf:           Section Name = NonPort.NT
+     inf:           Hardware Id  = PCMCIA\TRIMBLE_&_SOCKET_COMMUNICATIONS_INC-MOBILE_GPS_REVISION_B-6947
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SMART Serial Port}
+     inf:           Section Name = ComPort.NT
+     inf:           Hardware Id  = PCMCIA\SMART_SERIAL_PORT-A0F6
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SIIG CyberSerial Card}
+     inf:           Section Name = ComPort.NT
+     inf:           Hardware Id  = PCI\VEN_131F&DEV_1000&SUBSYS_00000000&REV_02
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SIIG CyberSerial Card}
+     inf:           Section Name = ComPort.NT
+     inf:           Hardware Id  = PCI\VEN_131F&DEV_2000&CC_0700
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Ericsson GC25}
+     inf:           Section Name = ComPort.NT
+     inf:           Hardware Id  = PCMCIA\ERICSSON-GC25-8C66
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Compaq GSM Radio Card}
+     inf:           Section Name = ComPort.NT
+     inf:           Hardware Id  = PCMCIA\COMPAQ-SPEEDPAQ_GSM_RADIO_PC_CARD-6D6C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Quatech Q-Lynx Serial Adapter}
+     inf:           Section Name = ComPort.NT
+     inf:           Hardware Id  = PCMCIA\Quatech_Inc-PCMCIA_RS-232_Serial_Port_Card-63EA
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\parport.sys' to 'C:\Windows\System32\drivers\parport.sys'.
+     cpy:      Existing file 'C:\Windows\System32\drivers\parport.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\serial.sys' to 'C:\Windows\System32\drivers\serial.sys'.
+     idb:      Last driver package 'msports.inf_amd64_db43c0c39a11ad06' to copy 'C:\Windows\System32\drivers\serial.sys' needs reconfiguration.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\serenum.sys' to 'C:\Windows\System32\drivers\serenum.sys'.
+     cpy:      Existing file 'C:\Windows\System32\drivers\serenum.sys' remains unchanged.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'buttonconverter.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_b210406b0d8c4695\buttonconverter.inf}
+     inf:      Class GUID     = {745a17a0-74d3-11d0-b6fe-00a0c90f57da}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           buttonconverter.inf_amd64_b210406b0d8c4695 (active)
+     idb:           buttonconverter.inf_amd64_3e28164cce51d5a9
+     inf:      {Configure Driver: Portable Device Control device}
+     inf:           Section Name = btnconv.NT
+     inf:           {Add Service: buttonconverter}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\buttonconverter.sys
+     inf:                Display Name  = Service for Portable Device Control devices
+     inf:                Updated service 'buttonconverter'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = HID_DEVICE_UP:0001_U:000d
+     inf:           {Configure Driver Configuration: btnconv.NT}
+     inf:                Service Name  = buttonconverter
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Converted Portable Device Control device}
+     inf:           Section Name = btnconv_converted.NT
+     inf:           {Add Service: mshidkmdf}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 0
+     inf:                Image Path    = \SystemRoot\System32\drivers\mshidkmdf.sys
+     inf:                Updated service 'mshidkmdf'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = ButtonConverter\ConvertedDevice
+     inf:           {Configure Driver Configuration: btnconv_converted.NT}
+     inf:                Service Name  = mshidkmdf
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: ButtonConverter Raw Device}
+     inf:           Section Name = btnconv_raw.NT
+     inf:           Hardware Id  = ButtonConverter\RawDevice
+     inf:           {Configure Driver Configuration: btnconv_raw.NT}
+     inf:                Service Name  = <none>
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_b210406b0d8c4695\buttonconverter.sys' to 'C:\Windows\System32\drivers\buttonconverter.sys'.
+     idb:      Last driver package 'buttonconverter.inf_amd64_3e28164cce51d5a9' to copy 'C:\Windows\System32\drivers\buttonconverter.sys' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Driver update 'mrvlpcie8897.inf' is already reflected.
+     sto: No effective section names for 'vhdmp.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_b486fbf51614c321\vhdmp.inf}
+     inf:      Class GUID     = {4d36e97b-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           vhdmp.inf_amd64_b486fbf51614c321 (active)
+     idb:           vhdmp.inf_amd64_33db47aeb773aeab
+     inf:      {Configure Driver: Microsoft VHD Loopback Controller}
+     inf:           Section Name = vhdmp_inst
+     inf:           {Add Service: vhdmp}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\vhdmp.sys
+     inf:                Group         = SCSI miniport
+     inf:                Updated service 'vhdmp'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = {8e7bd593-6e6c-4c52-86a6-77175494dd8e}\MsVhdHba
+     inf:           {Configure Driver Configuration: vhdmp_inst}
+     inf:                Service Name  = vhdmp
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_b486fbf51614c321\vhdmp.sys' to 'C:\Windows\System32\drivers\vhdmp.sys'.
+     idb:      Last driver package 'vhdmp.inf_amd64_33db47aeb773aeab' to copy 'C:\Windows\System32\drivers\vhdmp.sys' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'msgpiowin32.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_4563c8367012234f\msgpiowin32.inf}
+     inf:      Class GUID     = {745a17a0-74d3-11d0-b6fe-00a0c90f57da}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           msgpiowin32.inf_amd64_4563c8367012234f (active)
+     idb:           msgpiowin32.inf_amd64_a183375586623a76
+     inf:      {Configure Driver: GPIO Buttons Driver}
+     inf:           Section Name = GPIO_Inst.NT
+     inf:           {Add Service: msgpiowin32}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\msgpiowin32.sys
+     inf:                Display Name  = Common Driver for Buttons, DockMode and Laptop/Slate Indicator
+     inf:                Group         = Extended Base
+     inf:                Updated service 'msgpiowin32'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = PNP0C40
+     inf:           {Configure Driver Configuration: GPIO_Inst.NT}
+     inf:                Service Name  = msgpiowin32
+     inf:                Upper Filters = mshidkmdf
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: GPIO Laptop or Slate Indicator Driver}
+     inf:           Section Name = GPIO_Inst_Sensors.NT
+     inf:           Hardware Id  = PNP0C60
+     inf:           {Configure Driver Configuration: GPIO_Inst_Sensors.NT}
+     inf:                Service Name  = msgpiowin32
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: GPIO Dock Mode Indicator Driver}
+     inf:           Section Name = GPIO_Inst_Sensors.NT
+     inf:           Hardware Id  = PNP0C70
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Sideband GPIO Buttons Injection Device}
+     inf:           Section Name = GPIO_Inst_Injection.NT
+     inf:           Hardware Id  = {30ebfbf8-df5f-4d4d-9fc5-a26c7fd1df4a}\GPIO_Buttons
+     inf:           {Configure Driver Configuration: GPIO_Inst_Injection.NT}
+     inf:                Service Name  = <none>
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_4563c8367012234f\msgpiowin32.sys' to 'C:\Windows\System32\drivers\msgpiowin32.sys'.
+     idb:      Last driver package 'msgpiowin32.inf_amd64_a183375586623a76' to copy 'C:\Windows\System32\drivers\msgpiowin32.sys' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'wpdmtp.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\wpdmtp.inf}
+     inf:      Class GUID     = {eec5ad98-8080-425f-922a-dabf3de3f69a}
+     idb:      Driver packages:
+     idb:           wpdmtp.inf_amd64_5bffa673ab8cb4d4 (active)
+     idb:           wpdmtp.inf_amd64_bc644fccce0afbb3
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'tsusbhub.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_b01c6baade1c797a\tsusbhub.inf}
+     inf:      Class GUID     = {4d36e97d-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           tsusbhub.inf_amd64_b01c6baade1c797a (active)
+     idb:           tsusbhub.inf_amd64_35185b4c0664e5a3
+     inf:      {Configure Driver: Remote Desktop USB Hub}
+     inf:           Section Name = TsUsbHubXDynamicBus_Device.NT
+     inf:           {Add Service: tsusbhub}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\tsusbhub.sys
+     inf:                Display Name  = Remote Desktop USB Hub
+     inf:                Group         = Extended Base
+     inf:                Updated service 'tsusbhub'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = root\tsusbhub
+     inf:           {Configure Driver Configuration: TsUsbHubXDynamicBus_Device.NT}
+     inf:                Service Name  = tsusbhub
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Remote Desktop USB Hub}
+     inf:           Section Name = TsUsbHubXDynamicBus_Device.NT
+     inf:           Hardware Id  = UMB\TS_URB_HUB
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_b01c6baade1c797a\tsusbhub.sys' to 'C:\Windows\System32\drivers\tsusbhub.sys'.
+     idb:      Last driver package 'tsusbhub.inf_amd64_35185b4c0664e5a3' to copy 'C:\Windows\System32\drivers\tsusbhub.sys' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: {Update Device Drivers: miradisp.inf} 22:39:49.496
+     sto:      Driver Version = 6/21/2006,10.0.10240.16394
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.496
+     sto: {Update Device Drivers: hidscanner.inf} 22:39:49.496
+     sto:      Driver Version = 6/21/2006,10.0.10240.16732
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.516
+     sto: {Update Device Drivers: xusb22.inf} 22:39:49.516
+     sto:      Driver Version = 9/6/2016,10.0.10240.17113
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.516
+     sto: {Update Device Drivers: acpi.inf} 22:39:49.516
+     sto:      Driver Version = 6/21/2006,10.0.10240.16397
+     sto:      {Update Device: ACPI_HAL\PNP0C08\0}
+     sto:           Updating installed driver version:
+     sto:                Driver Version Last     = 6/21/2006,10.0.10240.16384
+     sto:                Driver Version New      = 6/21/2006,10.0.10240.16397
+     sto:                Driver Node Strong Name = acpi.inf:db04a16ce10b0c38:ACPI_Inst.NT:10.0.10240.16397:*PNP0C08
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      Updated drivers for 1 device node.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.528
+     sto: {Update Device Drivers: wfcvsc.inf} 22:39:49.528
+     sto:      Driver Version = 6/21/2006,10.0.10240.17113
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.528
+     sto: {Update Device Drivers: sensorshidclassdriver.inf} 22:39:49.528
+     sto:      Driver Version = 4/21/2009,10.0.10240.16515
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.528
+     sto: {Update Device Drivers: bth.inf} 22:39:49.528
+     sto:      Driver Version = 6/21/2006,10.0.10240.16515
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.544
+     sto: {Update Device Drivers: bthleenum.inf} 22:39:49.544
+     sto:      Driver Version = 6/21/2006,10.0.10240.16766
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.544
+     sto: {Update Device Drivers: genericusbfn.inf} 22:39:49.544
+     sto:      Driver Version = 9/6/2016,10.0.10240.17113
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.544
+     sto: {Update Device Drivers: usbstor.inf} 22:39:49.544
+     sto:      Driver Version = 6/21/2006,10.0.10240.16732
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.544
+     sto: {Update Device Drivers: usbport.inf} 22:39:49.544
+     sto:      Driver Version = 6/21/2006,10.0.10240.16542
+     sto:      {Update Device: PCI\VEN_106B&DEV_003F&SUBSYS_00000000&REV_00\3&267a616a&1&30}
+     sto:           Updating installed driver version:
+     sto:                Driver Version Last     = 6/21/2006,10.0.10240.16384
+     sto:                Driver Version New      = 6/21/2006,10.0.10240.16542
+     sto:                Driver Node Strong Name = usbport.inf:392c3d531fddeb19:OHCI.Dev.NT:10.0.10240.16542:PCI\CC_0C0310
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      {Update Device: PCI\VEN_8086&DEV_265C&SUBSYS_00000000&REV_00\3&267a616a&1&58}
+     sto:           Updating installed driver version:
+     sto:                Driver Version Last     = 6/21/2006,10.0.10240.16384
+     sto:                Driver Version New      = 6/21/2006,10.0.10240.16542
+     sto:                Driver Node Strong Name = usbport.inf:ddfda09403aa9831:EHCI.Dev.NT:10.0.10240.16542:PCI\VEN_8086&DEV_265C
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      {Update Device: USB\ROOT_HUB\4&159a73f4&0}
+     sto:           Updating installed driver version:
+     sto:                Driver Version Last     = 6/21/2006,10.0.10240.16384
+     sto:                Driver Version New      = 6/21/2006,10.0.10240.16542
+     sto:                Driver Node Strong Name = usbport.inf:392c3d536976a1f4:ROOTHUB.Dev.NT:10.0.10240.16542:USB\ROOT_HUB
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      {Update Device: USB\ROOT_HUB20\4&3749a296&0}
+     sto:           Updating installed driver version:
+     sto:                Driver Version Last     = 6/21/2006,10.0.10240.16384
+     sto:                Driver Version New      = 6/21/2006,10.0.10240.16542
+     sto:                Driver Node Strong Name = usbport.inf:392c3d536976a1f4:ROOTHUB.Dev.NT:10.0.10240.16542:USB\ROOT_HUB20
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      Updated drivers for 4 device nodes.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.578
+     sto: {Update Device Drivers: usbhub3.inf} 22:39:49.578
+     sto:      Driver Version = 11/24/2015,10.0.10240.16603
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.578
+     sto: {Update Device Drivers: usbxhci.inf} 22:39:49.578
+     sto:      Driver Version = 8/17/2015,10.0.10240.16461
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.578
+     sto: {Update Device Drivers: sdbus.inf} 22:39:49.578
+     sto:      Driver Version = 6/21/2006,10.0.10240.16515
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.596
+     sto: {Update Device Drivers: mdmbtmdm.inf} 22:39:49.596
+     sto:      Driver Version = 6/21/2006,10.0.10240.16515
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.596
+     sto: {Update Device Drivers: bthaudhid.inf} 22:39:49.596
+     sto:      Driver Version = 9/6/2016,10.0.10240.17113
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.596
+     sto: {Update Device Drivers: bthhfenum.inf} 22:39:49.611
+     sto:      Driver Version = 7/29/2015,10.0.10240.16412
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.611
+     sto: {Update Device Drivers: wudfusbcciddriver.inf} 22:39:49.611
+     sto:      Driver Version = 6/21/2006,10.0.10240.16942
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.611
+     sto: {Update Device Drivers: hdaudbus.inf} 22:39:49.611
+     sto:      Driver Version = 9/6/2016,10.0.10240.17113
+     sto:      {Update Device: PCI\VEN_8086&DEV_2668&SUBSYS_76808384&REV_01\3&267a616a&1&28}
+     sto:           Updating installed driver version:
+     sto:                Driver Version Last     = 7/9/2015,10.0.10240.16384
+     sto:                Driver Version New      = 9/6/2016,10.0.10240.17113
+     sto:                Driver Node Strong Name = hdaudbus.inf:db04a16c28a36625:HDAudio_Device.NT:10.0.10240.17113:PCI\CC_0403
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      Updated drivers for 1 device node.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.611
+     sto: {Update Device Drivers: wdmaudio.inf} 22:39:49.611
+     sto:      Driver Version = 1/4/2016,10.0.10240.16644
+     sto:      {Update Device: HDAUDIO\FUNC_01&VEN_8384&DEV_7680&SUBSYS_83847680&REV_1034\4&22a99211&0&0001}
+     sto:           Using driver package 'hdaudio.inf' that includes 'wdmaudio.inf'.
+     sto:           {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_9b7a5db27f6d6cbd\hdaudio.inf}
+     inf:                Class GUID     = {4d36e96c-e325-11ce-bfc1-08002be10318}
+     inf:                {Configure Driver: High Definition Audio Device}
+     inf:                     Section Name = HdAudModel
+     inf:                {Configure Driver: exit(0x00000000)}
+     flq:                Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\drmk.sys' to 'C:\Windows\system32\drivers\drmk.sys'.
+     cpy:                Existing file 'C:\Windows\system32\drivers\drmk.sys' remains unchanged.
+     flq:                Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\portcls.sys' to 'C:\Windows\system32\drivers\portcls.sys'.
+     cpy:                Existing file 'C:\Windows\system32\drivers\portcls.sys' remains unchanged.
+     flq:                Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\WMALFXGFXDSP.dll' to 'C:\Windows\system32\WMALFXGFXDSP.dll'.
+     cpy:                Existing file 'C:\Windows\system32\WMALFXGFXDSP.dll' remains unchanged.
+     flq:                Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\SysFxUI.dll' to 'C:\Windows\system32\SysFxUI.dll'.
+     cpy:                Existing file 'C:\Windows\system32\SysFxUI.dll' remains unchanged.
+     sto:           {Reflect Driver Package: exit(0x00000000)}
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      {Update Device: PCI\VEN_8086&DEV_2668&SUBSYS_76808384&REV_01\3&267a616a&1&28}
+     sto:           Using driver package 'hdaudbus.inf' that includes 'wdmaudio.inf'.
+     sto:           {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_3a98a84dd82f9b0a\hdaudbus.inf}
+     inf:                Class GUID     = {4d36e97d-e325-11ce-bfc1-08002be10318}
+     inf:                Class Options  = Configurable BootCritical
+     inf:                {Configure Driver: High Definition Audio Controller}
+     inf:                     Section Name = HDAudio_Device.NT
+     inf:                     Hardware Id  = PCI\CC_0403
+     inf:                     {Configure Driver Configuration: HDAudio_Device.NT}
+     inf:                          Service Name  = HDAudBus
+     inf:                          Included INFs = wdmaudio.inf
+     inf:                          Config Flags  = 0x00000000
+     inf:                     {Configure Driver Configuration: exit(0x00000000)}
+     inf:                {Configure Driver: exit(0x00000000)}
+     inf:                {Configure Driver: High Definition Audio Controller}
+     inf:                     Section Name = HDAudio_Device.NT
+     inf:                     Hardware Id  = ACPI\CLS_0004&SUBCLS_0003
+     inf:                {Configure Driver: exit(0x00000000)}
+     flq:                Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\drmk.sys' to 'C:\Windows\system32\drivers\drmk.sys'.
+     cpy:                Existing file 'C:\Windows\system32\drivers\drmk.sys' remains unchanged.
+     flq:                Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\portcls.sys' to 'C:\Windows\system32\drivers\portcls.sys'.
+     cpy:                Existing file 'C:\Windows\system32\drivers\portcls.sys' remains unchanged.
+     sto:           {Reflect Driver Package: exit(0x00000000)}
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      Updated drivers for 2 device nodes.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.796
+     sto: {Update Device Drivers: hdaudio.inf} 22:39:49.796
+     sto:      Driver Version = 9/6/2016,10.0.10240.17113
+     sto:      {Update Device: HDAUDIO\FUNC_01&VEN_8384&DEV_7680&SUBSYS_83847680&REV_1034\4&22a99211&0&0001}
+     sto:           Updating installed driver version:
+     sto:                Driver Version Last     = 7/9/2015,10.0.10240.16384
+     sto:                Driver Version New      = 9/6/2016,10.0.10240.17113
+     sto:                Driver Node Strong Name = hdaudio.inf:db04a16ce4e8d6ee:HdAudModel:10.0.10240.17113:hdaudio\func_01
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      Updated drivers for 1 device node.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.812
+     sto: {Update Device Drivers: netrtwlane_13.inf} 22:39:49.812
+     sto:      Driver Version = 12/18/2014,2013.12.1117.2014
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.826
+     sto: {Update Device Drivers: netwmbclass.inf} 22:39:49.826
+     sto:      Driver Version = 7/16/2015,10.0.10240.16392
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.826
+     sto: {Update Device Drivers: netrndis.inf} 22:39:49.826
+     sto:      Driver Version = 6/21/2006,10.0.10240.16732
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.826
+     sto: {Update Device Drivers: prnms003.inf} 22:39:49.826
+     sto:      Driver Version = 6/21/2006,10.0.10240.17113
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.846
+     sto: {Update Device Drivers: prnms004.inf} 22:39:49.846
+     sto:      Driver Version = 6/21/2006,10.0.10240.17113
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.846
+     sto: {Update Device Drivers: ntprint.inf} 22:39:49.846
+     sto:      Driver Version = 6/21/2006,10.0.10240.17113
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.846
+     sto: {Update Device Drivers: ntprint4.inf} 22:39:49.846
+     sto:      Driver Version = 6/21/2006,10.0.10240.17113
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.846
+     sto: {Update Device Drivers: ucmucsi.inf} 22:39:49.846
+     sto:      Driver Version = 6/21/2006,10.0.10240.16389
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.846
+     sto: {Update Device Drivers: pci.inf} 22:39:49.846
+     sto:      Driver Version = 6/21/2006,10.0.10240.16942
+     sto:      {Update Device: ACPI\PNP0A03\0}
+     sto:           Updating installed driver version:
+     sto:                Driver Version Last     = 6/21/2006,10.0.10240.16384
+     sto:                Driver Version New      = 6/21/2006,10.0.10240.16942
+     sto:                Driver Node Strong Name = pci.inf:4ac8f80c40d32231:PCI_ROOT:10.0.10240.16942:*PNP0A03
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      Updated drivers for 1 device node.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.864
+     sto: {Update Device Drivers: usbser.inf} 22:39:49.864
+     sto:      Driver Version = 6/21/2006,10.0.10240.16732
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.864
+     sto: {Update Device Drivers: stornvme.inf} 22:39:49.864
+     sto:      Driver Version = 6/21/2006,10.0.10240.16431
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.864
+     sto: {Update Device Drivers: msports.inf} 22:39:49.864
+     sto:      Driver Version = 6/21/2006,10.0.10240.16732
+!    inf:      Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 128
+!    inf:      Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 133
+!    inf:      Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 220
+!    inf:      Legacy directive 'LogConfig' will be ignored. Code = 2222, Line = 248
+     sto:      {Update Device: ACPI\PNP0400\4&e03a844&0}
+     sto:           Updating installed driver version:
+     sto:                Driver Version Last     = 6/21/2006,10.0.10240.16384
+     sto:                Driver Version New      = 6/21/2006,10.0.10240.16732
+     sto:                Driver Node Strong Name = msports.inf:10809047c11708a1:LptPort:10.0.10240.16732:*pnp0400
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      Updated drivers for 1 device node.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.880
+     sto: {Update Device Drivers: buttonconverter.inf} 22:39:49.880
+     sto:      Driver Version = 6/21/2006,10.0.10240.16515
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.880
+     sto: {Update Device Drivers: vhdmp.inf} 22:39:49.880
+     sto:      Driver Version = 6/21/2006,10.0.10240.17113
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.880
+     sto: {Update Device Drivers: msgpiowin32.inf} 22:39:49.880
+     sto:      Driver Version = 6/21/2006,10.0.10240.16425
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.896
+     sto: {Update Device Drivers: wpdmtp.inf} 22:39:49.896
+     sto:      Driver Version = 6/21/2006,10.0.10240.16431
+!    inf:      Legacy directive 'RegisterDlls' will be ignored. Code = 2222, Line = 109
+!    inf:      Legacy directive 'RegisterDlls' will be ignored. Code = 2222, Line = 190
+!    inf:      Legacy directive 'RegisterDlls' will be ignored. Code = 2222, Line = 217
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.896
+     sto: {Update Device Drivers: tsusbhub.inf} 22:39:49.896
+     sto:      Driver Version = 6/21/2006,10.0.10240.16732
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:39:49.896
+<<<  Section end 2016/10/09 22:39:49.896
+<<<  [Exit status: SUCCESS (REBOOT_REQUIRED)]
+
+
+[Boot Session: 2016/10/11 22:52:38.490]
+
+>>>  [Enable Device Install]
+>>>  Section start 2016/10/11 22:53:36.647
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     ump: DeviceInstall service is not started.
+<<<  Section end 2016/10/11 22:53:36.798
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Enable Device Install]
+>>>  Section start 2016/10/11 22:54:23.171
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     ump: DeviceInstall service is not disabled.
+     ump: DeviceInstall service is not started.
+<<<  Section end 2016/10/11 22:54:23.171
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Device Installation Restrictions Policy Check]
+>>>  Section start 2016/10/11 22:54:34.991
+<<<  Section end 2016/10/11 22:54:34.991
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Disable Device Install]
+>>>  Section start 2016/10/12 03:32:05.173
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     ump: DeviceInstall service is not started.
+<<<  Section end 2016/10/12 03:32:05.189
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Stage Driver Updates]
+>>>  Section start 2016/10/12 03:32:05.861
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 41
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_miradisp.inf_31bf3856ad364e35_10.0.10240.16394_none_65e15c6ab1574881\miradisp.inf} 03:32:06.236
+!    sto:      Driver package already imported as 'miradisp.inf' (C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_01ce808b39cab47d\miradisp.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.584
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_hidscanner.inf_31bf3856ad364e35_10.0.10240.16732_none_1347b790e8468683\hidscanner.inf} 03:32:06.584
+!    sto:      Driver package already imported as 'hidscanner.inf' (C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_a4bdb031f38afa10\hidscanner.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.584
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_xusb22.inf_31bf3856ad364e35_10.0.10240.17146_none_adcafa0ea7fce768\xusb22.inf} 03:32:06.584
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_xusb22.inf_31bf3856ad364e35_10.0.10240.17146_none_adcafa0ea7fce768\xusb22.inf} 03:32:06.584
+     inf:           Driver package 'xusb22.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 03:32:06.598
+     sto:      {DRIVERSTORE IMPORT BEGIN} 03:32:06.598
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 03:32:06.598
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_xusb22.inf_31bf3856ad364e35_10.0.10240.17146_none_adcafa0ea7fce768\x64\xusb22.sys' to 'C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_519ad1a6701b5cab\x64\xusb22.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_xusb22.inf_31bf3856ad364e35_10.0.10240.17146_none_adcafa0ea7fce768\xusb22.inf' to 'C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_519ad1a6701b5cab\xusb22.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_519ad1a6701b5cab\xusb22.inf} 03:32:06.627
+     idb:           Created driver package object 'xusb22.inf_amd64_519ad1a6701b5cab' in DRIVERS database node.
+     idb:           Driver INF file object 'xusb22.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'xusb22.inf_amd64_519ad1a6701b5cab' with 'xusb22.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 03:32:06.627
+     sto:      {DRIVERSTORE IMPORT END} 03:32:06.627
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 03:32:06.627
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.627
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_acpi.inf_31bf3856ad364e35_10.0.10240.16397_none_2a89249c68b52b02\acpi.inf} 03:32:06.627
+!    sto:      Driver package already imported as 'acpi.inf' (C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_19a61be22ae9944e\acpi.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.627
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_wfcvsc.inf_31bf3856ad364e35_10.0.10240.17146_none_75ab0fa805eb452a\wfcvsc.inf} 03:32:06.643
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_wfcvsc.inf_31bf3856ad364e35_10.0.10240.17146_none_75ab0fa805eb452a\wfcvsc.inf} 03:32:06.643
+     inf:           Driver package is fully isolated.
+     inf:           Driver package 'wfcvsc.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 03:32:06.643
+     sto:      {DRIVERSTORE IMPORT BEGIN} 03:32:06.643
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 03:32:06.643
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wfcvsc.inf_31bf3856ad364e35_10.0.10240.17146_none_75ab0fa805eb452a\fcvsc.sys' to 'C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_4b9b5d5319497dd4\fcvsc.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_wfcvsc.inf_31bf3856ad364e35_10.0.10240.17146_none_75ab0fa805eb452a\wfcvsc.inf' to 'C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_4b9b5d5319497dd4\wfcvsc.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_4b9b5d5319497dd4\wfcvsc.inf} 03:32:06.643
+     idb:           Created driver package object 'wfcvsc.inf_amd64_4b9b5d5319497dd4' in SYSTEM database node.
+     idb:           Driver INF file object 'wfcvsc.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'wfcvsc.inf_amd64_4b9b5d5319497dd4' with 'wfcvsc.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 03:32:06.689
+     sto:      {DRIVERSTORE IMPORT END} 03:32:06.689
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 03:32:06.689
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.689
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_sensorshidclassdriver.inf_31bf3856ad364e35_10.0.10240.16515_none_b200461c595346c5\sensorshidclassdriver.inf} 03:32:06.689
+!    sto:      Driver package already imported as 'sensorshidclassdriver.inf' (C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_57265cb2d2642968\sensorshidclassdriver.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.689
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_bth.inf_31bf3856ad364e35_10.0.10240.16515_none_7a47d7dc563bfea7\bth.inf} 03:32:06.689
+!    sto:      Driver package already imported as 'bth.inf' (C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\bth.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.689
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_bthleenum.inf_31bf3856ad364e35_10.0.10240.16766_none_93c33ffcf31d8bb1\bthleenum.inf} 03:32:06.689
+!    sto:      Driver package already imported as 'bthleenum.inf' (C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_0dabadc4461923c4\bthleenum.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.689
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_genericusbfn.inf_31bf3856ad364e35_10.0.10240.17146_none_bd77d9655793cf61\genericusbfn.inf} 03:32:06.689
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_genericusbfn.inf_31bf3856ad364e35_10.0.10240.17146_none_bd77d9655793cf61\genericusbfn.inf} 03:32:06.708
+     inf:           Driver package 'genericusbfn.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 03:32:06.708
+     sto:      {DRIVERSTORE IMPORT BEGIN} 03:32:06.708
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 03:32:06.708
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_genericusbfn.inf_31bf3856ad364e35_10.0.10240.17146_none_bd77d9655793cf61\genericusbfn.inf' to 'C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_221654d9bb6545af\genericusbfn.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_genericusbfn.inf_31bf3856ad364e35_10.0.10240.17146_none_bd77d9655793cf61\genericusbfn.sys' to 'C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_221654d9bb6545af\genericusbfn.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_221654d9bb6545af\genericusbfn.inf} 03:32:06.720
+     idb:           Created driver package object 'genericusbfn.inf_amd64_221654d9bb6545af' in SYSTEM database node.
+     idb:           Driver INF file object 'genericusbfn.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'genericusbfn.inf_amd64_221654d9bb6545af' with 'genericusbfn.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 03:32:06.752
+     sto:      {DRIVERSTORE IMPORT END} 03:32:06.752
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 03:32:06.752
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.752
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_usbstor.inf_31bf3856ad364e35_10.0.10240.16732_none_508b2fa9327c50d0\usbstor.inf} 03:32:06.752
+!    sto:      Driver package already imported as 'usbstor.inf' (C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_2780d7dc6ecda26e\usbstor.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.768
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.16542_none_c5c529099e38bdd6\usbport.inf} 03:32:06.768
+!    sto:      Driver package already imported as 'usbport.inf' (C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbport.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.768
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_usbhub3.inf_31bf3856ad364e35_10.0.10240.16603_none_fde4a6eee7af98e3\usbhub3.inf} 03:32:06.768
+!    sto:      Driver package already imported as 'usbhub3.inf' (C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_caa57285880769f4\usbhub3.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.768
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_usbxhci.inf_31bf3856ad364e35_10.0.10240.16461_none_28328d049912952d\usbxhci.inf} 03:32:06.768
+!    sto:      Driver package already imported as 'usbxhci.inf' (C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_7b59c1e1fa52c844\usbxhci.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.768
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_sdbus.inf_31bf3856ad364e35_10.0.10240.16515_none_79e5d0646501d8ec\sdbus.inf} 03:32:06.768
+!    sto:      Driver package already imported as 'sdbus.inf' (C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_b33128a95ba9fe0b\sdbus.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.768
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_mdmbtmdm.inf_31bf3856ad364e35_10.0.10240.16515_none_f5a6e1bb2609bdc5\mdmbtmdm.inf} 03:32:06.768
+!    sto:      Driver package already imported as 'mdmbtmdm.inf' (C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_57032036ac5b3f02\mdmbtmdm.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.768
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_bthaudhid.inf_31bf3856ad364e35_10.0.10240.17146_none_1beaef47e191cb33\bthaudhid.inf} 03:32:06.768
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_bthaudhid.inf_31bf3856ad364e35_10.0.10240.17146_none_1beaef47e191cb33\bthaudhid.inf} 03:32:06.830
+     inf:           Driver package 'bthaudhid.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 03:32:06.830
+     sto:      {DRIVERSTORE IMPORT BEGIN} 03:32:06.830
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 03:32:06.830
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bthaudhid.inf_31bf3856ad364e35_10.0.10240.17146_none_1beaef47e191cb33\BthhfHid.sys' to 'C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_47034a2e2794f3b2\BthhfHid.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bthaudhid.inf_31bf3856ad364e35_10.0.10240.17146_none_1beaef47e191cb33\bthaudhid.inf' to 'C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_47034a2e2794f3b2\bthaudhid.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_bthaudhid.inf_31bf3856ad364e35_10.0.10240.17146_none_1beaef47e191cb33\BthAvrcpTg.sys' to 'C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_47034a2e2794f3b2\BthAvrcpTg.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_47034a2e2794f3b2\bthaudhid.inf} 03:32:06.860
+     idb:           Created driver package object 'bthaudhid.inf_amd64_47034a2e2794f3b2' in SYSTEM database node.
+     idb:           Driver INF file object 'bthaudhid.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'bthaudhid.inf_amd64_47034a2e2794f3b2' with 'bthaudhid.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 03:32:06.860
+     sto:      {DRIVERSTORE IMPORT END} 03:32:06.860
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 03:32:06.860
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.860
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_bthhfenum.inf_31bf3856ad364e35_10.0.10240.16412_none_b2ef11ef014f9a50\bthhfenum.inf} 03:32:06.860
+!    sto:      Driver package already imported as 'bthhfenum.inf' (C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_06170919fa54ed29\bthhfenum.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.860
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_wudfusbcciddriver.inf_31bf3856ad364e35_10.0.10240.16942_none_6a807a679c5c43fe\wudfusbcciddriver.inf} 03:32:06.860
+!    sto:      Driver package already imported as 'wudfusbcciddriver.inf' (C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_dcc0445e956fcf69\wudfusbcciddriver.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:06.860
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_hdaudio.inf_31bf3856ad364e35_10.0.10240.17146_none_1d5435ea0226d0ec\hdaudio.inf} 03:32:06.877
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_hdaudio.inf_31bf3856ad364e35_10.0.10240.17146_none_1d5435ea0226d0ec\hdaudio.inf} 03:32:06.985
+     inf:           Driver package 'hdaudio.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 03:32:07.001
+     sto:      {DRIVERSTORE IMPORT BEGIN} 03:32:07.001
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 03:32:07.001
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_hdaudio.inf_31bf3856ad364e35_10.0.10240.17146_none_1d5435ea0226d0ec\hdaudio.inf' to 'C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_c8e3ac50c9bf5564\hdaudio.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_hdaudio.inf_31bf3856ad364e35_10.0.10240.17146_none_1d5435ea0226d0ec\HdAudio.sys' to 'C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_c8e3ac50c9bf5564\HdAudio.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_c8e3ac50c9bf5564\hdaudio.inf} 03:32:07.017
+     idb:           Created driver package object 'hdaudio.inf_amd64_c8e3ac50c9bf5564' in DRIVERS database node.
+     idb:           Driver INF file object 'hdaudio.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'hdaudio.inf_amd64_c8e3ac50c9bf5564' with 'hdaudio.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 03:32:07.017
+     sto:      {DRIVERSTORE IMPORT END} 03:32:07.017
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 03:32:07.017
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.017
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_wdmaudio.inf_31bf3856ad364e35_10.0.10240.16644_none_686b26bfb4cfd8e6\wdmaudio.inf} 03:32:07.017
+!    sto:      Driver package already imported as 'wdmaudio.inf' (C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\wdmaudio.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.017
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_hdaudbus.inf_31bf3856ad364e35_10.0.10240.17146_none_7f1592fc213de89a\hdaudbus.inf} 03:32:07.017
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_hdaudbus.inf_31bf3856ad364e35_10.0.10240.17146_none_7f1592fc213de89a\hdaudbus.inf} 03:32:07.033
+     inf:           Driver package 'hdaudbus.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 03:32:07.033
+     sto:      {DRIVERSTORE IMPORT BEGIN} 03:32:07.033
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 03:32:07.033
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_hdaudbus.inf_31bf3856ad364e35_10.0.10240.17146_none_7f1592fc213de89a\hdaudbus.inf' to 'C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_070bdb1ad27e2f16\hdaudbus.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_hdaudbus.inf_31bf3856ad364e35_10.0.10240.17146_none_7f1592fc213de89a\hdaudbus.sys' to 'C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_070bdb1ad27e2f16\hdaudbus.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_070bdb1ad27e2f16\hdaudbus.inf} 03:32:07.033
+     idb:           Created driver package object 'hdaudbus.inf_amd64_070bdb1ad27e2f16' in SYSTEM database node.
+     idb:           Driver INF file object 'hdaudbus.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'hdaudbus.inf_amd64_070bdb1ad27e2f16' with 'hdaudbus.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 03:32:07.048
+     sto:      {DRIVERSTORE IMPORT END} 03:32:07.048
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 03:32:07.048
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.048
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_netrtwlane_13.inf_31bf3856ad364e35_10.0.10240.16394_none_c45ee1d3ac882b6b\netrtwlane_13.inf} 03:32:07.048
+!    sto:      Driver package already imported as 'netrtwlane_13.inf' (C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_8e17ee2826ff2b07\netrtwlane_13.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.048
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_netwmbclass.inf_31bf3856ad364e35_10.0.10240.16392_none_d4f359d5f456fedf\netwmbclass.inf} 03:32:07.048
+!    sto:      Driver package already imported as 'netwmbclass.inf' (C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_ed51114936bfc236\netwmbclass.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.048
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_netrndis.inf_31bf3856ad364e35_10.0.10240.16732_none_cfc7701ce075d895\netrndis.inf} 03:32:07.048
+!    sto:      Driver package already imported as 'netrndis.inf' (C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_609a0bb012179987\netrndis.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.048
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17146_none_5ac378b96e96cd4d\prnms003.inf} 03:32:07.048
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17146_none_5ac378b96e96cd4d\prnms003.inf} 03:32:07.048
+     inf:           Driver package 'prnms003.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 03:32:07.048
+     sto:      {DRIVERSTORE IMPORT BEGIN} 03:32:07.064
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 03:32:07.064
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17146_none_5ac378b96e96cd4d\Amd64\PrintConfig.dll' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\Amd64\PrintConfig.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17146_none_5ac378b96e96cd4d\Amd64\unishare.gpd' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\Amd64\unishare.gpd'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17146_none_5ac378b96e96cd4d\Amd64\unishare-pipelineconfig.xml' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\Amd64\unishare-pipelineconfig.xml'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17146_none_5ac378b96e96cd4d\prnms003.cat' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\prnms003.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17146_none_5ac378b96e96cd4d\prnms003.inf' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\prnms003.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\prnms003.inf} 03:32:07.128
+     idb:           Created driver package object 'prnms003.inf_amd64_2da12eac1bd2c7cb' in DRIVERS database node.
+     idb:           Driver INF file object 'prnms003.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'prnms003.inf_amd64_2da12eac1bd2c7cb' with 'prnms003.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 03:32:07.142
+     sto:      {DRIVERSTORE IMPORT END} 03:32:07.142
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 03:32:07.142
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.142
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17146_none_5b4c8aee87b509b6\prnms004.inf} 03:32:07.142
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17146_none_5b4c8aee87b509b6\prnms004.inf} 03:32:07.142
+     inf:           Driver package 'prnms004.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 03:32:07.142
+     sto:      {DRIVERSTORE IMPORT BEGIN} 03:32:07.142
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 03:32:07.142
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17146_none_5b4c8aee87b509b6\prnms004.cat' to 'C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86\prnms004.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17146_none_5b4c8aee87b509b6\prnms004.inf' to 'C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86\prnms004.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17146_none_5b4c8aee87b509b6\Amd64\unisharev4-manifest.ini' to 'C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86\Amd64\unisharev4-manifest.ini'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17146_none_5b4c8aee87b509b6\Amd64\unisharev4.gpd' to 'C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86\Amd64\unisharev4.gpd'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17146_none_5b4c8aee87b509b6\Amd64\unisharev4-pipelineconfig.xml' to 'C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86\Amd64\unisharev4-pipelineconfig.xml'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86\prnms004.inf} 03:32:07.173
+     idb:           Created driver package object 'prnms004.inf_amd64_5646d0853ac66f86' in DRIVERS database node.
+     idb:           Driver INF file object 'prnms004.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'prnms004.inf_amd64_5646d0853ac66f86' with 'prnms004.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 03:32:07.173
+     sto:      {DRIVERSTORE IMPORT END} 03:32:07.173
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 03:32:07.173
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.173
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\ntprint.inf} 03:32:07.173
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\ntprint.inf} 03:32:07.173
+     inf:           Driver package 'ntprint.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 03:32:07.173
+     sto:      {DRIVERSTORE IMPORT BEGIN} 03:32:07.173
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 03:32:07.173
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\UNIRES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\UNIRES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\TTFSUB.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\TTFSUB.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\UNIDRV.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\UNIDRV.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\UNIDRV.HLP' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\UNIDRV.HLP'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\PCL4RES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\PCL4RES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\PS_SCHM.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\PS_SCHM.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\MXDWDRV.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\MXDWDRV.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\PSCRIPT.HLP' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\PSCRIPT.HLP'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\PSCRIPT.NTF' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\PSCRIPT.NTF'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\PCL5ERES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\PCL5ERES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\PCL5URES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\PCL5URES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\PSCRIPT5.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\PSCRIPT5.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\PJL.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\PJL.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\STDSCHEM.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\STDSCHEM.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\STDNAMES.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\STDNAMES.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\STDSCHMX.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\STDSCHMX.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\STDDTYPE.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\STDDTYPE.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\PSCRPTFE.NTF' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\PSCRPTFE.NTF'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\MSXPSINC.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\MSXPSINC.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\UNIDRVUI.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\UNIDRVUI.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\MSXPSINC.PPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\MSXPSINC.PPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\PS5UI.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\PS5UI.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\PCLXL.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\PCLXL.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\PCLXL.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\PCLXL.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\P6DISP.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\P6DISP.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\P6FONT.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\P6FONT.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\LOCALE.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\LOCALE.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\Amd64\PJLMON.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64\PJLMON.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\ntprint.cat' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\ntprint.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_42f49d1c5569a8e9\ntprint.inf' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\ntprint.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\ntprint.inf} 03:32:07.486
+     idb:           Created driver package object 'ntprint.inf_amd64_b3cf4018952c495c' in DRIVERS database node.
+     idb:           Driver INF file object 'ntprint.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'ntprint.inf_amd64_b3cf4018952c495c' with 'ntprint.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 03:32:07.486
+     sto:      {DRIVERSTORE IMPORT END} 03:32:07.486
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 03:32:07.486
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.486
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17113_none_4e14625f3f3544d3\ntprint4.inf} 03:32:07.486
+!    sto:      Driver package already imported as 'ntprint4.inf' (C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\ntprint4.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.486
+     sto: {Stage Driver Package: C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\ntprint.inf} 03:32:07.486
+     inf:      {Query Configurability: C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\ntprint.inf} 03:32:07.486
+     inf:           Driver package 'ntprint.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 03:32:07.504
+     sto:      {DRIVERSTORE IMPORT BEGIN} 03:32:07.504
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 03:32:07.504
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\PCL5URES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\PCL5URES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\PSCRIPT5.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\PSCRIPT5.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\PJL.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\PJL.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\STDSCHEM.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\STDSCHEM.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\STDNAMES.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\STDNAMES.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\STDSCHMX.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\STDSCHMX.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\STDDTYPE.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\STDDTYPE.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\PSCRPTFE.NTF' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\PSCRPTFE.NTF'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\MSXPSINC.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\MSXPSINC.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\UNIDRVUI.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\UNIDRVUI.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\MSXPSINC.PPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\MSXPSINC.PPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\PS5UI.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\PS5UI.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\PCLXL.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\PCLXL.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\PCLXL.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\PCLXL.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\P6DISP.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\P6DISP.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\P6FONT.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\P6FONT.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\LOCALE.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\LOCALE.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\PJLMON.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\PJLMON.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\UNIRES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\UNIRES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\TTFSUB.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\TTFSUB.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\UNIDRV.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\UNIDRV.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\UNIDRV.HLP' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\UNIDRV.HLP'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\PCL4RES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\PCL4RES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\PS_SCHM.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\PS_SCHM.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\MXDWDRV.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\MXDWDRV.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\PSCRIPT.HLP' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\PSCRIPT.HLP'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\PSCRIPT.NTF' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\PSCRIPT.NTF'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\I386\PCL5ERES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386\PCL5ERES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\ntprint.cat' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\ntprint.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17146_none_e6d601989d0c37b3\ntprint.inf' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\ntprint.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\ntprint.inf} 03:32:07.673
+     idb:           Created driver package object 'ntprint.inf_x86_b3cf4018952c495c' in DRIVERS database node.
+     idb:           Driver INF file object 'ntprint.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'ntprint.inf_x86_b3cf4018952c495c' with 'ntprint.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 03:32:07.673
+     sto:      {DRIVERSTORE IMPORT END} 03:32:07.673
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 03:32:07.673
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.673
+     sto: {Stage Driver Package: C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17146_none_fea4dd35b6395c17\prnms003.inf} 03:32:07.673
+     inf:      {Query Configurability: C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17146_none_fea4dd35b6395c17\prnms003.inf} 03:32:07.689
+     inf:           Driver package is fully isolated.
+     inf:           Driver package 'prnms003.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 03:32:07.689
+     sto:      {DRIVERSTORE IMPORT BEGIN} 03:32:07.689
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 03:32:07.689
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17146_none_fea4dd35b6395c17\prnms003.cat' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6\prnms003.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17146_none_fea4dd35b6395c17\prnms003.inf' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6\prnms003.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17146_none_fea4dd35b6395c17\I386\unishare.gpd' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6\I386\unishare.gpd'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17146_none_fea4dd35b6395c17\I386\unishare-pipelineconfig.xml' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6\I386\unishare-pipelineconfig.xml'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17146_none_fea4dd35b6395c17\I386\PrintConfig.dll' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6\I386\PrintConfig.dll'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6\prnms003.inf} 03:32:07.736
+     idb:           Created driver package object 'prnms003.inf_x86_8f17aac186c70ea6' in DRIVERS database node.
+     idb:           Driver INF file object 'prnms003.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'prnms003.inf_x86_8f17aac186c70ea6' with 'prnms003.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 03:32:07.752
+     sto:      {DRIVERSTORE IMPORT END} 03:32:07.752
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 03:32:07.752
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.752
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_ucmucsi.inf_31bf3856ad364e35_10.0.10240.16389_none_172d148ed918ff15\ucmucsi.inf} 03:32:07.752
+!    sto:      Driver package already imported as 'ucmucsi.inf' (C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_86bd71749200d4fb\ucmucsi.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.752
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_pci.inf_31bf3856ad364e35_10.0.10240.16942_none_11ad952af51946e9\pci.inf} 03:32:07.752
+!    sto:      Driver package already imported as 'pci.inf' (C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_61ccd5db98b3abf1\pci.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.752
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_usbser.inf_31bf3856ad364e35_10.0.10240.16732_none_0a9642fe457725ba\usbser.inf} 03:32:07.752
+!    sto:      Driver package already imported as 'usbser.inf' (C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_5de2576d6f02918e\usbser.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.752
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_stornvme.inf_31bf3856ad364e35_10.0.10240.16431_none_b94d338f8f0910e2\stornvme.inf} 03:32:07.752
+!    sto:      Driver package already imported as 'stornvme.inf' (C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_5ffb10fc0bbc4ac0\stornvme.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.752
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_msports.inf_31bf3856ad364e35_10.0.10240.16732_none_009c91a4530779c0\msports.inf} 03:32:07.752
+!    sto:      Driver package already imported as 'msports.inf' (C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\msports.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.752
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_buttonconverter.inf_31bf3856ad364e35_10.0.10240.16515_none_2e186184227fb405\buttonconverter.inf} 03:32:07.752
+!    sto:      Driver package already imported as 'buttonconverter.inf' (C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_b210406b0d8c4695\buttonconverter.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.752
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_mrvlpcie8897.inf_31bf3856ad364e35_10.0.10240.16515_none_3eb55dfb31919bf1\mrvlpcie8897.inf} 03:32:07.752
+!    sto:      Driver package already imported as 'mrvlpcie8897.inf' (C:\Windows\System32\DriverStore\FileRepository\mrvlpcie8897.inf_amd64_f68a8d902ea4d964\mrvlpcie8897.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.767
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_vhdmp.inf_31bf3856ad364e35_10.0.10240.17146_none_ae845e826454150b\vhdmp.inf} 03:32:07.767
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_vhdmp.inf_31bf3856ad364e35_10.0.10240.17146_none_ae845e826454150b\vhdmp.inf} 03:32:07.767
+     inf:           Driver package 'vhdmp.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 03:32:07.767
+     sto:      {DRIVERSTORE IMPORT BEGIN} 03:32:07.767
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 03:32:07.767
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_vhdmp.inf_31bf3856ad364e35_10.0.10240.17146_none_ae845e826454150b\vhdmp.inf' to 'C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_0e346fbd37116b8f\vhdmp.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_vhdmp.inf_31bf3856ad364e35_10.0.10240.17146_none_ae845e826454150b\vhdmp.sys' to 'C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_0e346fbd37116b8f\vhdmp.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_0e346fbd37116b8f\vhdmp.inf} 03:32:07.783
+     idb:           Created driver package object 'vhdmp.inf_amd64_0e346fbd37116b8f' in SYSTEM database node.
+     idb:           Driver INF file object 'vhdmp.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'vhdmp.inf_amd64_0e346fbd37116b8f' with 'vhdmp.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 03:32:07.799
+     sto:      {DRIVERSTORE IMPORT END} 03:32:07.814
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 03:32:07.814
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.814
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_msgpiowin32.inf_31bf3856ad364e35_10.0.10240.16425_none_275c9c62bee34e13\msgpiowin32.inf} 03:32:07.814
+!    sto:      Driver package already imported as 'msgpiowin32.inf' (C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_4563c8367012234f\msgpiowin32.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.814
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_wpdmtp.inf_31bf3856ad364e35_10.0.10240.16431_none_279c23d2215c89a2\wpdmtp.inf} 03:32:07.814
+!    sto:      Driver package already imported as 'wpdmtp.inf' (C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\wpdmtp.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.814
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_tsusbhub.inf_31bf3856ad364e35_10.0.10240.16732_none_11f5843010008a70\tsusbhub.inf} 03:32:07.814
+!    sto:      Driver package already imported as 'tsusbhub.inf' (C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_b01c6baade1c797a\tsusbhub.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 03:32:07.814
+<<<  Section end 2016/10/12 03:32:07.814
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Install Driver Updates]
+>>>  Section start 2016/10/12 03:32:07.830
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Transaction        = CbsDriversAndPrimitives
+     sto: Driver Updates     = 41
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_01ce808b39cab47d\miradisp.inf} 03:32:08.158
+     sto:      Driver Package = miradisp.inf_amd64_01ce808b39cab47d
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_01ce808b39cab47d\miradisp.inf} 03:32:08.158
+     idb:           Driver package 'miradisp.inf_amd64_01ce808b39cab47d' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.158
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.158
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_a4bdb031f38afa10\hidscanner.inf} 03:32:08.158
+     sto:      Driver Package = hidscanner.inf_amd64_a4bdb031f38afa10
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_a4bdb031f38afa10\hidscanner.inf} 03:32:08.158
+     idb:           Driver package 'hidscanner.inf_amd64_a4bdb031f38afa10' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.158
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.158
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_519ad1a6701b5cab\xusb22.inf} 03:32:08.158
+     sto:      Driver Package = xusb22.inf_amd64_519ad1a6701b5cab
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_519ad1a6701b5cab\xusb22.inf} 03:32:08.158
+     idb:           Changing active driver package from 'xusb22.inf_amd64_74d42d005ba12dd5' to 'xusb22.inf_amd64_519ad1a6701b5cab'.
+     cpy:           Unpublished 'xusb22.inf'.
+     idb:           Deindexed 1 driver file for 'xusb22.inf_amd64_74d42d005ba12dd5'.
+     idb:           Deindexed 6 device IDs for 'xusb22.inf_amd64_74d42d005ba12dd5'.
+     cpy:           Published 'xusb22.inf_amd64_519ad1a6701b5cab\xusb22.inf' to 'xusb22.inf'.
+     idb:           Indexed 1 driver file for 'xusb22.inf_amd64_519ad1a6701b5cab'.
+     idb:           Indexed 6 device IDs for 'xusb22.inf_amd64_519ad1a6701b5cab'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.236
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.236
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_19a61be22ae9944e\acpi.inf} 03:32:08.236
+     sto:      Driver Package = acpi.inf_amd64_19a61be22ae9944e
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_19a61be22ae9944e\acpi.inf} 03:32:08.236
+     idb:           Driver package 'acpi.inf_amd64_19a61be22ae9944e' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.251
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.251
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_4b9b5d5319497dd4\wfcvsc.inf} 03:32:08.251
+     sto:      Driver Package = wfcvsc.inf_amd64_4b9b5d5319497dd4
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_4b9b5d5319497dd4\wfcvsc.inf} 03:32:08.251
+     idb:           Changing active driver package from 'wfcvsc.inf_amd64_f146c688c52c6479' to 'wfcvsc.inf_amd64_4b9b5d5319497dd4'.
+     cpy:           Unpublished 'wfcvsc.inf'.
+     idb:           Deindexed 1 driver file for 'wfcvsc.inf_amd64_f146c688c52c6479'.
+     idb:           Deindexed 2 device IDs for 'wfcvsc.inf_amd64_f146c688c52c6479'.
+     cpy:           Published 'wfcvsc.inf_amd64_4b9b5d5319497dd4\wfcvsc.inf' to 'wfcvsc.inf'.
+     idb:           Indexed 1 driver file for 'wfcvsc.inf_amd64_4b9b5d5319497dd4'.
+     idb:           Indexed 2 device IDs for 'wfcvsc.inf_amd64_4b9b5d5319497dd4'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.315
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.315
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_57265cb2d2642968\sensorshidclassdriver.inf} 03:32:08.315
+     sto:      Driver Package = sensorshidclassdriver.inf_amd64_57265cb2d2642968
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_57265cb2d2642968\sensorshidclassdriver.inf} 03:32:08.315
+     idb:           Driver package 'sensorshidclassdriver.inf_amd64_57265cb2d2642968' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.315
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.315
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\bth.inf} 03:32:08.315
+     sto:      Driver Package = bth.inf_amd64_97f04f59eaecdf7a
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\bth.inf} 03:32:08.315
+     idb:           Driver package 'bth.inf_amd64_97f04f59eaecdf7a' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.315
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.315
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_0dabadc4461923c4\bthleenum.inf} 03:32:08.315
+     sto:      Driver Package = bthleenum.inf_amd64_0dabadc4461923c4
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_0dabadc4461923c4\bthleenum.inf} 03:32:08.315
+     idb:           Driver package 'bthleenum.inf_amd64_0dabadc4461923c4' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.315
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.315
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_221654d9bb6545af\genericusbfn.inf} 03:32:08.332
+     sto:      Driver Package = genericusbfn.inf_amd64_221654d9bb6545af
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_221654d9bb6545af\genericusbfn.inf} 03:32:08.332
+     idb:           Changing active driver package from 'genericusbfn.inf_amd64_d519ce9ec210da10' to 'genericusbfn.inf_amd64_221654d9bb6545af'.
+     cpy:           Unpublished 'genericusbfn.inf'.
+     idb:           Deindexed 1 driver file for 'genericusbfn.inf_amd64_d519ce9ec210da10'.
+     idb:           Deindexed 6 device IDs for 'genericusbfn.inf_amd64_d519ce9ec210da10'.
+     cpy:           Published 'genericusbfn.inf_amd64_221654d9bb6545af\genericusbfn.inf' to 'genericusbfn.inf'.
+     idb:           Indexed 1 driver file for 'genericusbfn.inf_amd64_221654d9bb6545af'.
+     idb:           Indexed 6 device IDs for 'genericusbfn.inf_amd64_221654d9bb6545af'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.363
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.363
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_2780d7dc6ecda26e\usbstor.inf} 03:32:08.363
+     sto:      Driver Package = usbstor.inf_amd64_2780d7dc6ecda26e
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_2780d7dc6ecda26e\usbstor.inf} 03:32:08.363
+     idb:           Driver package 'usbstor.inf_amd64_2780d7dc6ecda26e' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.363
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.363
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbport.inf} 03:32:08.363
+     sto:      Driver Package = usbport.inf_amd64_4215f546c8e8f9d6
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbport.inf} 03:32:08.363
+     idb:           Driver package 'usbport.inf_amd64_4215f546c8e8f9d6' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.363
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.363
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_caa57285880769f4\usbhub3.inf} 03:32:08.378
+     sto:      Driver Package = usbhub3.inf_amd64_caa57285880769f4
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_caa57285880769f4\usbhub3.inf} 03:32:08.378
+     idb:           Driver package 'usbhub3.inf_amd64_caa57285880769f4' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.378
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.378
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_7b59c1e1fa52c844\usbxhci.inf} 03:32:08.378
+     sto:      Driver Package = usbxhci.inf_amd64_7b59c1e1fa52c844
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_7b59c1e1fa52c844\usbxhci.inf} 03:32:08.378
+     idb:           Driver package 'usbxhci.inf_amd64_7b59c1e1fa52c844' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.378
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.378
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_b33128a95ba9fe0b\sdbus.inf} 03:32:08.378
+     sto:      Driver Package = sdbus.inf_amd64_b33128a95ba9fe0b
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_b33128a95ba9fe0b\sdbus.inf} 03:32:08.378
+     idb:           Driver package 'sdbus.inf_amd64_b33128a95ba9fe0b' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.378
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.378
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_57032036ac5b3f02\mdmbtmdm.inf} 03:32:08.378
+     sto:      Driver Package = mdmbtmdm.inf_amd64_57032036ac5b3f02
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_57032036ac5b3f02\mdmbtmdm.inf} 03:32:08.378
+     idb:           Driver package 'mdmbtmdm.inf_amd64_57032036ac5b3f02' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.378
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.378
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_47034a2e2794f3b2\bthaudhid.inf} 03:32:08.378
+     sto:      Driver Package = bthaudhid.inf_amd64_47034a2e2794f3b2
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_47034a2e2794f3b2\bthaudhid.inf} 03:32:08.378
+     idb:           Changing active driver package from 'bthaudhid.inf_amd64_aaeb679851734af2' to 'bthaudhid.inf_amd64_47034a2e2794f3b2'.
+     cpy:           Unpublished 'bthaudhid.inf'.
+     idb:           Deindexed 2 driver files for 'bthaudhid.inf_amd64_aaeb679851734af2'.
+     idb:           Deindexed 4 device IDs for 'bthaudhid.inf_amd64_aaeb679851734af2'.
+     cpy:           Published 'bthaudhid.inf_amd64_47034a2e2794f3b2\bthaudhid.inf' to 'bthaudhid.inf'.
+     idb:           Indexed 2 driver files for 'bthaudhid.inf_amd64_47034a2e2794f3b2'.
+     idb:           Indexed 4 device IDs for 'bthaudhid.inf_amd64_47034a2e2794f3b2'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.485
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.485
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_06170919fa54ed29\bthhfenum.inf} 03:32:08.485
+     sto:      Driver Package = bthhfenum.inf_amd64_06170919fa54ed29
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_06170919fa54ed29\bthhfenum.inf} 03:32:08.485
+     idb:           Driver package 'bthhfenum.inf_amd64_06170919fa54ed29' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.485
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.485
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_dcc0445e956fcf69\wudfusbcciddriver.inf} 03:32:08.485
+     sto:      Driver Package = wudfusbcciddriver.inf_amd64_dcc0445e956fcf69
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_dcc0445e956fcf69\wudfusbcciddriver.inf} 03:32:08.485
+     idb:           Driver package 'wudfusbcciddriver.inf_amd64_dcc0445e956fcf69' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.504
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.504
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_c8e3ac50c9bf5564\hdaudio.inf} 03:32:08.504
+     sto:      Driver Package = hdaudio.inf_amd64_c8e3ac50c9bf5564
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_c8e3ac50c9bf5564\hdaudio.inf} 03:32:08.504
+     idb:           Changing active driver package from 'hdaudio.inf_amd64_9b7a5db27f6d6cbd' to 'hdaudio.inf_amd64_c8e3ac50c9bf5564'.
+     cpy:           Unpublished 'hdaudio.inf'.
+     idb:           Deindexed 1 driver file for 'hdaudio.inf_amd64_9b7a5db27f6d6cbd'.
+     idb:           Deindexed 2 device IDs for 'hdaudio.inf_amd64_9b7a5db27f6d6cbd'.
+     cpy:           Published 'hdaudio.inf_amd64_c8e3ac50c9bf5564\hdaudio.inf' to 'hdaudio.inf'.
+     idb:           Indexed 1 driver file for 'hdaudio.inf_amd64_c8e3ac50c9bf5564'.
+     idb:           Indexed 2 device IDs for 'hdaudio.inf_amd64_c8e3ac50c9bf5564'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.627
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.627
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\wdmaudio.inf} 03:32:08.627
+     sto:      Driver Package = wdmaudio.inf_amd64_58b3142a36627a91
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\wdmaudio.inf} 03:32:08.627
+     idb:           Driver package 'wdmaudio.inf_amd64_58b3142a36627a91' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.627
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.627
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_070bdb1ad27e2f16\hdaudbus.inf} 03:32:08.627
+     sto:      Driver Package = hdaudbus.inf_amd64_070bdb1ad27e2f16
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_070bdb1ad27e2f16\hdaudbus.inf} 03:32:08.627
+     idb:           Changing active driver package from 'hdaudbus.inf_amd64_3a98a84dd82f9b0a' to 'hdaudbus.inf_amd64_070bdb1ad27e2f16'.
+     cpy:           Unpublished 'hdaudbus.inf'.
+     idb:           Deindexed 1 driver file for 'hdaudbus.inf_amd64_3a98a84dd82f9b0a'.
+     idb:           Deindexed 3 device IDs for 'hdaudbus.inf_amd64_3a98a84dd82f9b0a'.
+     cpy:           Published 'hdaudbus.inf_amd64_070bdb1ad27e2f16\hdaudbus.inf' to 'hdaudbus.inf'.
+     idb:           Indexed 1 driver file for 'hdaudbus.inf_amd64_070bdb1ad27e2f16'.
+     idb:           Indexed 3 device IDs for 'hdaudbus.inf_amd64_070bdb1ad27e2f16'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.689
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.689
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_8e17ee2826ff2b07\netrtwlane_13.inf} 03:32:08.708
+     sto:      Driver Package = netrtwlane_13.inf_amd64_8e17ee2826ff2b07
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_8e17ee2826ff2b07\netrtwlane_13.inf} 03:32:08.708
+     idb:           Driver package 'netrtwlane_13.inf_amd64_8e17ee2826ff2b07' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.708
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.708
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_ed51114936bfc236\netwmbclass.inf} 03:32:08.708
+     sto:      Driver Package = netwmbclass.inf_amd64_ed51114936bfc236
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_ed51114936bfc236\netwmbclass.inf} 03:32:08.708
+     idb:           Driver package 'netwmbclass.inf_amd64_ed51114936bfc236' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.708
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.708
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_609a0bb012179987\netrndis.inf} 03:32:08.708
+     sto:      Driver Package = netrndis.inf_amd64_609a0bb012179987
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_609a0bb012179987\netrndis.inf} 03:32:08.708
+     idb:           Driver package 'netrndis.inf_amd64_609a0bb012179987' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.708
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.708
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\prnms003.inf} 03:32:08.708
+     sto:      Driver Package = prnms003.inf_amd64_2da12eac1bd2c7cb
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\prnms003.inf} 03:32:08.708
+     idb:           Changing active driver package from 'prnms003.inf_amd64_73e8526b6d7c748c' to 'prnms003.inf_amd64_2da12eac1bd2c7cb'.
+     cpy:           Unpublished 'prnms003.inf'.
+     idb:           Deindexed 3 driver files for 'prnms003.inf_amd64_73e8526b6d7c748c'.
+     idb:           Deindexed 2 device IDs for 'prnms003.inf_amd64_73e8526b6d7c748c'.
+     cpy:           Published 'prnms003.inf_amd64_2da12eac1bd2c7cb\prnms003.inf' to 'prnms003.inf'.
+     idb:           Indexed 3 driver files for 'prnms003.inf_amd64_2da12eac1bd2c7cb'.
+     idb:           Indexed 2 device IDs for 'prnms003.inf_amd64_2da12eac1bd2c7cb'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.768
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.768
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86\prnms004.inf} 03:32:08.768
+     sto:      Driver Package = prnms004.inf_amd64_5646d0853ac66f86
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86\prnms004.inf} 03:32:08.768
+     idb:           Changing active driver package from 'prnms004.inf_amd64_dc355e772d68650c' to 'prnms004.inf_amd64_5646d0853ac66f86'.
+     cpy:           Unpublished 'prnms004.inf'.
+     idb:           Deindexed 3 driver files for 'prnms004.inf_amd64_dc355e772d68650c'.
+     idb:           Deindexed 2 device IDs for 'prnms004.inf_amd64_dc355e772d68650c'.
+     cpy:           Published 'prnms004.inf_amd64_5646d0853ac66f86\prnms004.inf' to 'prnms004.inf'.
+     idb:           Indexed 3 driver files for 'prnms004.inf_amd64_5646d0853ac66f86'.
+     idb:           Indexed 2 device IDs for 'prnms004.inf_amd64_5646d0853ac66f86'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.798
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.798
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\ntprint.inf} 03:32:08.798
+     sto:      Driver Package = ntprint.inf_amd64_b3cf4018952c495c
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\ntprint.inf} 03:32:08.798
+     idb:           Changing active driver package from 'ntprint.inf_amd64_f9aae5bf86267495' to 'ntprint.inf_amd64_b3cf4018952c495c'.
+     cpy:           Unpublished 'ntprint.inf'.
+     idb:           Deindexed 28 driver files for 'ntprint.inf_amd64_f9aae5bf86267495'.
+     idb:           Deindexed 6 device IDs for 'ntprint.inf_amd64_f9aae5bf86267495'.
+     cpy:           Published 'ntprint.inf_amd64_b3cf4018952c495c\ntprint.inf' to 'ntprint.inf'.
+     idb:           Indexed 28 driver files for 'ntprint.inf_amd64_b3cf4018952c495c'.
+     idb:           Indexed 6 device IDs for 'ntprint.inf_amd64_b3cf4018952c495c'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.864
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.864
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\ntprint4.inf} 03:32:08.864
+     sto:      Driver Package = ntprint4.inf_amd64_34fc089922f9b11d
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\ntprint4.inf} 03:32:08.864
+     idb:           Driver package 'ntprint4.inf_amd64_34fc089922f9b11d' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.864
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.864
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\ntprint.inf} 03:32:08.864
+     sto:      Driver Package = ntprint.inf_x86_b3cf4018952c495c
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\ntprint.inf} 03:32:08.878
+     idb:           Driver package 'ntprint.inf_amd64_b3cf4018952c495c' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.878
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.878
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6\prnms003.inf} 03:32:08.878
+     sto:      Driver Package = prnms003.inf_x86_8f17aac186c70ea6
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6\prnms003.inf} 03:32:08.878
+     idb:           Driver package 'prnms003.inf_amd64_2da12eac1bd2c7cb' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.878
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.878
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_86bd71749200d4fb\ucmucsi.inf} 03:32:08.878
+     sto:      Driver Package = ucmucsi.inf_amd64_86bd71749200d4fb
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_86bd71749200d4fb\ucmucsi.inf} 03:32:08.878
+     idb:           Driver package 'ucmucsi.inf_amd64_86bd71749200d4fb' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.878
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.878
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_61ccd5db98b3abf1\pci.inf} 03:32:08.878
+     sto:      Driver Package = pci.inf_amd64_61ccd5db98b3abf1
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_61ccd5db98b3abf1\pci.inf} 03:32:08.878
+     idb:           Driver package 'pci.inf_amd64_61ccd5db98b3abf1' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.878
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.878
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_5de2576d6f02918e\usbser.inf} 03:32:08.892
+     sto:      Driver Package = usbser.inf_amd64_5de2576d6f02918e
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_5de2576d6f02918e\usbser.inf} 03:32:08.892
+     idb:           Driver package 'usbser.inf_amd64_5de2576d6f02918e' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.892
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.892
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_5ffb10fc0bbc4ac0\stornvme.inf} 03:32:08.892
+     sto:      Driver Package = stornvme.inf_amd64_5ffb10fc0bbc4ac0
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_5ffb10fc0bbc4ac0\stornvme.inf} 03:32:08.892
+     idb:           Driver package 'stornvme.inf_amd64_5ffb10fc0bbc4ac0' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.892
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.892
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\msports.inf} 03:32:08.892
+     sto:      Driver Package = msports.inf_amd64_46e9747fe38474e5
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\msports.inf} 03:32:08.892
+     idb:           Driver package 'msports.inf_amd64_46e9747fe38474e5' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.892
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.892
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_b210406b0d8c4695\buttonconverter.inf} 03:32:08.892
+     sto:      Driver Package = buttonconverter.inf_amd64_b210406b0d8c4695
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_b210406b0d8c4695\buttonconverter.inf} 03:32:08.892
+     idb:           Driver package 'buttonconverter.inf_amd64_b210406b0d8c4695' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.892
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.892
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\mrvlpcie8897.inf_amd64_f68a8d902ea4d964\mrvlpcie8897.inf} 03:32:08.892
+     sto:      Driver Package = mrvlpcie8897.inf_amd64_f68a8d902ea4d964
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\mrvlpcie8897.inf_amd64_f68a8d902ea4d964\mrvlpcie8897.inf} 03:32:08.892
+     idb:           Driver package 'mrvlpcie8897.inf_amd64_f68a8d902ea4d964' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.892
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.892
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_0e346fbd37116b8f\vhdmp.inf} 03:32:08.892
+     sto:      Driver Package = vhdmp.inf_amd64_0e346fbd37116b8f
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_0e346fbd37116b8f\vhdmp.inf} 03:32:08.892
+     idb:           Changing active driver package from 'vhdmp.inf_amd64_b486fbf51614c321' to 'vhdmp.inf_amd64_0e346fbd37116b8f'.
+     cpy:           Unpublished 'vhdmp.inf'.
+     idb:           Deindexed 1 driver file for 'vhdmp.inf_amd64_b486fbf51614c321'.
+     idb:           Deindexed 2 device IDs for 'vhdmp.inf_amd64_b486fbf51614c321'.
+     cpy:           Published 'vhdmp.inf_amd64_0e346fbd37116b8f\vhdmp.inf' to 'vhdmp.inf'.
+     idb:           Indexed 1 driver file for 'vhdmp.inf_amd64_0e346fbd37116b8f'.
+     idb:           Indexed 2 device IDs for 'vhdmp.inf_amd64_0e346fbd37116b8f'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.986
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.986
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_4563c8367012234f\msgpiowin32.inf} 03:32:08.986
+     sto:      Driver Package = msgpiowin32.inf_amd64_4563c8367012234f
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_4563c8367012234f\msgpiowin32.inf} 03:32:08.986
+     idb:           Driver package 'msgpiowin32.inf_amd64_4563c8367012234f' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:08.986
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:08.986
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\wpdmtp.inf} 03:32:08.986
+     sto:      Driver Package = wpdmtp.inf_amd64_5bffa673ab8cb4d4
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\wpdmtp.inf} 03:32:08.986
+     idb:           Driver package 'wpdmtp.inf_amd64_5bffa673ab8cb4d4' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:09.002
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:09.002
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_b01c6baade1c797a\tsusbhub.inf} 03:32:09.002
+     sto:      Driver Package = tsusbhub.inf_amd64_b01c6baade1c797a
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_b01c6baade1c797a\tsusbhub.inf} 03:32:09.002
+     idb:           Driver package 'tsusbhub.inf_amd64_b01c6baade1c797a' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 03:32:09.002
+     sto: {Publish Driver Package: exit(0x00000000)} 03:32:09.002
+     sto: Driver update 'miradisp.inf' is already reflected.
+     sto: Driver update 'hidscanner.inf' is already reflected.
+     sto: {Cache Device Nodes} 03:32:09.002
+     sto:      Cached 61 device nodes. Time = 63ms
+     sto: {Cache Device Nodes: exit(0x00000000)} 03:32:09.064
+     sto: No effective section names for 'xusb22.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_519ad1a6701b5cab\xusb22.inf}
+     inf:      Class GUID     = {d61ca365-5af4-4486-998b-9db4734c6ca3}
+     inf:      Class Options  = Configurable
+     idb:      Driver packages:
+     idb:           xusb22.inf_amd64_519ad1a6701b5cab (active)
+     idb:           xusb22.inf_amd64_74d42d005ba12dd5
+     idb:           xusb22.inf_amd64_438b7c551e424b28
+     idb:      {Configure Device Setup Class: {d61ca365-5af4-4486-998b-9db4734c6ca3}}
+     idb:           Updating existing class.
+     idb:           Class Name = XnaComposite
+     idb:      {Configure Device Setup Class: exit(0x00000000)}
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Driver update 'acpi.inf' is already reflected.
+     sto: No effective section names for 'wfcvsc.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_4b9b5d5319497dd4\wfcvsc.inf}
+     inf:      Class GUID     = {4d36e97b-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           wfcvsc.inf_amd64_4b9b5d5319497dd4 (active)
+     idb:           wfcvsc.inf_amd64_f146c688c52c6479
+     idb:           wfcvsc.inf_amd64_f049c0f8aa802928
+     inf:      {Configure Driver: Microsoft Hyper-V Fibre Channel HBA (not supported)}
+     inf:           Section Name = fcvscDriveInstall_NULL
+     inf:           Hardware Id  = VMBUS\{2f9bcc4a-0069-4af3-b76b-6fd0be528cda}
+     inf:           {Configure Driver Configuration: fcvscDriveInstall_NULL}
+     inf:                Service Name  = <none>
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Driver update 'sensorshidclassdriver.inf' is already reflected.
+     sto: Driver update 'bth.inf' is already reflected.
+     sto: Driver update 'bthleenum.inf' is already reflected.
+     sto: No effective section names for 'genericusbfn.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_221654d9bb6545af\genericusbfn.inf}
+     inf:      Class GUID     = {36fc9e60-c465-11cf-8056-444553540000}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           genericusbfn.inf_amd64_221654d9bb6545af (active)
+     idb:           genericusbfn.inf_amd64_d519ce9ec210da10
+     idb:           genericusbfn.inf_amd64_74a699053034b56d
+     inf:      {Configure Driver: Generic USB Function Class}
+     inf:           Section Name = genericusbfn.Install.NT
+     inf:           {Add Service: genericusbfn}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\genericusbfn.sys
+     inf:                Display Name  = Generic USB Function Class
+     inf:                Group         = Base
+     inf:                Updated service 'genericusbfn'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = USBFN\GENERICUSBFN
+     inf:           {Configure Driver Configuration: genericusbfn.Install.NT}
+     inf:                Service Name  = genericusbfn
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Generic USB Function Class}
+     inf:           Section Name = genericusbfn.InstallSecure.NT
+     inf:           Hardware Id  = USBFN\MTP
+     inf:           {Configure Driver Configuration: genericusbfn.InstallSecure.NT}
+     inf:                Service Name  = genericusbfn
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Generic USB Function Class}
+     inf:           Section Name = genericusbfn.InstallSecure.NT
+     inf:           Hardware Id  = USBFN\IpOverUSB
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Generic USB Function Class}
+     inf:           Section Name = genericusbfn.Install.NT
+     inf:           Hardware Id  = USBFN\UOSFlashing
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Generic USB Function Class}
+     inf:           Section Name = genericusbfn.Install.NT
+     inf:           Hardware Id  = USBFN\MainOSFlashing
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_221654d9bb6545af\genericusbfn.sys' to 'C:\Windows\System32\drivers\genericusbfn.sys'.
+     idb:      Last driver package 'genericusbfn.inf_amd64_d519ce9ec210da10' to copy 'C:\Windows\System32\drivers\genericusbfn.sys' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Driver update 'usbstor.inf' is already reflected.
+     sto: Driver update 'usbport.inf' is already reflected.
+     sto: Driver update 'usbhub3.inf' is already reflected.
+     sto: Driver update 'usbxhci.inf' is already reflected.
+     sto: Driver update 'sdbus.inf' is already reflected.
+     sto: Driver update 'mdmbtmdm.inf' is already reflected.
+     sto: No effective section names for 'bthaudhid.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_47034a2e2794f3b2\bthaudhid.inf}
+     inf:      Class GUID     = {745a17a0-74d3-11d0-b6fe-00a0c90f57da}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           bthaudhid.inf_amd64_47034a2e2794f3b2 (active)
+     idb:           bthaudhid.inf_amd64_aaeb679851734af2
+     idb:           bthaudhid.inf_amd64_b9a1f939467681b0
+     inf:      {Configure Driver: Bluetooth Hands-Free Call Control HID}
+     inf:           Section Name = BthAudioHFHid
+     inf:           {Add Service: bthhfhid}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\BthHFHid.sys
+     inf:                Display Name  = Bluetooth Hands-Free Call Control HID
+     inf:                Updated service 'bthhfhid'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = BTHHFENUM\BthHFPHID
+     inf:           {Configure Driver Configuration: BthAudioHFHid}
+     inf:                Service Name  = bthhfhid
+     inf:                Upper Filters = mshidkmdf
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Bluetooth Audio/Video Remote Control HID}
+     inf:           Section Name = BthAvrcpTg_DDI
+     inf:           {Add Service: BthAvrcpTg}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\BthAvrcpTg.sys
+     inf:                Display Name  = Bluetooth Audio/Video Remote Control HID
+     inf:                Group         = Extended Base
+     inf:                Updated service 'BthAvrcpTg'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = BTHENUM\{0000110E-0000-1000-8000-00805F9B34FB}
+     inf:           {Configure Driver Configuration: BthAvrcpTg_DDI}
+     inf:                Service Name  = BthAvrcpTg
+     inf:                Included INFs = BtaMpm.inf
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Bluetooth Audio/Video Remote Control HID}
+     inf:           Section Name = BthAvrcpTg_DDI
+     inf:           Hardware Id  = BTHENUM\{0000110E-0000-1000-8000-00805F9B34FB}_LOCALMFG&000a
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_47034a2e2794f3b2\BthhfHid.sys' to 'C:\Windows\System32\drivers\BthhfHid.sys'.
+     cpy:      Existing file 'C:\Windows\System32\drivers\BthhfHid.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_47034a2e2794f3b2\BthAvrcpTg.sys' to 'C:\Windows\System32\drivers\BthAvrcpTg.sys'.
+     idb:      Last driver package 'bthaudhid.inf_amd64_aaeb679851734af2' to copy 'C:\Windows\System32\drivers\BthAvrcpTg.sys' needs reconfiguration.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\btampm.inf_amd64_6e15be8bd68ddc6b\BtaMPM.sys' to 'C:\Windows\System32\drivers\BtaMPM.sys'.
+     cpy:      Existing file 'C:\Windows\System32\drivers\BtaMPM.sys' remains unchanged.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Driver update 'bthhfenum.inf' is already reflected.
+     sto: Driver update 'wudfusbcciddriver.inf' is already reflected.
+     sto: Devices using 'hdaudio.inf':
+     sto:      HDAUDIO\FUNC_01&VEN_8384&DEV_7680&SUBSYS_83847680&REV_1034\4&22a99211&0&0001 -> hdaudio\func_01 [HdAudModel]
+     sto: Installed section names:
+     sto:      HdAudModel
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_c8e3ac50c9bf5564\hdaudio.inf}
+     inf:      Class GUID     = {4d36e96c-e325-11ce-bfc1-08002be10318}
+     idb:      Driver packages:
+     idb:           hdaudio.inf_amd64_c8e3ac50c9bf5564 (active)
+     idb:           hdaudio.inf_amd64_9b7a5db27f6d6cbd
+     idb:           hdaudio.inf_amd64_dab2294dc8af0030
+     inf:      {Configure Driver: High Definition Audio Device}
+     inf:           Section Name = HdAudModel
+     inf:           {Add Service: HdAudAddService}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\HdAudio.sys
+     inf:                Display Name  = Microsoft 1.1 UAA Function Driver for High Definition Audio Service
+     inf:                Updated service 'HdAudAddService'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_c8e3ac50c9bf5564\HdAudio.sys' to 'C:\Windows\System32\drivers\HdAudio.sys'.
+     idb:      Last driver package 'hdaudio.inf_amd64_9b7a5db27f6d6cbd' to copy 'C:\Windows\System32\drivers\HdAudio.sys' needs reconfiguration.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\drmk.sys' to 'C:\Windows\system32\drivers\drmk.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\drmk.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\portcls.sys' to 'C:\Windows\system32\drivers\portcls.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\portcls.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\WMALFXGFXDSP.dll' to 'C:\Windows\system32\WMALFXGFXDSP.dll'.
+     cpy:      Existing file 'C:\Windows\system32\WMALFXGFXDSP.dll' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\SysFxUI.dll' to 'C:\Windows\system32\SysFxUI.dll'.
+     cpy:      Existing file 'C:\Windows\system32\SysFxUI.dll' remains unchanged.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Driver update 'wdmaudio.inf' is already reflected.
+     sto: Devices using 'hdaudbus.inf':
+     sto:      PCI\VEN_8086&DEV_2668&SUBSYS_76808384&REV_01\3&267a616a&1&28 -> PCI\CC_0403 [HDAudio_Device.NT]
+     sto: Installed section names:
+     sto:      HDAudio_Device.NT
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_070bdb1ad27e2f16\hdaudbus.inf}
+     inf:      Class GUID     = {4d36e97d-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           hdaudbus.inf_amd64_070bdb1ad27e2f16 (active)
+     idb:           hdaudbus.inf_amd64_3a98a84dd82f9b0a
+     idb:           hdaudbus.inf_amd64_59e464503a2b3653
+     inf:      {Configure Driver: High Definition Audio Controller}
+     inf:           Section Name = HDAudio_Device.NT
+     inf:           {Add Service: HDAudBus}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\HDAudBus.sys
+     inf:                Display Name  = Microsoft UAA Bus Driver for High Definition Audio
+     inf:                Group         = Extended Base
+     inf:                Updated service 'HDAudBus'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = PCI\CC_0403
+     inf:           {Configure Driver Configuration: HDAudio_Device.NT}
+     inf:                Service Name  = HDAudBus
+     inf:                Included INFs = wdmaudio.inf
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: High Definition Audio Controller}
+     inf:           Section Name = HDAudio_Device.NT
+     inf:           Hardware Id  = ACPI\CLS_0004&SUBCLS_0003
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_070bdb1ad27e2f16\hdaudbus.sys' to 'C:\Windows\System32\drivers\hdaudbus.sys'.
+     idb:      Last driver package 'hdaudbus.inf_amd64_3a98a84dd82f9b0a' to copy 'C:\Windows\System32\drivers\hdaudbus.sys' needs reconfiguration.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\drmk.sys' to 'C:\Windows\system32\drivers\drmk.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\drmk.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\portcls.sys' to 'C:\Windows\system32\drivers\portcls.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\portcls.sys' remains unchanged.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Driver update 'netrtwlane_13.inf' is already reflected.
+     sto: Driver update 'netwmbclass.inf' is already reflected.
+     sto: Driver update 'netrndis.inf' is already reflected.
+     sto: No effective section names for 'prnms003.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\prnms003.inf}
+     inf:      Class GUID     = {4d36e979-e325-11ce-bfc1-08002be10318}
+     idb:      Driver packages:
+     idb:           prnms003.inf_x86_8f17aac186c70ea6
+     idb:           prnms003.inf_x86_157f2e5194701963
+     idb:           prnms003.inf_x86_c42df827ba78f834
+     idb:           prnms003.inf_amd64_2da12eac1bd2c7cb (active)
+     idb:           prnms003.inf_amd64_73e8526b6d7c748c
+     idb:           prnms003.inf_amd64_827219ff41f9ea64
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'prnms004.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86\prnms004.inf}
+     inf:      Class GUID     = {4d36e979-e325-11ce-bfc1-08002be10318}
+     idb:      Driver packages:
+     idb:           prnms004.inf_amd64_5646d0853ac66f86 (active)
+     idb:           prnms004.inf_amd64_dc355e772d68650c
+     idb:           prnms004.inf_amd64_8b38d267bd5fdbd9
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'ntprint.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\ntprint.inf}
+     inf:      Class GUID     = {4d36e979-e325-11ce-bfc1-08002be10318}
+     idb:      Driver packages:
+     idb:           ntprint.inf_x86_b3cf4018952c495c
+     idb:           ntprint.inf_x86_f9aae5bf86267495
+     idb:           ntprint.inf_x86_08e757f7c012ea27
+     idb:           ntprint.inf_amd64_b3cf4018952c495c (active)
+     idb:           ntprint.inf_amd64_f9aae5bf86267495
+     idb:           ntprint.inf_amd64_08e757f7c012ea27
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Driver update 'ntprint4.inf' is already reflected.
+     sto: Skipping non-native x86 driver package 'ntprint.inf' on amd64.
+     sto: Skipping non-native x86 driver package 'prnms003.inf' on amd64.
+     sto: Driver update 'ucmucsi.inf' is already reflected.
+     sto: Driver update 'pci.inf' is already reflected.
+     sto: Driver update 'usbser.inf' is already reflected.
+     sto: Driver update 'stornvme.inf' is already reflected.
+     sto: Driver update 'msports.inf' is already reflected.
+     sto: Driver update 'buttonconverter.inf' is already reflected.
+     sto: Driver update 'mrvlpcie8897.inf' is already reflected.
+     sto: No effective section names for 'vhdmp.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_0e346fbd37116b8f\vhdmp.inf}
+     inf:      Class GUID     = {4d36e97b-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           vhdmp.inf_amd64_0e346fbd37116b8f (active)
+     idb:           vhdmp.inf_amd64_b486fbf51614c321
+     idb:           vhdmp.inf_amd64_33db47aeb773aeab
+     inf:      {Configure Driver: Microsoft VHD Loopback Controller}
+     inf:           Section Name = vhdmp_inst
+     inf:           {Add Service: vhdmp}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\vhdmp.sys
+     inf:                Group         = SCSI miniport
+     inf:                Updated service 'vhdmp'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = {8e7bd593-6e6c-4c52-86a6-77175494dd8e}\MsVhdHba
+     inf:           {Configure Driver Configuration: vhdmp_inst}
+     inf:                Service Name  = vhdmp
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_0e346fbd37116b8f\vhdmp.sys' to 'C:\Windows\System32\drivers\vhdmp.sys'.
+     idb:      Last driver package 'vhdmp.inf_amd64_b486fbf51614c321' to copy 'C:\Windows\System32\drivers\vhdmp.sys' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Driver update 'msgpiowin32.inf' is already reflected.
+     sto: Driver update 'wpdmtp.inf' is already reflected.
+     sto: Driver update 'tsusbhub.inf' is already reflected.
+     sto: {Update Device Drivers: xusb22.inf} 03:32:10.127
+     sto:      Driver Version = 9/29/2016,10.0.10240.17146
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 03:32:10.127
+     sto: {Update Device Drivers: wfcvsc.inf} 03:32:10.127
+     sto:      Driver Version = 6/21/2006,10.0.10240.17146
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 03:32:10.127
+     sto: {Update Device Drivers: genericusbfn.inf} 03:32:10.127
+     sto:      Driver Version = 9/29/2016,10.0.10240.17146
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 03:32:10.144
+     sto: {Update Device Drivers: bthaudhid.inf} 03:32:10.144
+     sto:      Driver Version = 9/29/2016,10.0.10240.17146
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 03:32:10.144
+     sto: {Update Device Drivers: hdaudio.inf} 03:32:10.144
+     sto:      Driver Version = 9/29/2016,10.0.10240.17146
+     sto:      {Update Device: HDAUDIO\FUNC_01&VEN_8384&DEV_7680&SUBSYS_83847680&REV_1034\4&22a99211&0&0001}
+     sto:           Updating installed driver version:
+     sto:                Driver Version Last     = 9/6/2016,10.0.10240.17113
+     sto:                Driver Version New      = 9/29/2016,10.0.10240.17146
+     sto:                Driver Node Strong Name = hdaudio.inf:db04a16ce4e8d6ee:HdAudModel:10.0.10240.17146:hdaudio\func_01
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      Updated drivers for 1 device node.
+     sto: {Update Device Drivers: exit(0x00000000)} 03:32:10.158
+     sto: {Update Device Drivers: hdaudbus.inf} 03:32:10.158
+     sto:      Driver Version = 9/29/2016,10.0.10240.17146
+     sto:      {Update Device: PCI\VEN_8086&DEV_2668&SUBSYS_76808384&REV_01\3&267a616a&1&28}
+     sto:           Updating installed driver version:
+     sto:                Driver Version Last     = 9/6/2016,10.0.10240.17113
+     sto:                Driver Version New      = 9/29/2016,10.0.10240.17146
+     sto:                Driver Node Strong Name = hdaudbus.inf:db04a16c28a36625:HDAudio_Device.NT:10.0.10240.17146:PCI\CC_0403
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      Updated drivers for 1 device node.
+     sto: {Update Device Drivers: exit(0x00000000)} 03:32:10.158
+     sto: {Update Device Drivers: prnms003.inf} 03:32:10.158
+     sto:      Driver Version = 6/21/2006,10.0.10240.17146
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 03:32:10.158
+     sto: {Update Device Drivers: prnms004.inf} 03:32:10.158
+     sto:      Driver Version = 6/21/2006,10.0.10240.17146
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 03:32:10.158
+     sto: {Update Device Drivers: ntprint.inf} 03:32:10.158
+     sto:      Driver Version = 6/21/2006,10.0.10240.17146
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 03:32:10.176
+     sto: {Update Device Drivers: vhdmp.inf} 03:32:10.176
+     sto:      Driver Version = 6/21/2006,10.0.10240.17146
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 03:32:10.176
+<<<  Section end 2016/10/12 03:32:10.176
+<<<  [Exit status: SUCCESS (REBOOT_REQUIRED)]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/12 03:32:10.204
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Transaction        = CbsDriversAndPrimitives
+     sto: Driver Updates     = 12
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_b486fbf51614c321\vhdmp.inf} 03:32:10.237
+     sto:      Driver Package = vhdmp.inf_amd64_b486fbf51614c321
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_b486fbf51614c321\vhdmp.inf} 03:32:10.237
+     idb:           Driver package 'vhdmp.inf_amd64_0e346fbd37116b8f' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 03:32:10.237
+     sto: {Unpublish Driver Package: exit(0x00000000)} 03:32:10.237
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_157f2e5194701963\prnms003.inf} 03:32:10.252
+     sto:      Driver Package = prnms003.inf_x86_157f2e5194701963
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_157f2e5194701963\prnms003.inf} 03:32:10.252
+     idb:           Driver package 'prnms003.inf_amd64_2da12eac1bd2c7cb' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 03:32:10.252
+     sto: {Unpublish Driver Package: exit(0x00000000)} 03:32:10.252
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\ntprint.inf} 03:32:10.252
+     sto:      Driver Package = ntprint.inf_x86_f9aae5bf86267495
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\ntprint.inf} 03:32:10.252
+     idb:           Driver package 'ntprint.inf_amd64_b3cf4018952c495c' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 03:32:10.252
+     sto: {Unpublish Driver Package: exit(0x00000000)} 03:32:10.252
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\ntprint.inf} 03:32:10.252
+     sto:      Driver Package = ntprint.inf_amd64_f9aae5bf86267495
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\ntprint.inf} 03:32:10.252
+     idb:           Driver package 'ntprint.inf_amd64_b3cf4018952c495c' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 03:32:10.252
+     sto: {Unpublish Driver Package: exit(0x00000000)} 03:32:10.252
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_dc355e772d68650c\prnms004.inf} 03:32:10.252
+     sto:      Driver Package = prnms004.inf_amd64_dc355e772d68650c
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_dc355e772d68650c\prnms004.inf} 03:32:10.252
+     idb:           Driver package 'prnms004.inf_amd64_5646d0853ac66f86' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 03:32:10.252
+     sto: {Unpublish Driver Package: exit(0x00000000)} 03:32:10.252
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_73e8526b6d7c748c\prnms003.inf} 03:32:10.252
+     sto:      Driver Package = prnms003.inf_amd64_73e8526b6d7c748c
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_73e8526b6d7c748c\prnms003.inf} 03:32:10.268
+     idb:           Driver package 'prnms003.inf_amd64_2da12eac1bd2c7cb' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 03:32:10.268
+     sto: {Unpublish Driver Package: exit(0x00000000)} 03:32:10.268
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_9b7a5db27f6d6cbd\hdaudio.inf} 03:32:10.268
+     sto:      Driver Package = hdaudio.inf_amd64_9b7a5db27f6d6cbd
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_9b7a5db27f6d6cbd\hdaudio.inf} 03:32:10.268
+     idb:           Driver package 'hdaudio.inf_amd64_c8e3ac50c9bf5564' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 03:32:10.268
+     sto: {Unpublish Driver Package: exit(0x00000000)} 03:32:10.268
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_3a98a84dd82f9b0a\hdaudbus.inf} 03:32:10.268
+     sto:      Driver Package = hdaudbus.inf_amd64_3a98a84dd82f9b0a
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_3a98a84dd82f9b0a\hdaudbus.inf} 03:32:10.268
+     idb:           Driver package 'hdaudbus.inf_amd64_070bdb1ad27e2f16' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 03:32:10.268
+     sto: {Unpublish Driver Package: exit(0x00000000)} 03:32:10.268
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_aaeb679851734af2\bthaudhid.inf} 03:32:10.268
+     sto:      Driver Package = bthaudhid.inf_amd64_aaeb679851734af2
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_aaeb679851734af2\bthaudhid.inf} 03:32:10.268
+     idb:           Driver package 'bthaudhid.inf_amd64_47034a2e2794f3b2' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 03:32:10.268
+     sto: {Unpublish Driver Package: exit(0x00000000)} 03:32:10.268
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_d519ce9ec210da10\genericusbfn.inf} 03:32:10.268
+     sto:      Driver Package = genericusbfn.inf_amd64_d519ce9ec210da10
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_d519ce9ec210da10\genericusbfn.inf} 03:32:10.268
+     idb:           Driver package 'genericusbfn.inf_amd64_221654d9bb6545af' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 03:32:10.268
+     sto: {Unpublish Driver Package: exit(0x00000000)} 03:32:10.284
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_f146c688c52c6479\wfcvsc.inf} 03:32:10.284
+     sto:      Driver Package = wfcvsc.inf_amd64_f146c688c52c6479
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_f146c688c52c6479\wfcvsc.inf} 03:32:10.284
+     idb:           Driver package 'wfcvsc.inf_amd64_4b9b5d5319497dd4' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 03:32:10.284
+     sto: {Unpublish Driver Package: exit(0x00000000)} 03:32:10.284
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_74d42d005ba12dd5\xusb22.inf} 03:32:10.284
+     sto:      Driver Package = xusb22.inf_amd64_74d42d005ba12dd5
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_74d42d005ba12dd5\xusb22.inf} 03:32:10.284
+     idb:           Driver package 'xusb22.inf_amd64_519ad1a6701b5cab' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 03:32:10.284
+     sto: {Unpublish Driver Package: exit(0x00000000)} 03:32:10.284
+     sto: Higher version of 'vhdmp.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_0e346fbd37116b8f\vhdmp.inf
+     sto: Skipping non-native x86 driver package 'prnms003.inf' on amd64.
+     sto: Skipping non-native x86 driver package 'ntprint.inf' on amd64.
+     sto: Higher version of 'ntprint.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\ntprint.inf
+     sto: Higher version of 'prnms004.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86\prnms004.inf
+     sto: Higher version of 'prnms003.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\prnms003.inf
+     sto: Higher version of 'hdaudio.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_c8e3ac50c9bf5564\hdaudio.inf
+     sto: Higher version of 'hdaudbus.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_070bdb1ad27e2f16\hdaudbus.inf
+     sto: Higher version of 'bthaudhid.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_47034a2e2794f3b2\bthaudhid.inf
+     sto: Higher version of 'genericusbfn.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_221654d9bb6545af\genericusbfn.inf
+     sto: Higher version of 'wfcvsc.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_4b9b5d5319497dd4\wfcvsc.inf
+     sto: Higher version of 'xusb22.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_519ad1a6701b5cab\xusb22.inf
+<<<  Section end 2016/10/12 03:32:10.298
+<<<  [Exit status: SUCCESS]
+
+
+[Boot Session: 2016/10/12 03:33:36.492]
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/12 03:34:33.625
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 12
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_b486fbf51614c321\vhdmp.inf} 03:34:34.213
+     sto:      {DRIVERSTORE DELETE BEGIN} 03:34:34.213
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 03:34:34.213
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_b486fbf51614c321\vhdmp.inf} 03:34:34.228
+     idb:           Unregistered driver package 'vhdmp.inf_amd64_b486fbf51614c321' from 'vhdmp.inf'.
+     idb:           Deleted driver package object 'vhdmp.inf_amd64_b486fbf51614c321' from SYSTEM database node.
+     idb:           Driver packages registered to 'vhdmp.inf':
+     idb:                vhdmp.inf_amd64_0e346fbd37116b8f
+     idb:                vhdmp.inf_amd64_33db47aeb773aeab
+     idb:      {Unregister Driver Package: exit(0x00000000)} 03:34:34.228
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_b486fbf51614c321} 03:34:34.228
+     cpy:      {Delete Directory: exit(0x00000000)} 03:34:34.259
+     sto:      {DRIVERSTORE DELETE END} 03:34:34.259
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 03:34:34.259
+     sto: {Unstage Driver Package: exit(0x00000000)} 03:34:34.259
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_157f2e5194701963\prnms003.inf} 03:34:34.259
+     sto:      {DRIVERSTORE DELETE BEGIN} 03:34:34.259
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 03:34:34.259
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_157f2e5194701963\prnms003.inf} 03:34:34.259
+     idb:           Unregistered driver package 'prnms003.inf_x86_157f2e5194701963' from 'prnms003.inf'.
+     idb:           Deleted driver package object 'prnms003.inf_x86_157f2e5194701963' from DRIVERS database node.
+     idb:           Driver packages registered to 'prnms003.inf':
+     idb:                prnms003.inf_x86_8f17aac186c70ea6
+     idb:                prnms003.inf_x86_c42df827ba78f834
+     idb:                prnms003.inf_amd64_2da12eac1bd2c7cb
+     idb:                prnms003.inf_amd64_73e8526b6d7c748c
+     idb:                prnms003.inf_amd64_827219ff41f9ea64
+     idb:      {Unregister Driver Package: exit(0x00000000)} 03:34:34.274
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_157f2e5194701963} 03:34:34.274
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_157f2e5194701963\I386} 03:34:34.305
+     cpy:           {Delete Directory: exit(0x00000000)} 03:34:34.337
+     cpy:      {Delete Directory: exit(0x00000000)} 03:34:34.417
+     sto:      {DRIVERSTORE DELETE END} 03:34:34.417
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 03:34:34.417
+     sto: {Unstage Driver Package: exit(0x00000000)} 03:34:34.417
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\ntprint.inf} 03:34:34.417
+     sto:      {DRIVERSTORE DELETE BEGIN} 03:34:34.417
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 03:34:34.417
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\ntprint.inf} 03:34:34.417
+     idb:           Unregistered driver package 'ntprint.inf_x86_f9aae5bf86267495' from 'ntprint.inf'.
+     idb:           Deleted driver package object 'ntprint.inf_x86_f9aae5bf86267495' from DRIVERS database node.
+     idb:           Driver packages registered to 'ntprint.inf':
+     idb:                ntprint.inf_x86_b3cf4018952c495c
+     idb:                ntprint.inf_x86_08e757f7c012ea27
+     idb:                ntprint.inf_amd64_b3cf4018952c495c
+     idb:                ntprint.inf_amd64_f9aae5bf86267495
+     idb:                ntprint.inf_amd64_08e757f7c012ea27
+     idb:      {Unregister Driver Package: exit(0x00000000)} 03:34:34.417
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495} 03:34:34.417
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_f9aae5bf86267495\I386} 03:34:34.492
+     cpy:           {Delete Directory: exit(0x00000000)} 03:34:34.584
+     cpy:      {Delete Directory: exit(0x00000000)} 03:34:34.584
+     sto:      {DRIVERSTORE DELETE END} 03:34:34.584
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 03:34:34.584
+     sto: {Unstage Driver Package: exit(0x00000000)} 03:34:34.584
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\ntprint.inf} 03:34:34.584
+     sto:      {DRIVERSTORE DELETE BEGIN} 03:34:34.584
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 03:34:34.584
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\ntprint.inf} 03:34:34.584
+     idb:           Unregistered driver package 'ntprint.inf_amd64_f9aae5bf86267495' from 'ntprint.inf'.
+     idb:           Deleted driver package object 'ntprint.inf_amd64_f9aae5bf86267495' from DRIVERS database node.
+     idb:           Driver packages registered to 'ntprint.inf':
+     idb:                ntprint.inf_x86_b3cf4018952c495c
+     idb:                ntprint.inf_x86_08e757f7c012ea27
+     idb:                ntprint.inf_amd64_b3cf4018952c495c
+     idb:                ntprint.inf_amd64_08e757f7c012ea27
+     idb:      {Unregister Driver Package: exit(0x00000000)} 03:34:34.584
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495} 03:34:34.584
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_f9aae5bf86267495\Amd64} 03:34:34.615
+     cpy:           {Delete Directory: exit(0x00000000)} 03:34:34.646
+     cpy:      {Delete Directory: exit(0x00000000)} 03:34:34.662
+     sto:      {DRIVERSTORE DELETE END} 03:34:34.662
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 03:34:34.662
+     sto: {Unstage Driver Package: exit(0x00000000)} 03:34:34.662
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_dc355e772d68650c\prnms004.inf} 03:34:34.662
+     sto:      {DRIVERSTORE DELETE BEGIN} 03:34:34.662
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 03:34:34.662
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_dc355e772d68650c\prnms004.inf} 03:34:34.662
+     idb:           Unregistered driver package 'prnms004.inf_amd64_dc355e772d68650c' from 'prnms004.inf'.
+     idb:           Deleted driver package object 'prnms004.inf_amd64_dc355e772d68650c' from DRIVERS database node.
+     idb:           Driver packages registered to 'prnms004.inf':
+     idb:                prnms004.inf_amd64_5646d0853ac66f86
+     idb:                prnms004.inf_amd64_8b38d267bd5fdbd9
+     idb:      {Unregister Driver Package: exit(0x00000000)} 03:34:34.662
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_dc355e772d68650c} 03:34:34.662
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_dc355e772d68650c\Amd64} 03:34:34.676
+     cpy:           {Delete Directory: exit(0x00000000)} 03:34:34.723
+     cpy:      {Delete Directory: exit(0x00000000)} 03:34:34.739
+     sto:      {DRIVERSTORE DELETE END} 03:34:34.739
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 03:34:34.739
+     sto: {Unstage Driver Package: exit(0x00000000)} 03:34:34.739
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_73e8526b6d7c748c\prnms003.inf} 03:34:34.739
+     sto:      {DRIVERSTORE DELETE BEGIN} 03:34:34.739
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 03:34:34.739
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_73e8526b6d7c748c\prnms003.inf} 03:34:34.739
+     idb:           Unregistered driver package 'prnms003.inf_amd64_73e8526b6d7c748c' from 'prnms003.inf'.
+     idb:           Deleted driver package object 'prnms003.inf_amd64_73e8526b6d7c748c' from DRIVERS database node.
+     idb:           Driver packages registered to 'prnms003.inf':
+     idb:                prnms003.inf_x86_8f17aac186c70ea6
+     idb:                prnms003.inf_x86_c42df827ba78f834
+     idb:                prnms003.inf_amd64_2da12eac1bd2c7cb
+     idb:                prnms003.inf_amd64_827219ff41f9ea64
+     idb:      {Unregister Driver Package: exit(0x00000000)} 03:34:34.739
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_73e8526b6d7c748c} 03:34:34.739
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_73e8526b6d7c748c\Amd64} 03:34:34.739
+     cpy:           {Delete Directory: exit(0x00000000)} 03:34:34.758
+     cpy:      {Delete Directory: exit(0x00000000)} 03:34:34.758
+     sto:      {DRIVERSTORE DELETE END} 03:34:34.758
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 03:34:34.758
+     sto: {Unstage Driver Package: exit(0x00000000)} 03:34:34.773
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_9b7a5db27f6d6cbd\hdaudio.inf} 03:34:34.773
+     sto:      {DRIVERSTORE DELETE BEGIN} 03:34:34.773
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 03:34:34.773
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_9b7a5db27f6d6cbd\hdaudio.inf} 03:34:34.773
+     idb:           Unregistered driver package 'hdaudio.inf_amd64_9b7a5db27f6d6cbd' from 'hdaudio.inf'.
+     idb:           Deleted driver package object 'hdaudio.inf_amd64_9b7a5db27f6d6cbd' from DRIVERS database node.
+     idb:           Driver packages registered to 'hdaudio.inf':
+     idb:                hdaudio.inf_amd64_c8e3ac50c9bf5564
+     idb:                hdaudio.inf_amd64_dab2294dc8af0030
+     idb:      {Unregister Driver Package: exit(0x00000000)} 03:34:34.773
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_9b7a5db27f6d6cbd} 03:34:34.773
+     cpy:      {Delete Directory: exit(0x00000000)} 03:34:34.801
+     sto:      {DRIVERSTORE DELETE END} 03:34:34.801
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 03:34:34.801
+     sto: {Unstage Driver Package: exit(0x00000000)} 03:34:34.801
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_3a98a84dd82f9b0a\hdaudbus.inf} 03:34:34.801
+     sto:      {DRIVERSTORE DELETE BEGIN} 03:34:34.801
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 03:34:34.801
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_3a98a84dd82f9b0a\hdaudbus.inf} 03:34:34.801
+     idb:           Unregistered driver package 'hdaudbus.inf_amd64_3a98a84dd82f9b0a' from 'hdaudbus.inf'.
+     idb:           Deleted driver package object 'hdaudbus.inf_amd64_3a98a84dd82f9b0a' from SYSTEM database node.
+     idb:           Driver packages registered to 'hdaudbus.inf':
+     idb:                hdaudbus.inf_amd64_070bdb1ad27e2f16
+     idb:                hdaudbus.inf_amd64_59e464503a2b3653
+     idb:      {Unregister Driver Package: exit(0x00000000)} 03:34:34.801
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_3a98a84dd82f9b0a} 03:34:34.801
+     cpy:      {Delete Directory: exit(0x00000000)} 03:34:34.801
+     sto:      {DRIVERSTORE DELETE END} 03:34:34.801
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 03:34:34.801
+     sto: {Unstage Driver Package: exit(0x00000000)} 03:34:34.801
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_aaeb679851734af2\bthaudhid.inf} 03:34:34.819
+     sto:      {DRIVERSTORE DELETE BEGIN} 03:34:34.819
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 03:34:34.819
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_aaeb679851734af2\bthaudhid.inf} 03:34:34.819
+     idb:           Unregistered driver package 'bthaudhid.inf_amd64_aaeb679851734af2' from 'bthaudhid.inf'.
+     idb:           Deleted driver package object 'bthaudhid.inf_amd64_aaeb679851734af2' from SYSTEM database node.
+     idb:           Driver packages registered to 'bthaudhid.inf':
+     idb:                bthaudhid.inf_amd64_47034a2e2794f3b2
+     idb:                bthaudhid.inf_amd64_b9a1f939467681b0
+     idb:      {Unregister Driver Package: exit(0x00000000)} 03:34:34.819
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_aaeb679851734af2} 03:34:34.819
+     cpy:      {Delete Directory: exit(0x00000000)} 03:34:34.862
+     sto:      {DRIVERSTORE DELETE END} 03:34:34.862
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 03:34:34.862
+     sto: {Unstage Driver Package: exit(0x00000000)} 03:34:34.862
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_d519ce9ec210da10\genericusbfn.inf} 03:34:34.862
+     sto:      {DRIVERSTORE DELETE BEGIN} 03:34:34.862
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 03:34:34.862
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_d519ce9ec210da10\genericusbfn.inf} 03:34:34.862
+     idb:           Unregistered driver package 'genericusbfn.inf_amd64_d519ce9ec210da10' from 'genericusbfn.inf'.
+     idb:           Deleted driver package object 'genericusbfn.inf_amd64_d519ce9ec210da10' from SYSTEM database node.
+     idb:           Driver packages registered to 'genericusbfn.inf':
+     idb:                genericusbfn.inf_amd64_221654d9bb6545af
+     idb:                genericusbfn.inf_amd64_74a699053034b56d
+     idb:      {Unregister Driver Package: exit(0x00000000)} 03:34:34.862
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_d519ce9ec210da10} 03:34:34.862
+     cpy:      {Delete Directory: exit(0x00000000)} 03:34:34.878
+     sto:      {DRIVERSTORE DELETE END} 03:34:34.878
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 03:34:34.878
+     sto: {Unstage Driver Package: exit(0x00000000)} 03:34:34.878
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_f146c688c52c6479\wfcvsc.inf} 03:34:34.878
+     sto:      {DRIVERSTORE DELETE BEGIN} 03:34:34.878
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 03:34:34.878
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_f146c688c52c6479\wfcvsc.inf} 03:34:34.878
+     idb:           Unregistered driver package 'wfcvsc.inf_amd64_f146c688c52c6479' from 'wfcvsc.inf'.
+     idb:           Deleted driver package object 'wfcvsc.inf_amd64_f146c688c52c6479' from SYSTEM database node.
+     idb:           Driver packages registered to 'wfcvsc.inf':
+     idb:                wfcvsc.inf_amd64_4b9b5d5319497dd4
+     idb:                wfcvsc.inf_amd64_f049c0f8aa802928
+     idb:      {Unregister Driver Package: exit(0x00000000)} 03:34:34.878
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_f146c688c52c6479} 03:34:34.878
+     cpy:      {Delete Directory: exit(0x00000000)} 03:34:34.924
+     sto:      {DRIVERSTORE DELETE END} 03:34:34.924
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 03:34:34.924
+     sto: {Unstage Driver Package: exit(0x00000000)} 03:34:34.924
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_74d42d005ba12dd5\xusb22.inf} 03:34:34.924
+     sto:      {DRIVERSTORE DELETE BEGIN} 03:34:34.924
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 03:34:34.924
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_74d42d005ba12dd5\xusb22.inf} 03:34:34.939
+     idb:           Unregistered driver package 'xusb22.inf_amd64_74d42d005ba12dd5' from 'xusb22.inf'.
+     idb:           Deleted driver package object 'xusb22.inf_amd64_74d42d005ba12dd5' from DRIVERS database node.
+     idb:           Driver packages registered to 'xusb22.inf':
+     idb:                xusb22.inf_amd64_519ad1a6701b5cab
+     idb:                xusb22.inf_amd64_438b7c551e424b28
+     idb:      {Unregister Driver Package: exit(0x00000000)} 03:34:34.939
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_74d42d005ba12dd5} 03:34:34.939
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_74d42d005ba12dd5\x64} 03:34:34.939
+     cpy:           {Delete Directory: exit(0x00000000)} 03:34:34.971
+     cpy:      {Delete Directory: exit(0x00000000)} 03:34:34.971
+     sto:      {DRIVERSTORE DELETE END} 03:34:34.971
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 03:34:34.971
+     sto: {Unstage Driver Package: exit(0x00000000)} 03:34:34.971
+<<<  Section end 2016/10/12 03:34:34.971
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Enable Device Install]
+>>>  Section start 2016/10/12 03:34:34.971
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     ump: DeviceInstall service is not started.
+<<<  Section end 2016/10/12 03:34:35.002
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Enable Device Install]
+>>>  Section start 2016/10/12 03:35:10.591
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     ump: DeviceInstall service is not disabled.
+     ump: DeviceInstall service is not started.
+<<<  Section end 2016/10/12 03:35:10.608
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Device Install (DiInstallDriver) - C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6\prnms003.inf]
+>>>  Section start 2016/10/12 03:36:30.936
+      cmd: C:\Windows\System32\spoolsv.exe
+     inf: {SetupCopyOEMInf: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6\prnms003.inf} 03:36:30.966
+     inf:      Driver Store Path: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6\prnms003.inf
+     inf:      Published Inf Path: C:\Windows\INF\prnms003.inf
+     inf: {SetupCopyOEMInf exit (0x00000000)} 03:36:30.982
+<<<  Section end 2016/10/12 03:36:30.998
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Device Install (DiInstallDriver) - C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\prnms003.inf]
+>>>  Section start 2016/10/12 03:36:34.286
+      cmd: C:\Windows\System32\spoolsv.exe
+     inf: {SetupCopyOEMInf: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\prnms003.inf} 03:36:34.366
+     inf:      Driver Store Path: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\prnms003.inf
+     inf:      Published Inf Path: C:\Windows\INF\prnms003.inf
+     inf: {SetupCopyOEMInf exit (0x00000000)} 03:36:34.906
+<<<  Section end 2016/10/12 03:36:34.921
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:52.562
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_ad65e307b13e6893\acpi.inf} 20:33:52.608
+     sto:      Driver Package = acpi.inf_amd64_ad65e307b13e6893
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_ad65e307b13e6893\acpi.inf} 20:33:52.608
+     idb:           Driver package 'acpi.inf_amd64_19a61be22ae9944e' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 94 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:52.701
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:52.701
+     sto: Higher version of 'acpi.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_19a61be22ae9944e\acpi.inf
+<<<  Section end 2016/10/14 20:33:52.701
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:52.701
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_ad65e307b13e6893\acpi.inf} 20:33:52.748
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:52.748
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:52.748
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_ad65e307b13e6893\acpi.inf} 20:33:52.748
+     idb:           Unregistered driver package 'acpi.inf_amd64_ad65e307b13e6893' from 'acpi.inf'.
+     idb:           Deleted driver package object 'acpi.inf_amd64_ad65e307b13e6893' from SYSTEM database node.
+     idb:           Driver packages registered to 'acpi.inf':
+     idb:                acpi.inf_amd64_19a61be22ae9944e
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:52.748
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_ad65e307b13e6893} 20:33:52.748
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:52.748
+     sto:      {DRIVERSTORE DELETE END} 20:33:52.748
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:52.748
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:52.748
+<<<  Section end 2016/10/14 20:33:52.765
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:52.765
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_6e5d1d4c2e1fa2ec\bth.inf} 20:33:53.155
+     sto:      Driver Package = bth.inf_amd64_6e5d1d4c2e1fa2ec
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_6e5d1d4c2e1fa2ec\bth.inf} 20:33:53.155
+     idb:           Driver package 'bth.inf_amd64_97f04f59eaecdf7a' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 265 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 63 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:53.499
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:53.499
+     sto: Higher version of 'bth.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\bth.inf
+<<<  Section end 2016/10/14 20:33:53.499
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:53.499
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_6e5d1d4c2e1fa2ec\bth.inf} 20:33:53.515
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:53.515
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:53.515
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_6e5d1d4c2e1fa2ec\bth.inf} 20:33:53.515
+     idb:           Unregistered driver package 'bth.inf_amd64_6e5d1d4c2e1fa2ec' from 'bth.inf'.
+     idb:           Deleted driver package object 'bth.inf_amd64_6e5d1d4c2e1fa2ec' from DRIVERS database node.
+     idb:           Driver packages registered to 'bth.inf':
+     idb:                bth.inf_amd64_97f04f59eaecdf7a
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:53.515
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_6e5d1d4c2e1fa2ec} 20:33:53.515
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:53.546
+     sto:      {DRIVERSTORE DELETE END} 20:33:53.546
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:53.546
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:53.546
+<<<  Section end 2016/10/14 20:33:53.546
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:53.608
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_b9a1f939467681b0\bthaudhid.inf} 20:33:53.639
+     sto:      Driver Package = bthaudhid.inf_amd64_b9a1f939467681b0
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_b9a1f939467681b0\bthaudhid.inf} 20:33:53.639
+     idb:           Driver package 'bthaudhid.inf_amd64_47034a2e2794f3b2' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 78 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:53.718
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:53.718
+     sto: Higher version of 'bthaudhid.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_47034a2e2794f3b2\bthaudhid.inf
+<<<  Section end 2016/10/14 20:33:53.735
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:53.735
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_b9a1f939467681b0\bthaudhid.inf} 20:33:53.735
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:53.735
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:53.735
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_b9a1f939467681b0\bthaudhid.inf} 20:33:53.735
+     idb:           Unregistered driver package 'bthaudhid.inf_amd64_b9a1f939467681b0' from 'bthaudhid.inf'.
+     idb:           Deleted driver package object 'bthaudhid.inf_amd64_b9a1f939467681b0' from SYSTEM database node.
+     idb:           Driver packages registered to 'bthaudhid.inf':
+     idb:                bthaudhid.inf_amd64_47034a2e2794f3b2
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:53.735
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_b9a1f939467681b0} 20:33:53.735
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:53.735
+     sto:      {DRIVERSTORE DELETE END} 20:33:53.735
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:53.735
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:53.735
+<<<  Section end 2016/10/14 20:33:53.751
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:53.751
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_40249d17ba142187\bthhfenum.inf} 20:33:53.751
+     sto:      Driver Package = bthhfenum.inf_amd64_40249d17ba142187
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_40249d17ba142187\bthhfenum.inf} 20:33:53.751
+     idb:           Driver package 'bthhfenum.inf_amd64_06170919fa54ed29' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 63 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:53.827
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:53.827
+     sto: Higher version of 'bthhfenum.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_06170919fa54ed29\bthhfenum.inf
+<<<  Section end 2016/10/14 20:33:53.827
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:53.827
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_40249d17ba142187\bthhfenum.inf} 20:33:53.827
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:53.827
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:53.827
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_40249d17ba142187\bthhfenum.inf} 20:33:53.827
+     idb:           Unregistered driver package 'bthhfenum.inf_amd64_40249d17ba142187' from 'bthhfenum.inf'.
+     idb:           Deleted driver package object 'bthhfenum.inf_amd64_40249d17ba142187' from SYSTEM database node.
+     idb:           Driver packages registered to 'bthhfenum.inf':
+     idb:                bthhfenum.inf_amd64_06170919fa54ed29
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:53.827
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_40249d17ba142187} 20:33:53.844
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:53.844
+     sto:      {DRIVERSTORE DELETE END} 20:33:53.844
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:53.844
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:53.844
+<<<  Section end 2016/10/14 20:33:53.844
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:53.844
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_91c9f1f9f9c90133\bthleenum.inf} 20:33:53.873
+     sto:      Driver Package = bthleenum.inf_amd64_91c9f1f9f9c90133
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_91c9f1f9f9c90133\bthleenum.inf} 20:33:53.873
+     idb:           Driver package 'bthleenum.inf_amd64_0dabadc4461923c4' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 15 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 63 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:53.952
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:53.952
+     sto: Higher version of 'bthleenum.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_0dabadc4461923c4\bthleenum.inf
+<<<  Section end 2016/10/14 20:33:53.952
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:53.952
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_91c9f1f9f9c90133\bthleenum.inf} 20:33:53.969
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:53.969
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:53.969
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_91c9f1f9f9c90133\bthleenum.inf} 20:33:53.969
+     idb:           Unregistered driver package 'bthleenum.inf_amd64_91c9f1f9f9c90133' from 'bthleenum.inf'.
+     idb:           Deleted driver package object 'bthleenum.inf_amd64_91c9f1f9f9c90133' from DRIVERS database node.
+     idb:           Driver packages registered to 'bthleenum.inf':
+     idb:                bthleenum.inf_amd64_0dabadc4461923c4
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:53.969
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_91c9f1f9f9c90133} 20:33:53.969
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:53.969
+     sto:      {DRIVERSTORE DELETE END} 20:33:53.969
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:53.969
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:53.969
+<<<  Section end 2016/10/14 20:33:53.969
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:54.014
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_3e28164cce51d5a9\buttonconverter.inf} 20:33:54.124
+     sto:      Driver Package = buttonconverter.inf_amd64_3e28164cce51d5a9
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_3e28164cce51d5a9\buttonconverter.inf} 20:33:54.124
+     idb:           Driver package 'buttonconverter.inf_amd64_b210406b0d8c4695' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 15 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:54.139
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:54.139
+     sto: Higher version of 'buttonconverter.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_b210406b0d8c4695\buttonconverter.inf
+<<<  Section end 2016/10/14 20:33:54.139
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:54.139
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_3e28164cce51d5a9\buttonconverter.inf} 20:33:54.155
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:54.155
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:54.155
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_3e28164cce51d5a9\buttonconverter.inf} 20:33:54.155
+     idb:           Unregistered driver package 'buttonconverter.inf_amd64_3e28164cce51d5a9' from 'buttonconverter.inf'.
+     idb:           Deleted driver package object 'buttonconverter.inf_amd64_3e28164cce51d5a9' from SYSTEM database node.
+     idb:           Driver packages registered to 'buttonconverter.inf':
+     idb:                buttonconverter.inf_amd64_b210406b0d8c4695
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:54.155
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_3e28164cce51d5a9} 20:33:54.155
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:54.155
+     sto:      {DRIVERSTORE DELETE END} 20:33:54.155
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:54.155
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:54.155
+<<<  Section end 2016/10/14 20:33:54.155
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:54.186
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_74a699053034b56d\genericusbfn.inf} 20:33:54.217
+     sto:      Driver Package = genericusbfn.inf_amd64_74a699053034b56d
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_74a699053034b56d\genericusbfn.inf} 20:33:54.217
+     idb:           Driver package 'genericusbfn.inf_amd64_221654d9bb6545af' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 78 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:54.295
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:54.295
+     sto: Higher version of 'genericusbfn.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_221654d9bb6545af\genericusbfn.inf
+<<<  Section end 2016/10/14 20:33:54.311
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:54.311
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_74a699053034b56d\genericusbfn.inf} 20:33:54.311
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:54.311
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:54.311
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_74a699053034b56d\genericusbfn.inf} 20:33:54.311
+     idb:           Unregistered driver package 'genericusbfn.inf_amd64_74a699053034b56d' from 'genericusbfn.inf'.
+     idb:           Deleted driver package object 'genericusbfn.inf_amd64_74a699053034b56d' from SYSTEM database node.
+     idb:           Driver packages registered to 'genericusbfn.inf':
+     idb:                genericusbfn.inf_amd64_221654d9bb6545af
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:54.311
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_74a699053034b56d} 20:33:54.311
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:54.311
+     sto:      {DRIVERSTORE DELETE END} 20:33:54.311
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:54.311
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:54.311
+<<<  Section end 2016/10/14 20:33:54.311
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:54.358
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_59e464503a2b3653\hdaudbus.inf} 20:33:54.358
+     sto:      Driver Package = hdaudbus.inf_amd64_59e464503a2b3653
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_59e464503a2b3653\hdaudbus.inf} 20:33:54.358
+     idb:           Driver package 'hdaudbus.inf_amd64_070bdb1ad27e2f16' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 62 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:54.420
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:54.420
+     sto: Higher version of 'hdaudbus.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_070bdb1ad27e2f16\hdaudbus.inf
+<<<  Section end 2016/10/14 20:33:54.420
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:54.437
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_59e464503a2b3653\hdaudbus.inf} 20:33:54.437
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:54.437
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:54.437
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_59e464503a2b3653\hdaudbus.inf} 20:33:54.437
+     idb:           Unregistered driver package 'hdaudbus.inf_amd64_59e464503a2b3653' from 'hdaudbus.inf'.
+     idb:           Deleted driver package object 'hdaudbus.inf_amd64_59e464503a2b3653' from SYSTEM database node.
+     idb:           Driver packages registered to 'hdaudbus.inf':
+     idb:                hdaudbus.inf_amd64_070bdb1ad27e2f16
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:54.437
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_59e464503a2b3653} 20:33:54.437
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:54.437
+     sto:      {DRIVERSTORE DELETE END} 20:33:54.437
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:54.437
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:54.437
+<<<  Section end 2016/10/14 20:33:54.437
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:54.455
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_dab2294dc8af0030\hdaudio.inf} 20:33:54.485
+     sto:      Driver Package = hdaudio.inf_amd64_dab2294dc8af0030
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_dab2294dc8af0030\hdaudio.inf} 20:33:54.485
+     idb:           Driver package 'hdaudio.inf_amd64_c8e3ac50c9bf5564' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 16 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 46 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:54.545
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:54.545
+     sto: Higher version of 'hdaudio.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_c8e3ac50c9bf5564\hdaudio.inf
+<<<  Section end 2016/10/14 20:33:54.561
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:54.561
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_dab2294dc8af0030\hdaudio.inf} 20:33:54.561
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:54.561
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:54.561
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_dab2294dc8af0030\hdaudio.inf} 20:33:54.561
+     idb:           Unregistered driver package 'hdaudio.inf_amd64_dab2294dc8af0030' from 'hdaudio.inf'.
+     idb:           Deleted driver package object 'hdaudio.inf_amd64_dab2294dc8af0030' from DRIVERS database node.
+     idb:           Driver packages registered to 'hdaudio.inf':
+     idb:                hdaudio.inf_amd64_c8e3ac50c9bf5564
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:54.577
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_dab2294dc8af0030} 20:33:54.577
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:54.577
+     sto:      {DRIVERSTORE DELETE END} 20:33:54.577
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:54.577
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:54.577
+<<<  Section end 2016/10/14 20:33:54.577
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:54.608
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_59c6e34e5bb0339a\hidscanner.inf} 20:33:54.655
+     sto:      Driver Package = hidscanner.inf_amd64_59c6e34e5bb0339a
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_59c6e34e5bb0339a\hidscanner.inf} 20:33:54.655
+     idb:           Driver package 'hidscanner.inf_amd64_a4bdb031f38afa10' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 15 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 0 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:54.671
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:54.671
+     sto: Higher version of 'hidscanner.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_a4bdb031f38afa10\hidscanner.inf
+<<<  Section end 2016/10/14 20:33:54.671
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:54.688
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_59c6e34e5bb0339a\hidscanner.inf} 20:33:54.688
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:54.688
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:54.688
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_59c6e34e5bb0339a\hidscanner.inf} 20:33:54.688
+     idb:           Unregistered driver package 'hidscanner.inf_amd64_59c6e34e5bb0339a' from 'hidscanner.inf'.
+     idb:           Deleted driver package object 'hidscanner.inf_amd64_59c6e34e5bb0339a' from DRIVERS database node.
+     idb:           Driver packages registered to 'hidscanner.inf':
+     idb:                hidscanner.inf_amd64_a4bdb031f38afa10
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:54.688
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_59c6e34e5bb0339a} 20:33:54.688
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:54.688
+     sto:      {DRIVERSTORE DELETE END} 20:33:54.688
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:54.688
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:54.688
+<<<  Section end 2016/10/14 20:33:54.705
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:54.718
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_a39b901bc01403cc\mdmbtmdm.inf} 20:33:54.733
+     sto:      Driver Package = mdmbtmdm.inf_amd64_a39b901bc01403cc
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_a39b901bc01403cc\mdmbtmdm.inf} 20:33:54.733
+     idb:           Driver package 'mdmbtmdm.inf_amd64_57032036ac5b3f02' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 31 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 0 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:54.764
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:54.764
+     sto: Higher version of 'mdmbtmdm.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_57032036ac5b3f02\mdmbtmdm.inf
+<<<  Section end 2016/10/14 20:33:54.764
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:54.764
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_a39b901bc01403cc\mdmbtmdm.inf} 20:33:54.764
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:54.764
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:54.764
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_a39b901bc01403cc\mdmbtmdm.inf} 20:33:54.764
+     idb:           Unregistered driver package 'mdmbtmdm.inf_amd64_a39b901bc01403cc' from 'mdmbtmdm.inf'.
+     idb:           Deleted driver package object 'mdmbtmdm.inf_amd64_a39b901bc01403cc' from DRIVERS database node.
+     idb:           Driver packages registered to 'mdmbtmdm.inf':
+     idb:                mdmbtmdm.inf_amd64_57032036ac5b3f02
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:54.781
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_a39b901bc01403cc} 20:33:54.781
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:54.781
+     sto:      {DRIVERSTORE DELETE END} 20:33:54.781
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:54.781
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:54.781
+<<<  Section end 2016/10/14 20:33:54.781
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:54.796
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_1ae5c465b296b702\miradisp.inf} 20:33:54.828
+     sto:      Driver Package = miradisp.inf_amd64_1ae5c465b296b702
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_1ae5c465b296b702\miradisp.inf} 20:33:54.845
+     idb:           Driver package 'miradisp.inf_amd64_01ce808b39cab47d' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 16 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 0 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:54.873
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:54.873
+     sto: Higher version of 'miradisp.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_01ce808b39cab47d\miradisp.inf
+<<<  Section end 2016/10/14 20:33:54.873
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:54.873
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_1ae5c465b296b702\miradisp.inf} 20:33:54.891
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:54.891
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:54.891
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_1ae5c465b296b702\miradisp.inf} 20:33:54.891
+     idb:           Unregistered driver package 'miradisp.inf_amd64_1ae5c465b296b702' from 'miradisp.inf'.
+     idb:           Deleted driver package object 'miradisp.inf_amd64_1ae5c465b296b702' from DRIVERS database node.
+     idb:           Driver packages registered to 'miradisp.inf':
+     idb:                miradisp.inf_amd64_01ce808b39cab47d
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:54.891
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_1ae5c465b296b702} 20:33:54.891
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:54.891
+     sto:      {DRIVERSTORE DELETE END} 20:33:54.891
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:54.891
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:54.891
+<<<  Section end 2016/10/14 20:33:54.891
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:54.905
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_a183375586623a76\msgpiowin32.inf} 20:33:54.936
+     sto:      Driver Package = msgpiowin32.inf_amd64_a183375586623a76
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_a183375586623a76\msgpiowin32.inf} 20:33:54.936
+     idb:           Driver package 'msgpiowin32.inf_amd64_4563c8367012234f' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 63 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:54.999
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:54.999
+     sto: Higher version of 'msgpiowin32.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_4563c8367012234f\msgpiowin32.inf
+<<<  Section end 2016/10/14 20:33:54.999
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:54.999
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_a183375586623a76\msgpiowin32.inf} 20:33:55.015
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:55.015
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:55.015
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_a183375586623a76\msgpiowin32.inf} 20:33:55.015
+     idb:           Unregistered driver package 'msgpiowin32.inf_amd64_a183375586623a76' from 'msgpiowin32.inf'.
+     idb:           Deleted driver package object 'msgpiowin32.inf_amd64_a183375586623a76' from SYSTEM database node.
+     idb:           Driver packages registered to 'msgpiowin32.inf':
+     idb:                msgpiowin32.inf_amd64_4563c8367012234f
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:55.015
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_a183375586623a76} 20:33:55.015
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:55.015
+     sto:      {DRIVERSTORE DELETE END} 20:33:55.015
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:55.015
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:55.015
+<<<  Section end 2016/10/14 20:33:55.015
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:55.031
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_db43c0c39a11ad06\msports.inf} 20:33:55.077
+     sto:      Driver Package = msports.inf_amd64_db43c0c39a11ad06
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_db43c0c39a11ad06\msports.inf} 20:33:55.077
+     idb:           Driver package 'msports.inf_amd64_46e9747fe38474e5' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 78 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:55.155
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:55.155
+     sto: Higher version of 'msports.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\msports.inf
+<<<  Section end 2016/10/14 20:33:55.155
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:55.155
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_db43c0c39a11ad06\msports.inf} 20:33:55.171
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:55.171
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:55.171
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_db43c0c39a11ad06\msports.inf} 20:33:55.171
+     idb:           Unregistered driver package 'msports.inf_amd64_db43c0c39a11ad06' from 'msports.inf'.
+     idb:           Deleted driver package object 'msports.inf_amd64_db43c0c39a11ad06' from SYSTEM database node.
+     idb:           Driver packages registered to 'msports.inf':
+     idb:                msports.inf_amd64_46e9747fe38474e5
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:55.171
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_db43c0c39a11ad06} 20:33:55.171
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:55.189
+     sto:      {DRIVERSTORE DELETE END} 20:33:55.189
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:55.189
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:55.189
+<<<  Section end 2016/10/14 20:33:55.189
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:55.189
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_15559e68f1d2f050\netrndis.inf} 20:33:55.219
+     sto:      Driver Package = netrndis.inf_amd64_15559e68f1d2f050
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_15559e68f1d2f050\netrndis.inf} 20:33:55.219
+     idb:           Driver package 'netrndis.inf_amd64_609a0bb012179987' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 32 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 62 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:55.311
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:55.311
+     sto: Higher version of 'netrndis.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_609a0bb012179987\netrndis.inf
+<<<  Section end 2016/10/14 20:33:55.311
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:55.329
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_15559e68f1d2f050\netrndis.inf} 20:33:55.329
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:55.329
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:55.329
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_15559e68f1d2f050\netrndis.inf} 20:33:55.329
+     idb:           Unregistered driver package 'netrndis.inf_amd64_15559e68f1d2f050' from 'netrndis.inf'.
+     idb:           Deleted driver package object 'netrndis.inf_amd64_15559e68f1d2f050' from DRIVERS database node.
+     idb:           Driver packages registered to 'netrndis.inf':
+     idb:                netrndis.inf_amd64_609a0bb012179987
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:55.329
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_15559e68f1d2f050} 20:33:55.329
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:55.329
+     sto:      {DRIVERSTORE DELETE END} 20:33:55.329
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:55.329
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:55.329
+<<<  Section end 2016/10/14 20:33:55.329
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:55.359
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_08862ceb4cd44db9\netrtwlane_13.inf} 20:33:55.389
+     sto:      Driver Package = netrtwlane_13.inf_amd64_08862ceb4cd44db9
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_08862ceb4cd44db9\netrtwlane_13.inf} 20:33:55.389
+     idb:           Driver package 'netrtwlane_13.inf_amd64_8e17ee2826ff2b07' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 31 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 0 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:55.420
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:55.420
+     sto: Higher version of 'netrtwlane_13.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_8e17ee2826ff2b07\netrtwlane_13.inf
+<<<  Section end 2016/10/14 20:33:55.420
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:55.420
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_08862ceb4cd44db9\netrtwlane_13.inf} 20:33:55.439
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:55.439
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:55.439
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_08862ceb4cd44db9\netrtwlane_13.inf} 20:33:55.439
+     idb:           Unregistered driver package 'netrtwlane_13.inf_amd64_08862ceb4cd44db9' from 'netrtwlane_13.inf'.
+     idb:           Deleted driver package object 'netrtwlane_13.inf_amd64_08862ceb4cd44db9' from DRIVERS database node.
+     idb:           Driver packages registered to 'netrtwlane_13.inf':
+     idb:                netrtwlane_13.inf_amd64_8e17ee2826ff2b07
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:55.457
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_08862ceb4cd44db9} 20:33:55.457
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:55.457
+     sto:      {DRIVERSTORE DELETE END} 20:33:55.457
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:55.457
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:55.457
+<<<  Section end 2016/10/14 20:33:55.457
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:55.457
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_828a7d91ae6b1b6a\netwmbclass.inf} 20:33:55.499
+     sto:      Driver Package = netwmbclass.inf_amd64_828a7d91ae6b1b6a
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_828a7d91ae6b1b6a\netwmbclass.inf} 20:33:55.499
+     idb:           Driver package 'netwmbclass.inf_amd64_ed51114936bfc236' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 31 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 0 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:55.530
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:55.530
+     sto: Higher version of 'netwmbclass.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_ed51114936bfc236\netwmbclass.inf
+<<<  Section end 2016/10/14 20:33:55.530
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:55.530
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_828a7d91ae6b1b6a\netwmbclass.inf} 20:33:55.530
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:55.530
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:55.530
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_828a7d91ae6b1b6a\netwmbclass.inf} 20:33:55.530
+     idb:           Unregistered driver package 'netwmbclass.inf_amd64_828a7d91ae6b1b6a' from 'netwmbclass.inf'.
+     idb:           Deleted driver package object 'netwmbclass.inf_amd64_828a7d91ae6b1b6a' from DRIVERS database node.
+     idb:           Driver packages registered to 'netwmbclass.inf':
+     idb:                netwmbclass.inf_amd64_ed51114936bfc236
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:55.530
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_828a7d91ae6b1b6a} 20:33:55.530
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:55.530
+     sto:      {DRIVERSTORE DELETE END} 20:33:55.547
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:55.547
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:55.547
+<<<  Section end 2016/10/14 20:33:55.547
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:55.562
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_08e757f7c012ea27\ntprint.inf} 20:33:55.577
+     sto:      Driver Package = ntprint.inf_amd64_08e757f7c012ea27
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_08e757f7c012ea27\ntprint.inf} 20:33:55.577
+     idb:           Driver package 'ntprint.inf_amd64_b3cf4018952c495c' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 15 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 0 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:55.608
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:55.608
+     sto: Higher version of 'ntprint.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\ntprint.inf
+<<<  Section end 2016/10/14 20:33:55.608
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:55.608
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_08e757f7c012ea27\ntprint.inf} 20:33:55.608
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:55.608
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:55.608
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_08e757f7c012ea27\ntprint.inf} 20:33:55.608
+     idb:           Unregistered driver package 'ntprint.inf_amd64_08e757f7c012ea27' from 'ntprint.inf'.
+     idb:           Deleted driver package object 'ntprint.inf_amd64_08e757f7c012ea27' from DRIVERS database node.
+     idb:           Driver packages registered to 'ntprint.inf':
+     idb:                ntprint.inf_x86_b3cf4018952c495c
+     idb:                ntprint.inf_x86_08e757f7c012ea27
+     idb:                ntprint.inf_amd64_b3cf4018952c495c
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:55.608
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_08e757f7c012ea27} 20:33:55.608
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_08e757f7c012ea27\Amd64} 20:33:55.608
+     cpy:           {Delete Directory: exit(0x00000000)} 20:33:55.639
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:55.639
+     sto:      {DRIVERSTORE DELETE END} 20:33:55.657
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:55.657
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:55.657
+<<<  Section end 2016/10/14 20:33:55.657
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:55.657
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_7373a688eceb5d01\ntprint4.inf} 20:33:55.657
+     sto:      Driver Package = ntprint4.inf_amd64_7373a688eceb5d01
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_7373a688eceb5d01\ntprint4.inf} 20:33:55.657
+     idb:           Driver package 'ntprint4.inf_amd64_34fc089922f9b11d' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 31 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 0 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:55.686
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:55.686
+     sto: Higher version of 'ntprint4.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\ntprint4.inf
+<<<  Section end 2016/10/14 20:33:55.686
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:55.686
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_7373a688eceb5d01\ntprint4.inf} 20:33:55.703
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:55.703
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:55.703
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_7373a688eceb5d01\ntprint4.inf} 20:33:55.703
+     idb:           Unregistered driver package 'ntprint4.inf_amd64_7373a688eceb5d01' from 'ntprint4.inf'.
+     idb:           Deleted driver package object 'ntprint4.inf_amd64_7373a688eceb5d01' from DRIVERS database node.
+     idb:           Driver packages registered to 'ntprint4.inf':
+     idb:                ntprint4.inf_amd64_34fc089922f9b11d
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:55.703
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_7373a688eceb5d01} 20:33:55.703
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_7373a688eceb5d01\Amd64} 20:33:55.703
+     cpy:           {Delete Directory: exit(0x00000000)} 20:33:55.749
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:55.749
+     sto:      {DRIVERSTORE DELETE END} 20:33:55.749
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:55.749
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:55.749
+<<<  Section end 2016/10/14 20:33:55.749
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:55.765
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_e13dd3a79d516ff2\pci.inf} 20:33:55.765
+     sto:      Driver Package = pci.inf_amd64_e13dd3a79d516ff2
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_e13dd3a79d516ff2\pci.inf} 20:33:55.765
+     idb:           Driver package 'pci.inf_amd64_61ccd5db98b3abf1' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 63 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:55.826
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:55.826
+     sto: Higher version of 'pci.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_61ccd5db98b3abf1\pci.inf
+<<<  Section end 2016/10/14 20:33:55.826
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:55.826
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_e13dd3a79d516ff2\pci.inf} 20:33:55.844
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:55.844
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:55.844
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_e13dd3a79d516ff2\pci.inf} 20:33:55.844
+     idb:           Unregistered driver package 'pci.inf_amd64_e13dd3a79d516ff2' from 'pci.inf'.
+     idb:           Deleted driver package object 'pci.inf_amd64_e13dd3a79d516ff2' from SYSTEM database node.
+     idb:           Driver packages registered to 'pci.inf':
+     idb:                pci.inf_amd64_61ccd5db98b3abf1
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:55.844
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_e13dd3a79d516ff2} 20:33:55.844
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:55.844
+     sto:      {DRIVERSTORE DELETE END} 20:33:55.844
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:55.844
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:55.844
+<<<  Section end 2016/10/14 20:33:55.844
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:55.873
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_827219ff41f9ea64\prnms003.inf} 20:33:55.889
+     sto:      Driver Package = prnms003.inf_amd64_827219ff41f9ea64
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_827219ff41f9ea64\prnms003.inf} 20:33:55.889
+     idb:           Driver package 'prnms003.inf_amd64_2da12eac1bd2c7cb' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 16 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 62 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:55.967
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:55.967
+     sto: Higher version of 'prnms003.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\prnms003.inf
+<<<  Section end 2016/10/14 20:33:55.967
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:55.967
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_827219ff41f9ea64\prnms003.inf} 20:33:55.985
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:55.985
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:55.985
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_827219ff41f9ea64\prnms003.inf} 20:33:55.985
+     idb:           Unregistered driver package 'prnms003.inf_amd64_827219ff41f9ea64' from 'prnms003.inf'.
+     idb:           Deleted driver package object 'prnms003.inf_amd64_827219ff41f9ea64' from DRIVERS database node.
+     idb:           Driver packages registered to 'prnms003.inf':
+     idb:                prnms003.inf_x86_8f17aac186c70ea6
+     idb:                prnms003.inf_x86_c42df827ba78f834
+     idb:                prnms003.inf_amd64_2da12eac1bd2c7cb
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:55.985
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_827219ff41f9ea64} 20:33:55.985
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_827219ff41f9ea64\Amd64} 20:33:55.985
+     cpy:           {Delete Directory: exit(0x00000000)} 20:33:55.985
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:55.985
+     sto:      {DRIVERSTORE DELETE END} 20:33:55.985
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:55.985
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:55.985
+<<<  Section end 2016/10/14 20:33:55.985
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:56.014
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_8b38d267bd5fdbd9\prnms004.inf} 20:33:56.014
+     sto:      Driver Package = prnms004.inf_amd64_8b38d267bd5fdbd9
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_8b38d267bd5fdbd9\prnms004.inf} 20:33:56.014
+     idb:           Driver package 'prnms004.inf_amd64_5646d0853ac66f86' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 16 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 0 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:56.030
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:56.030
+     sto: Higher version of 'prnms004.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86\prnms004.inf
+<<<  Section end 2016/10/14 20:33:56.048
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:56.048
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_8b38d267bd5fdbd9\prnms004.inf} 20:33:56.048
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:56.048
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:56.048
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_8b38d267bd5fdbd9\prnms004.inf} 20:33:56.048
+     idb:           Unregistered driver package 'prnms004.inf_amd64_8b38d267bd5fdbd9' from 'prnms004.inf'.
+     idb:           Deleted driver package object 'prnms004.inf_amd64_8b38d267bd5fdbd9' from DRIVERS database node.
+     idb:           Driver packages registered to 'prnms004.inf':
+     idb:                prnms004.inf_amd64_5646d0853ac66f86
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:56.048
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_8b38d267bd5fdbd9} 20:33:56.048
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_8b38d267bd5fdbd9\Amd64} 20:33:56.048
+     cpy:           {Delete Directory: exit(0x00000000)} 20:33:56.048
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:56.063
+     sto:      {DRIVERSTORE DELETE END} 20:33:56.063
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:56.063
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:56.063
+<<<  Section end 2016/10/14 20:33:56.063
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:56.063
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_7fb86acc31fcdbad\sdbus.inf} 20:33:56.077
+     sto:      Driver Package = sdbus.inf_amd64_7fb86acc31fcdbad
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_7fb86acc31fcdbad\sdbus.inf} 20:33:56.077
+     idb:           Driver package 'sdbus.inf_amd64_b33128a95ba9fe0b' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 109 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:56.186
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:56.186
+     sto: Higher version of 'sdbus.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_b33128a95ba9fe0b\sdbus.inf
+<<<  Section end 2016/10/14 20:33:56.186
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:56.186
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_7fb86acc31fcdbad\sdbus.inf} 20:33:56.204
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:56.204
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:56.204
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_7fb86acc31fcdbad\sdbus.inf} 20:33:56.204
+     idb:           Unregistered driver package 'sdbus.inf_amd64_7fb86acc31fcdbad' from 'sdbus.inf'.
+     idb:           Deleted driver package object 'sdbus.inf_amd64_7fb86acc31fcdbad' from SYSTEM database node.
+     idb:           Driver packages registered to 'sdbus.inf':
+     idb:                sdbus.inf_amd64_b33128a95ba9fe0b
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:56.204
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_7fb86acc31fcdbad} 20:33:56.221
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:56.221
+     sto:      {DRIVERSTORE DELETE END} 20:33:56.221
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:56.221
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:56.221
+<<<  Section end 2016/10/14 20:33:56.221
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:56.221
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_63666a8e1afcc522\sensorshidclassdriver.inf} 20:33:56.249
+     sto:      Driver Package = sensorshidclassdriver.inf_amd64_63666a8e1afcc522
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_63666a8e1afcc522\sensorshidclassdriver.inf} 20:33:56.249
+     idb:           Driver package 'sensorshidclassdriver.inf_amd64_57265cb2d2642968' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 31 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 31 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:56.311
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:56.311
+     sto: Higher version of 'SensorsHidClassDriver.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_57265cb2d2642968\sensorshidclassdriver.inf
+<<<  Section end 2016/10/14 20:33:56.311
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:56.311
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_63666a8e1afcc522\sensorshidclassdriver.inf} 20:33:56.329
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:56.329
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:56.329
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_63666a8e1afcc522\sensorshidclassdriver.inf} 20:33:56.329
+     idb:           Unregistered driver package 'sensorshidclassdriver.inf_amd64_63666a8e1afcc522' from 'SensorsHidClassDriver.inf'.
+     idb:           Deleted driver package object 'sensorshidclassdriver.inf_amd64_63666a8e1afcc522' from DRIVERS database node.
+     idb:           Driver packages registered to 'SensorsHidClassDriver.inf':
+     idb:                sensorshidclassdriver.inf_amd64_57265cb2d2642968
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:56.329
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_63666a8e1afcc522} 20:33:56.329
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:56.329
+     sto:      {DRIVERSTORE DELETE END} 20:33:56.329
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:56.329
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:56.329
+<<<  Section end 2016/10/14 20:33:56.329
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:56.389
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_701b8d7c698c983a\stornvme.inf} 20:33:56.405
+     sto:      Driver Package = stornvme.inf_amd64_701b8d7c698c983a
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_701b8d7c698c983a\stornvme.inf} 20:33:56.421
+     idb:           Driver package 'stornvme.inf_amd64_5ffb10fc0bbc4ac0' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 79 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:56.498
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:56.498
+     sto: Higher version of 'stornvme.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_5ffb10fc0bbc4ac0\stornvme.inf
+<<<  Section end 2016/10/14 20:33:56.498
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:56.498
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_701b8d7c698c983a\stornvme.inf} 20:33:56.515
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:56.515
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:56.515
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_701b8d7c698c983a\stornvme.inf} 20:33:56.515
+     idb:           Unregistered driver package 'stornvme.inf_amd64_701b8d7c698c983a' from 'stornvme.inf'.
+     idb:           Deleted driver package object 'stornvme.inf_amd64_701b8d7c698c983a' from SYSTEM database node.
+     idb:           Driver packages registered to 'stornvme.inf':
+     idb:                stornvme.inf_amd64_5ffb10fc0bbc4ac0
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:56.515
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_701b8d7c698c983a} 20:33:56.515
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:56.515
+     sto:      {DRIVERSTORE DELETE END} 20:33:56.515
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:56.515
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:56.515
+<<<  Section end 2016/10/14 20:33:56.515
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:56.545
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_35185b4c0664e5a3\tsusbhub.inf} 20:33:56.545
+     sto:      Driver Package = tsusbhub.inf_amd64_35185b4c0664e5a3
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_35185b4c0664e5a3\tsusbhub.inf} 20:33:56.561
+     idb:           Driver package 'tsusbhub.inf_amd64_b01c6baade1c797a' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 63 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:56.624
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:56.624
+     sto: Higher version of 'tsusbhub.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_b01c6baade1c797a\tsusbhub.inf
+<<<  Section end 2016/10/14 20:33:56.624
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:56.624
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_35185b4c0664e5a3\tsusbhub.inf} 20:33:56.640
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:56.640
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:56.640
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_35185b4c0664e5a3\tsusbhub.inf} 20:33:56.640
+     idb:           Unregistered driver package 'tsusbhub.inf_amd64_35185b4c0664e5a3' from 'tsusbhub.inf'.
+     idb:           Deleted driver package object 'tsusbhub.inf_amd64_35185b4c0664e5a3' from SYSTEM database node.
+     idb:           Driver packages registered to 'tsusbhub.inf':
+     idb:                tsusbhub.inf_amd64_b01c6baade1c797a
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:56.640
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_35185b4c0664e5a3} 20:33:56.640
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:56.640
+     sto:      {DRIVERSTORE DELETE END} 20:33:56.640
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:56.640
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:56.640
+<<<  Section end 2016/10/14 20:33:56.640
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:56.702
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_836de75251bf9189\ucmucsi.inf} 20:33:56.702
+     sto:      Driver Package = ucmucsi.inf_amd64_836de75251bf9189
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_836de75251bf9189\ucmucsi.inf} 20:33:56.702
+     idb:           Driver package 'ucmucsi.inf_amd64_86bd71749200d4fb' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 78 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:56.780
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:56.780
+     sto: Higher version of 'UcmUcsi.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_86bd71749200d4fb\ucmucsi.inf
+<<<  Section end 2016/10/14 20:33:56.796
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:56.796
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_836de75251bf9189\ucmucsi.inf} 20:33:56.796
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:56.796
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:56.796
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_836de75251bf9189\ucmucsi.inf} 20:33:56.796
+     idb:           Unregistered driver package 'ucmucsi.inf_amd64_836de75251bf9189' from 'UcmUcsi.inf'.
+     idb:           Deleted driver package object 'ucmucsi.inf_amd64_836de75251bf9189' from SYSTEM database node.
+     idb:           Driver packages registered to 'UcmUcsi.inf':
+     idb:                ucmucsi.inf_amd64_86bd71749200d4fb
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:56.796
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_836de75251bf9189} 20:33:56.796
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:56.796
+     sto:      {DRIVERSTORE DELETE END} 20:33:56.796
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:56.796
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:56.796
+<<<  Section end 2016/10/14 20:33:56.796
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:56.813
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_8c7cb6330f81414a\usbhub3.inf} 20:33:56.813
+     sto:      Driver Package = usbhub3.inf_amd64_8c7cb6330f81414a
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_8c7cb6330f81414a\usbhub3.inf} 20:33:56.813
+     idb:           Driver package 'usbhub3.inf_amd64_caa57285880769f4' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 94 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:56.905
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:56.905
+     sto: Higher version of 'usbhub3.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_caa57285880769f4\usbhub3.inf
+<<<  Section end 2016/10/14 20:33:56.905
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:56.905
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_8c7cb6330f81414a\usbhub3.inf} 20:33:56.921
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:56.921
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:56.921
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_8c7cb6330f81414a\usbhub3.inf} 20:33:56.921
+     idb:           Unregistered driver package 'usbhub3.inf_amd64_8c7cb6330f81414a' from 'usbhub3.inf'.
+     idb:           Deleted driver package object 'usbhub3.inf_amd64_8c7cb6330f81414a' from SYSTEM database node.
+     idb:           Driver packages registered to 'usbhub3.inf':
+     idb:                usbhub3.inf_amd64_caa57285880769f4
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:56.921
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_8c7cb6330f81414a} 20:33:56.937
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:56.937
+     sto:      {DRIVERSTORE DELETE END} 20:33:56.937
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:56.937
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:56.937
+<<<  Section end 2016/10/14 20:33:56.937
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:56.937
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_1e58ad6583f1ecab\usbport.inf} 20:33:56.983
+     sto:      Driver Package = usbport.inf_amd64_1e58ad6583f1ecab
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_1e58ad6583f1ecab\usbport.inf} 20:33:56.983
+     idb:           Driver package 'usbport.inf_amd64_4215f546c8e8f9d6' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 78 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:57.092
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:57.092
+     sto: Higher version of 'usbport.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbport.inf
+<<<  Section end 2016/10/14 20:33:57.092
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:57.092
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_1e58ad6583f1ecab\usbport.inf} 20:33:57.109
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:57.109
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:57.109
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_1e58ad6583f1ecab\usbport.inf} 20:33:57.109
+     idb:           Unregistered driver package 'usbport.inf_amd64_1e58ad6583f1ecab' from 'usbport.inf'.
+     idb:           Deleted driver package object 'usbport.inf_amd64_1e58ad6583f1ecab' from SYSTEM database node.
+     idb:           Driver packages registered to 'usbport.inf':
+     idb:                usbport.inf_amd64_4215f546c8e8f9d6
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:57.109
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_1e58ad6583f1ecab} 20:33:57.109
+!    cpy:           Could not delete file 'usbd.sys'. Error = 0x00000005
+     cpy:           File 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_1e58ad6583f1ecab\usbd.sys' is not in use by any processes.
+!    cpy:           Could not delete file 'usbehci.sys'. Error = 0x00000005
+     cpy:           File 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_1e58ad6583f1ecab\usbehci.sys' is not in use by any processes.
+!    cpy:           Could not delete file 'usbohci.sys'. Error = 0x00000005
+     cpy:           File 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_1e58ad6583f1ecab\usbohci.sys' is not in use by any processes.
+!    cpy:           Could not delete file 'usbport.sys'. Error = 0x00000005
+     cpy:           File 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_1e58ad6583f1ecab\usbport.sys' is not in use by any processes.
+     cpy:      {Delete Directory: exit(0x00000005)} 20:33:57.125
+!    sto:      Unable to delete driver package directory 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_1e58ad6583f1ecab'. Error = 0x00000005
+     sto:      {DRIVERSTORE DELETE END} 20:33:57.141
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:57.141
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:57.141
+<<<  Section end 2016/10/14 20:33:57.141
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:57.141
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_827db80716f312be\usbser.inf} 20:33:57.141
+     sto:      Driver Package = usbser.inf_amd64_827db80716f312be
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_827db80716f312be\usbser.inf} 20:33:57.141
+     idb:           Driver package 'usbser.inf_amd64_5de2576d6f02918e' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 63 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:57.201
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:57.201
+     sto: Higher version of 'usbser.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_5de2576d6f02918e\usbser.inf
+<<<  Section end 2016/10/14 20:33:57.201
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:57.201
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_827db80716f312be\usbser.inf} 20:33:57.221
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:57.221
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:57.221
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_827db80716f312be\usbser.inf} 20:33:57.221
+     idb:           Unregistered driver package 'usbser.inf_amd64_827db80716f312be' from 'usbser.inf'.
+     idb:           Deleted driver package object 'usbser.inf_amd64_827db80716f312be' from SYSTEM database node.
+     idb:           Driver packages registered to 'usbser.inf':
+     idb:                usbser.inf_amd64_5de2576d6f02918e
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:57.221
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_827db80716f312be} 20:33:57.221
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:57.221
+     sto:      {DRIVERSTORE DELETE END} 20:33:57.221
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:57.221
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:57.221
+<<<  Section end 2016/10/14 20:33:57.221
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:57.234
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_8c69d27bb757b62d\usbstor.inf} 20:33:57.249
+     sto:      Driver Package = usbstor.inf_amd64_8c69d27bb757b62d
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_8c69d27bb757b62d\usbstor.inf} 20:33:57.265
+     idb:           Driver package 'usbstor.inf_amd64_2780d7dc6ecda26e' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 63 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:57.327
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:57.327
+     sto: Higher version of 'usbstor.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_2780d7dc6ecda26e\usbstor.inf
+<<<  Section end 2016/10/14 20:33:57.327
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:57.344
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_8c69d27bb757b62d\usbstor.inf} 20:33:57.344
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:57.344
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:57.344
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_8c69d27bb757b62d\usbstor.inf} 20:33:57.344
+     idb:           Unregistered driver package 'usbstor.inf_amd64_8c69d27bb757b62d' from 'usbstor.inf'.
+     idb:           Deleted driver package object 'usbstor.inf_amd64_8c69d27bb757b62d' from SYSTEM database node.
+     idb:           Driver packages registered to 'usbstor.inf':
+     idb:                usbstor.inf_amd64_2780d7dc6ecda26e
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:57.361
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_8c69d27bb757b62d} 20:33:57.361
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:57.361
+     sto:      {DRIVERSTORE DELETE END} 20:33:57.361
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:57.361
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:57.361
+<<<  Section end 2016/10/14 20:33:57.361
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:57.361
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_57248f1a8744b4fc\usbxhci.inf} 20:33:57.361
+     sto:      Driver Package = usbxhci.inf_amd64_57248f1a8744b4fc
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_57248f1a8744b4fc\usbxhci.inf} 20:33:57.361
+     idb:           Driver package 'usbxhci.inf_amd64_7b59c1e1fa52c844' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 93 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:57.468
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:57.468
+     sto: Higher version of 'usbxhci.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_7b59c1e1fa52c844\usbxhci.inf
+<<<  Section end 2016/10/14 20:33:57.468
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:57.468
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_57248f1a8744b4fc\usbxhci.inf} 20:33:57.485
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:57.485
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:57.485
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_57248f1a8744b4fc\usbxhci.inf} 20:33:57.485
+     idb:           Unregistered driver package 'usbxhci.inf_amd64_57248f1a8744b4fc' from 'usbxhci.inf'.
+     idb:           Deleted driver package object 'usbxhci.inf_amd64_57248f1a8744b4fc' from SYSTEM database node.
+     idb:           Driver packages registered to 'usbxhci.inf':
+     idb:                usbxhci.inf_amd64_7b59c1e1fa52c844
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:57.485
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_57248f1a8744b4fc} 20:33:57.485
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:57.485
+     sto:      {DRIVERSTORE DELETE END} 20:33:57.485
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:57.485
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:57.485
+<<<  Section end 2016/10/14 20:33:57.485
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:57.500
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_33db47aeb773aeab\vhdmp.inf} 20:33:57.530
+     sto:      Driver Package = vhdmp.inf_amd64_33db47aeb773aeab
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_33db47aeb773aeab\vhdmp.inf} 20:33:57.530
+     idb:           Driver package 'vhdmp.inf_amd64_0e346fbd37116b8f' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 94 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:57.624
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:57.624
+     sto: Higher version of 'vhdmp.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_0e346fbd37116b8f\vhdmp.inf
+<<<  Section end 2016/10/14 20:33:57.624
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:57.624
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_33db47aeb773aeab\vhdmp.inf} 20:33:57.624
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:57.624
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:57.624
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_33db47aeb773aeab\vhdmp.inf} 20:33:57.641
+     idb:           Unregistered driver package 'vhdmp.inf_amd64_33db47aeb773aeab' from 'vhdmp.inf'.
+     idb:           Deleted driver package object 'vhdmp.inf_amd64_33db47aeb773aeab' from SYSTEM database node.
+     idb:           Driver packages registered to 'vhdmp.inf':
+     idb:                vhdmp.inf_amd64_0e346fbd37116b8f
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:57.641
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_33db47aeb773aeab} 20:33:57.641
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:57.641
+     sto:      {DRIVERSTORE DELETE END} 20:33:57.641
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:57.641
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:57.641
+<<<  Section end 2016/10/14 20:33:57.641
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:57.641
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_256ad046a471df0d\wdmaudio.inf} 20:33:57.655
+     sto:      Driver Package = wdmaudio.inf_amd64_256ad046a471df0d
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_256ad046a471df0d\wdmaudio.inf} 20:33:57.655
+     idb:           Driver package 'wdmaudio.inf_amd64_58b3142a36627a91' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 15 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 47 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:57.717
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:57.717
+     sto: Higher version of 'wdmaudio.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\wdmaudio.inf
+<<<  Section end 2016/10/14 20:33:57.717
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:57.717
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_256ad046a471df0d\wdmaudio.inf} 20:33:57.735
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:57.735
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:57.735
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_256ad046a471df0d\wdmaudio.inf} 20:33:57.735
+     idb:           Unregistered driver package 'wdmaudio.inf_amd64_256ad046a471df0d' from 'wdmaudio.inf'.
+     idb:           Deleted driver package object 'wdmaudio.inf_amd64_256ad046a471df0d' from DRIVERS database node.
+     idb:           Driver packages registered to 'wdmaudio.inf':
+     idb:                wdmaudio.inf_amd64_58b3142a36627a91
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:57.735
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_256ad046a471df0d} 20:33:57.735
+!    cpy:           Could not delete file 'drmk.sys'. Error = 0x00000005
+     cpy:           File 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_256ad046a471df0d\drmk.sys' is not in use by any processes.
+     cpy:      {Delete Directory: exit(0x00000005)} 20:33:57.749
+!    sto:      Unable to delete driver package directory 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_256ad046a471df0d'. Error = 0x00000005
+     sto:      {DRIVERSTORE DELETE END} 20:33:57.749
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:57.749
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:57.749
+<<<  Section end 2016/10/14 20:33:57.749
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:57.780
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_f049c0f8aa802928\wfcvsc.inf} 20:33:57.780
+     sto:      Driver Package = wfcvsc.inf_amd64_f049c0f8aa802928
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_f049c0f8aa802928\wfcvsc.inf} 20:33:57.780
+     idb:           Driver package 'wfcvsc.inf_amd64_4b9b5d5319497dd4' is already active.
+     sto:           Flushed driver database node 'SYSTEM'. Time = 62 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:57.842
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:57.842
+     sto: Higher version of 'wfcvsc.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_4b9b5d5319497dd4\wfcvsc.inf
+<<<  Section end 2016/10/14 20:33:57.842
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:57.842
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_f049c0f8aa802928\wfcvsc.inf} 20:33:57.861
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:57.861
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:57.861
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_f049c0f8aa802928\wfcvsc.inf} 20:33:57.861
+     idb:           Unregistered driver package 'wfcvsc.inf_amd64_f049c0f8aa802928' from 'wfcvsc.inf'.
+     idb:           Deleted driver package object 'wfcvsc.inf_amd64_f049c0f8aa802928' from SYSTEM database node.
+     idb:           Driver packages registered to 'wfcvsc.inf':
+     idb:                wfcvsc.inf_amd64_4b9b5d5319497dd4
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:57.861
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_f049c0f8aa802928} 20:33:57.861
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:57.861
+     sto:      {DRIVERSTORE DELETE END} 20:33:57.861
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:57.861
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:57.861
+<<<  Section end 2016/10/14 20:33:57.861
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:57.905
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_bc644fccce0afbb3\wpdmtp.inf} 20:33:57.920
+     sto:      Driver Package = wpdmtp.inf_amd64_bc644fccce0afbb3
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_bc644fccce0afbb3\wpdmtp.inf} 20:33:57.920
+     idb:           Driver package 'wpdmtp.inf_amd64_5bffa673ab8cb4d4' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 16 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 78 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:58.014
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:58.014
+     sto: Higher version of 'wpdmtp.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\wpdmtp.inf
+<<<  Section end 2016/10/14 20:33:58.014
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:58.014
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_bc644fccce0afbb3\wpdmtp.inf} 20:33:58.014
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:58.014
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:58.014
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_bc644fccce0afbb3\wpdmtp.inf} 20:33:58.014
+     idb:           Unregistered driver package 'wpdmtp.inf_amd64_bc644fccce0afbb3' from 'wpdmtp.inf'.
+     idb:           Deleted driver package object 'wpdmtp.inf_amd64_bc644fccce0afbb3' from DRIVERS database node.
+     idb:           Driver packages registered to 'wpdmtp.inf':
+     idb:                wpdmtp.inf_amd64_5bffa673ab8cb4d4
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:58.031
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_bc644fccce0afbb3} 20:33:58.031
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:58.031
+     sto:      {DRIVERSTORE DELETE END} 20:33:58.031
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:58.031
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:58.031
+<<<  Section end 2016/10/14 20:33:58.031
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:58.062
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_5c0a61506fb5918d\wudfusbcciddriver.inf} 20:33:58.077
+     sto:      Driver Package = wudfusbcciddriver.inf_amd64_5c0a61506fb5918d
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_5c0a61506fb5918d\wudfusbcciddriver.inf} 20:33:58.093
+     idb:           Driver package 'wudfusbcciddriver.inf_amd64_dcc0445e956fcf69' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 16 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 0 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:58.108
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:58.108
+     sto: Higher version of 'wudfusbcciddriver.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_dcc0445e956fcf69\wudfusbcciddriver.inf
+<<<  Section end 2016/10/14 20:33:58.108
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:58.108
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_5c0a61506fb5918d\wudfusbcciddriver.inf} 20:33:58.108
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:58.108
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:58.108
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_5c0a61506fb5918d\wudfusbcciddriver.inf} 20:33:58.108
+     idb:           Unregistered driver package 'wudfusbcciddriver.inf_amd64_5c0a61506fb5918d' from 'wudfusbcciddriver.inf'.
+     idb:           Deleted driver package object 'wudfusbcciddriver.inf_amd64_5c0a61506fb5918d' from DRIVERS database node.
+     idb:           Driver packages registered to 'wudfusbcciddriver.inf':
+     idb:                wudfusbcciddriver.inf_amd64_dcc0445e956fcf69
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:58.125
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_5c0a61506fb5918d} 20:33:58.125
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:58.125
+     sto:      {DRIVERSTORE DELETE END} 20:33:58.125
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:58.125
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:58.125
+<<<  Section end 2016/10/14 20:33:58.125
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:58.155
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_438b7c551e424b28\xusb22.inf} 20:33:58.186
+     sto:      Driver Package = xusb22.inf_amd64_438b7c551e424b28
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_438b7c551e424b28\xusb22.inf} 20:33:58.186
+     idb:           Driver package 'xusb22.inf_amd64_519ad1a6701b5cab' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 16 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 0 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:58.202
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:58.202
+     sto: Higher version of 'xusb22.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_519ad1a6701b5cab\xusb22.inf
+<<<  Section end 2016/10/14 20:33:58.221
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:58.221
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_438b7c551e424b28\xusb22.inf} 20:33:58.342
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:58.342
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:58.342
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_438b7c551e424b28\xusb22.inf} 20:33:58.342
+     idb:           Unregistered driver package 'xusb22.inf_amd64_438b7c551e424b28' from 'xusb22.inf'.
+     idb:           Deleted driver package object 'xusb22.inf_amd64_438b7c551e424b28' from DRIVERS database node.
+     idb:           Driver packages registered to 'xusb22.inf':
+     idb:                xusb22.inf_amd64_519ad1a6701b5cab
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:58.342
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_438b7c551e424b28} 20:33:58.361
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_438b7c551e424b28\x64} 20:33:58.361
+     cpy:           {Delete Directory: exit(0x00000000)} 20:33:58.361
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:58.361
+     sto:      {DRIVERSTORE DELETE END} 20:33:58.361
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:58.361
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:58.361
+<<<  Section end 2016/10/14 20:33:58.361
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:58.374
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_08e757f7c012ea27\ntprint.inf} 20:33:58.389
+     sto:      Driver Package = ntprint.inf_x86_08e757f7c012ea27
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_08e757f7c012ea27\ntprint.inf} 20:33:58.405
+     idb:           Driver package 'ntprint.inf_amd64_b3cf4018952c495c' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 15 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 0 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:58.420
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:58.420
+     sto: Skipping non-native x86 driver package 'ntprint.inf' on amd64.
+<<<  Section end 2016/10/14 20:33:58.420
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:58.420
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_08e757f7c012ea27\ntprint.inf} 20:33:58.437
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:58.437
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:58.437
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_08e757f7c012ea27\ntprint.inf} 20:33:58.437
+     idb:           Unregistered driver package 'ntprint.inf_x86_08e757f7c012ea27' from 'ntprint.inf'.
+     idb:           Deleted driver package object 'ntprint.inf_x86_08e757f7c012ea27' from DRIVERS database node.
+     idb:           Driver packages registered to 'ntprint.inf':
+     idb:                ntprint.inf_x86_b3cf4018952c495c
+     idb:                ntprint.inf_amd64_b3cf4018952c495c
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:58.437
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_08e757f7c012ea27} 20:33:58.437
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_08e757f7c012ea27\I386} 20:33:58.437
+     cpy:           {Delete Directory: exit(0x00000000)} 20:33:58.467
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:58.467
+     sto:      {DRIVERSTORE DELETE END} 20:33:58.467
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:58.467
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:58.467
+<<<  Section end 2016/10/14 20:33:58.467
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:33:58.485
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_c42df827ba78f834\prnms003.inf} 20:33:58.498
+     sto:      Driver Package = prnms003.inf_x86_c42df827ba78f834
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_c42df827ba78f834\prnms003.inf} 20:33:58.498
+     idb:           Driver package 'prnms003.inf_amd64_2da12eac1bd2c7cb' is already active.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 31 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 0 ms
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 20:33:58.530
+     sto: {Unpublish Driver Package: exit(0x00000000)} 20:33:58.530
+     sto: Skipping non-native x86 driver package 'prnms003.inf' on amd64.
+<<<  Section end 2016/10/14 20:33:58.530
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:33:58.530
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_c42df827ba78f834\prnms003.inf} 20:33:58.530
+     sto:      {DRIVERSTORE DELETE BEGIN} 20:33:58.549
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 20:33:58.549
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_c42df827ba78f834\prnms003.inf} 20:33:58.549
+     idb:           Unregistered driver package 'prnms003.inf_x86_c42df827ba78f834' from 'prnms003.inf'.
+     idb:           Deleted driver package object 'prnms003.inf_x86_c42df827ba78f834' from DRIVERS database node.
+     idb:           Driver packages registered to 'prnms003.inf':
+     idb:                prnms003.inf_x86_8f17aac186c70ea6
+     idb:                prnms003.inf_amd64_2da12eac1bd2c7cb
+     idb:      {Unregister Driver Package: exit(0x00000000)} 20:33:58.549
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_c42df827ba78f834} 20:33:58.549
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_c42df827ba78f834\I386} 20:33:58.549
+     cpy:           {Delete Directory: exit(0x00000000)} 20:33:58.549
+     cpy:      {Delete Directory: exit(0x00000000)} 20:33:58.549
+     sto:      {DRIVERSTORE DELETE END} 20:33:58.549
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 20:33:58.549
+     sto: {Unstage Driver Package: exit(0x00000000)} 20:33:58.549
+<<<  Section end 2016/10/14 20:33:58.549
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:56.442
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_miradisp.inf_31bf3856ad364e35_10.0.10240.16384_none_65e17332b1572ee0\miradisp.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.054
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.054
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_miradisp.inf_31bf3856ad364e35_10.0.10240.16384_none_65e17332b1572ee0\miradisp.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.054
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.068
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_msgpiowin32.inf_31bf3856ad364e35_10.0.10240.16384_none_275b1182bee4d15b\msgpiowin32.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.068
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.068
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_msgpiowin32.inf_31bf3856ad364e35_10.0.10240.16384_none_275b1182bee4d15b\msgpiowin32.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.068
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.068
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_msports.inf_31bf3856ad364e35_10.0.10240.16384_none_00982260530b8ed7\msports.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.082
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.082
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_msports.inf_31bf3856ad364e35_10.0.10240.16384_none_00982260530b8ed7\msports.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.082
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.082
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_netrndis.inf_31bf3856ad364e35_10.0.10240.16384_none_cfc300d8e079edac\netrndis.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.082
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.082
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_netrndis.inf_31bf3856ad364e35_10.0.10240.16384_none_cfc300d8e079edac\netrndis.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.098
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.098
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_netrtwlane_13.inf_31bf3856ad364e35_10.0.10240.16384_none_c45ef89bac8811ca\netrtwlane_13.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.098
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.098
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_netrtwlane_13.inf_31bf3856ad364e35_10.0.10240.16384_none_c45ef89bac8811ca\netrtwlane_13.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.098
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.114
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_netwmbclass.inf_31bf3856ad364e35_10.0.10240.16384_none_d4f37469f456df8c\netwmbclass.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.114
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.114
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_netwmbclass.inf_31bf3856ad364e35_10.0.10240.16384_none_d4f37469f456df8c\netwmbclass.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.114
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.114
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.16384_none_43010eb055602bdc\ntprint.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.126
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.126
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.16384_none_43010eb055602bdc\ntprint.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.126
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.126
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.16384_none_4e20954d3f2c0c1e\ntprint4.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.126
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.126
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.16384_none_4e20954d3f2c0c1e\ntprint4.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.142
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.142
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_pci.inf_31bf3856ad364e35_10.0.10240.16384_none_11a73c1af51f0fb1\pci.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.142
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.142
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_pci.inf_31bf3856ad364e35_10.0.10240.16384_none_11a73c1af51f0fb1\pci.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.142
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.142
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.16384_none_5acfea4d6e8d5040\prnms003.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.142
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.158
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.16384_none_5acfea4d6e8d5040\prnms003.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.158
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.158
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.16384_none_5b58fc8287ab8ca9\prnms004.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.158
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.158
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.16384_none_5b58fc8287ab8ca9\prnms004.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.158
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.174
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_sdbus.inf_31bf3856ad364e35_10.0.10240.16384_none_79e32e7265045c7e\sdbus.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.174
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.174
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_sdbus.inf_31bf3856ad364e35_10.0.10240.16384_none_79e32e7265045c7e\sdbus.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.174
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.174
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_sdbus.inf_31bf3856ad364e35_10.0.10240.16384_none_79e32e7265045c7e\sdbus.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.188
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.188
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_sdbus.inf_31bf3856ad364e35_10.0.10240.16384_none_79e32e7265045c7e\sdbus.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.188
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.188
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_sensorshidclassdriver.inf_31bf3856ad364e35_10.0.10240.16384_none_b1fda42a5955ca57\SensorsHidClassDriver.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.188
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.188
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_sensorshidclassdriver.inf_31bf3856ad364e35_10.0.10240.16384_none_b1fda42a5955ca57\SensorsHidClassDriver.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.188
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.206
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_sensorshidclassdriver.inf_31bf3856ad364e35_10.0.10240.16384_none_b1fda42a5955ca57\SensorsHidClassDriver.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.206
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.206
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_sensorshidclassdriver.inf_31bf3856ad364e35_10.0.10240.16384_none_b1fda42a5955ca57\SensorsHidClassDriver.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.206
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.206
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_stornvme.inf_31bf3856ad364e35_10.0.10240.16384_none_b94bc70f8f0a6f25\stornvme.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.206
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.206
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_stornvme.inf_31bf3856ad364e35_10.0.10240.16384_none_b94bc70f8f0a6f25\stornvme.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.247
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.247
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_tsusbhub.inf_31bf3856ad364e35_10.0.10240.16384_none_11f114ec10049f87\tsusbhub.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.262
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.262
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_tsusbhub.inf_31bf3856ad364e35_10.0.10240.16384_none_11f114ec10049f87\tsusbhub.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.262
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.262
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_ucmucsi.inf_31bf3856ad364e35_10.0.10240.16384_none_172d0b10d9190d52\UcmUcsi.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.262
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.262
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_ucmucsi.inf_31bf3856ad364e35_10.0.10240.16384_none_172d0b10d9190d52\UcmUcsi.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.262
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.262
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_usbhub3.inf_31bf3856ad364e35_10.0.10240.16384_none_fde0f1b6e7b3170d\usbhub3.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.278
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.278
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_usbhub3.inf_31bf3856ad364e35_10.0.10240.16384_none_fde0f1b6e7b3170d\usbhub3.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.278
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.278
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_usbhub3.inf_31bf3856ad364e35_10.0.10240.16384_none_fde0f1b6e7b3170d\usbhub3.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.278
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.278
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_usbhub3.inf_31bf3856ad364e35_10.0.10240.16384_none_fde0f1b6e7b3170d\usbhub3.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.294
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.294
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.16384_none_c5c2d1219e3aebfa\usbport.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.294
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.294
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.16384_none_c5c2d1219e3aebfa\usbport.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.294
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.294
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.16384_none_c5c2d1219e3aebfa\usbport.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.294
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.314
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.16384_none_c5c2d1219e3aebfa\usbport.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.314
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.314
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_usbser.inf_31bf3856ad364e35_10.0.10240.16384_none_0a91d3ba457b3ad1\usbser.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.314
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.330
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_usbser.inf_31bf3856ad364e35_10.0.10240.16384_none_0a91d3ba457b3ad1\usbser.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.330
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.330
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_usbstor.inf_31bf3856ad364e35_10.0.10240.16384_none_5086c065328065e7\usbstor.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.330
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.330
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_usbstor.inf_31bf3856ad364e35_10.0.10240.16384_none_5086c065328065e7\usbstor.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.345
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.345
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_usbstor.inf_31bf3856ad364e35_10.0.10240.16384_none_5086c065328065e7\usbstor.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.345
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.345
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_usbstor.inf_31bf3856ad364e35_10.0.10240.16384_none_5086c065328065e7\usbstor.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.345
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.345
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_usbxhci.inf_31bf3856ad364e35_10.0.10240.16384_none_283164dc9913a68d\usbxhci.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.360
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.360
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_usbxhci.inf_31bf3856ad364e35_10.0.10240.16384_none_283164dc9913a68d\usbxhci.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.360
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.360
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_usbxhci.inf_31bf3856ad364e35_10.0.10240.16384_none_283164dc9913a68d\usbxhci.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.360
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.360
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_usbxhci.inf_31bf3856ad364e35_10.0.10240.16384_none_283164dc9913a68d\usbxhci.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.360
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.376
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_vhdmp.inf_31bf3856ad364e35_10.0.10240.16384_none_ae90d016644a97fe\vhdmp.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.376
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.376
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_vhdmp.inf_31bf3856ad364e35_10.0.10240.16384_none_ae90d016644a97fe\vhdmp.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.376
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.376
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_wdmaudio.inf_31bf3856ad364e35_10.0.10240.16384_none_6867cac1b4d2f365\wdmaudio.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.376
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.376
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_wdmaudio.inf_31bf3856ad364e35_10.0.10240.16384_none_6867cac1b4d2f365\wdmaudio.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.392
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.392
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_wfcvsc.inf_31bf3856ad364e35_10.0.10240.16384_none_75b7813c05e1c81d\wfcvsc.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.392
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.392
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_wfcvsc.inf_31bf3856ad364e35_10.0.10240.16384_none_75b7813c05e1c81d\wfcvsc.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.392
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.392
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_wpdmtp.inf_31bf3856ad364e35_10.0.10240.16384_none_279ab752215de7e5\wpdmtp.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.408
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.408
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_wpdmtp.inf_31bf3856ad364e35_10.0.10240.16384_none_279ab752215de7e5\wpdmtp.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.408
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.408
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_wudfusbcciddriver.inf_31bf3856ad364e35_10.0.10240.16384_none_6a7a21579c620cc6\WUDFUsbccidDriver.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.408
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.408
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_wudfusbcciddriver.inf_31bf3856ad364e35_10.0.10240.16384_none_6a7a21579c620cc6\WUDFUsbccidDriver.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.426
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.426
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\amd64_xusb22.inf_31bf3856ad364e35_10.0.10240.16384_none_add76ba2a7f36a5b\xusb22.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.426
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.426
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\amd64_xusb22.inf_31bf3856ad364e35_10.0.10240.16384_none_add76ba2a7f36a5b\xusb22.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.426
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.426
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.16384_none_e6e2732c9d02baa6\ntprint.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.438
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.438
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.16384_none_e6e2732c9d02baa6\ntprint.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.438
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.438
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+!    sto: Unable to find driver update 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.16384_none_feb14ec9b62fdf0a\prnms003.inf' in Driver Store.
+<<<  Section end 2016/10/14 20:43:57.438
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/10/14 20:43:57.438
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 1
+     sto: Driver update 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.16384_none_feb14ec9b62fdf0a\prnms003.inf' is not staged.
+<<<  Section end 2016/10/14 20:43:57.454
+<<<  [Exit status: SUCCESS]
+
+
+[Boot Session: 2016/10/18 22:07:36.493]
+
+>>>  [Device Installation Restrictions Policy Check]
+>>>  Section start 2016/10/18 22:08:23.152
+<<<  Section end 2016/10/18 22:08:25.227
+<<<  [Exit status: SUCCESS]
+
+
+[Boot Session: 2016/10/18 22:24:34.493]
+
+>>>  [Device Installation Restrictions Policy Check]
+>>>  Section start 2016/10/18 22:25:44.487
+<<<  Section end 2016/10/18 22:25:47.409
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Device Installation Restrictions Policy Check]
+>>>  Section start 2016/10/19 00:06:43.248
+<<<  Section end 2016/10/19 00:06:43.264
+<<<  [Exit status: SUCCESS]
+
+
+[Boot Session: 2016/11/08 14:10:14.761]
+
+>>>  [Device and Driver Disk Cleanup Handler]
+>>>  Section start 2016/11/08 14:29:09.351
+      cmd: taskhostw.exe
+     set: Searching for not-recently detected devices that may be removed from the system.
+     set: Devices will be removed during this pass.
+     set: Device SWD\IP_TUNNEL_VBUS\ISATAP_0 will be removed.
+     set: Device SWD\IP_TUNNEL_VBUS\ISATAP_0 was removed.
+     set: Device DISPLAY\DEFAULT_MONITOR\1&8713BCA&0&UID0 will be removed.
+     set: Device DISPLAY\DEFAULT_MONITOR\1&8713BCA&0&UID0 was removed.
+     set: Devices removed: 2
+     set: Searching for unused drivers that may be removed from the system.
+     set: Drivers will be removed during this pass.
+     set: Recovery Timestamp: 11/23/2015 01:58:46:0157.
+     set: Preserving oem2.inf because it was imported after the recovery timestamp
+     set: Preserving oem3.inf because it was imported after the recovery timestamp
+     set: Driver packages removed: 0
+     set: Total size on disk: 0
+<<<  Section end 2016/11/08 14:29:15.414
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Disable Device Install]
+>>>  Section start 2016/11/22 22:04:49.991
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     ump: DeviceInstall service is not started.
+<<<  Section end 2016/11/22 22:04:50.007
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Stage Driver Updates]
+>>>  Section start 2016/11/22 22:04:52.944
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 41
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_miradisp.inf_31bf3856ad364e35_10.0.10240.16394_none_65e15c6ab1574881\miradisp.inf} 22:04:55.023
+!    sto:      Driver package already imported as 'miradisp.inf' (C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_01ce808b39cab47d\miradisp.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:56.038
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_hidscanner.inf_31bf3856ad364e35_10.0.10240.16732_none_1347b790e8468683\hidscanner.inf} 22:04:56.038
+!    sto:      Driver package already imported as 'hidscanner.inf' (C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_a4bdb031f38afa10\hidscanner.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:56.054
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_xusb22.inf_31bf3856ad364e35_10.0.10240.17146_none_adcafa0ea7fce768\xusb22.inf} 22:04:56.054
+!    sto:      Driver package already imported as 'xusb22.inf' (C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_519ad1a6701b5cab\xusb22.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:56.054
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_acpi.inf_31bf3856ad364e35_10.0.10240.17184_none_2a7c653268bf032f\acpi.inf} 22:04:56.054
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_acpi.inf_31bf3856ad364e35_10.0.10240.17184_none_2a7c653268bf032f\acpi.inf} 22:04:56.054
+     inf:           Driver package 'acpi.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:04:56.084
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:04:56.084
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:04:56.084
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_acpi.inf_31bf3856ad364e35_10.0.10240.17184_none_2a7c653268bf032f\acpi.inf' to 'C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_a60e43d0fd77edd8\acpi.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_acpi.inf_31bf3856ad364e35_10.0.10240.17184_none_2a7c653268bf032f\acpi.sys' to 'C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_a60e43d0fd77edd8\acpi.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_a60e43d0fd77edd8\acpi.inf} 22:04:56.460
+     idb:           Created driver package object 'acpi.inf_amd64_a60e43d0fd77edd8' in SYSTEM database node.
+     idb:           Driver INF file object 'acpi.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'acpi.inf_amd64_a60e43d0fd77edd8' with 'acpi.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:04:56.647
+     sto:      {DRIVERSTORE IMPORT END} 22:04:56.647
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:04:56.647
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:56.647
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_wfcvsc.inf_31bf3856ad364e35_10.0.10240.17146_none_75ab0fa805eb452a\wfcvsc.inf} 22:04:56.647
+!    sto:      Driver package already imported as 'wfcvsc.inf' (C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_4b9b5d5319497dd4\wfcvsc.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:56.647
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_sensorshidclassdriver.inf_31bf3856ad364e35_10.0.10240.16515_none_b200461c595346c5\sensorshidclassdriver.inf} 22:04:56.647
+!    sto:      Driver package already imported as 'sensorshidclassdriver.inf' (C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_57265cb2d2642968\sensorshidclassdriver.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:56.647
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_bth.inf_31bf3856ad364e35_10.0.10240.16515_none_7a47d7dc563bfea7\bth.inf} 22:04:56.647
+!    sto:      Driver package already imported as 'bth.inf' (C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\bth.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:56.647
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_bthleenum.inf_31bf3856ad364e35_10.0.10240.16766_none_93c33ffcf31d8bb1\bthleenum.inf} 22:04:56.666
+!    sto:      Driver package already imported as 'bthleenum.inf' (C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_0dabadc4461923c4\bthleenum.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:56.666
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_genericusbfn.inf_31bf3856ad364e35_10.0.10240.17146_none_bd77d9655793cf61\genericusbfn.inf} 22:04:56.666
+!    sto:      Driver package already imported as 'genericusbfn.inf' (C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_221654d9bb6545af\genericusbfn.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:56.666
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_usbstor.inf_31bf3856ad364e35_10.0.10240.16732_none_508b2fa9327c50d0\usbstor.inf} 22:04:56.666
+!    sto:      Driver package already imported as 'usbstor.inf' (C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_2780d7dc6ecda26e\usbstor.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:56.666
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_usbhub3.inf_31bf3856ad364e35_10.0.10240.16603_none_fde4a6eee7af98e3\usbhub3.inf} 22:04:56.666
+!    sto:      Driver package already imported as 'usbhub3.inf' (C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_caa57285880769f4\usbhub3.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:56.666
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_usbxhci.inf_31bf3856ad364e35_10.0.10240.16461_none_28328d049912952d\usbxhci.inf} 22:04:56.666
+!    sto:      Driver package already imported as 'usbxhci.inf' (C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_7b59c1e1fa52c844\usbxhci.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:56.666
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.17184_none_c5b600a19e44d53d\usbport.inf} 22:04:56.666
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.17184_none_c5b600a19e44d53d\usbport.inf} 22:04:56.682
+     inf:           Driver package 'usbport.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:04:56.698
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:04:56.698
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:04:56.698
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.17184_none_c5b600a19e44d53d\usbhub.sys' to 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbhub.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.17184_none_c5b600a19e44d53d\usbehci.sys' to 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbehci.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.17184_none_c5b600a19e44d53d\usbport.inf' to 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbport.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.17184_none_c5b600a19e44d53d\usbohci.sys' to 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbohci.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.17184_none_c5b600a19e44d53d\usbuhci.sys' to 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbuhci.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.17184_none_c5b600a19e44d53d\usbport.sys' to 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbport.sys'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_usbport.inf_31bf3856ad364e35_10.0.10240.17184_none_c5b600a19e44d53d\usbd.sys' to 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbd.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbport.inf} 22:04:57.288
+     idb:           Created driver package object 'usbport.inf_amd64_57cc78a6a0b04383' in SYSTEM database node.
+     idb:           Driver INF file object 'usbport.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'usbport.inf_amd64_57cc78a6a0b04383' with 'usbport.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:04:57.366
+     sto:      {DRIVERSTORE IMPORT END} 22:04:57.366
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:04:57.366
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:57.366
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_sdbus.inf_31bf3856ad364e35_10.0.10240.16515_none_79e5d0646501d8ec\sdbus.inf} 22:04:57.366
+!    sto:      Driver package already imported as 'sdbus.inf' (C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_b33128a95ba9fe0b\sdbus.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:57.397
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_mdmbtmdm.inf_31bf3856ad364e35_10.0.10240.16515_none_f5a6e1bb2609bdc5\mdmbtmdm.inf} 22:04:57.397
+!    sto:      Driver package already imported as 'mdmbtmdm.inf' (C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_57032036ac5b3f02\mdmbtmdm.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:57.414
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_bthaudhid.inf_31bf3856ad364e35_10.0.10240.17146_none_1beaef47e191cb33\bthaudhid.inf} 22:04:57.414
+!    sto:      Driver package already imported as 'bthaudhid.inf' (C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_47034a2e2794f3b2\bthaudhid.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:57.414
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_bthhfenum.inf_31bf3856ad364e35_10.0.10240.16412_none_b2ef11ef014f9a50\bthhfenum.inf} 22:04:57.414
+!    sto:      Driver package already imported as 'bthhfenum.inf' (C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_06170919fa54ed29\bthhfenum.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:57.414
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_wudfusbcciddriver.inf_31bf3856ad364e35_10.0.10240.16942_none_6a807a679c5c43fe\wudfusbcciddriver.inf} 22:04:57.414
+!    sto:      Driver package already imported as 'wudfusbcciddriver.inf' (C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_dcc0445e956fcf69\wudfusbcciddriver.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:57.414
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_hdaudio.inf_31bf3856ad364e35_10.0.10240.17146_none_1d5435ea0226d0ec\hdaudio.inf} 22:04:57.414
+!    sto:      Driver package already imported as 'hdaudio.inf' (C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_c8e3ac50c9bf5564\hdaudio.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:57.430
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_wdmaudio.inf_31bf3856ad364e35_10.0.10240.16644_none_686b26bfb4cfd8e6\wdmaudio.inf} 22:04:57.430
+!    sto:      Driver package already imported as 'wdmaudio.inf' (C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\wdmaudio.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:57.430
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_hdaudbus.inf_31bf3856ad364e35_10.0.10240.17146_none_7f1592fc213de89a\hdaudbus.inf} 22:04:57.430
+!    sto:      Driver package already imported as 'hdaudbus.inf' (C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_070bdb1ad27e2f16\hdaudbus.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:57.430
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_netrtwlane_13.inf_31bf3856ad364e35_10.0.10240.16394_none_c45ee1d3ac882b6b\netrtwlane_13.inf} 22:04:57.430
+!    sto:      Driver package already imported as 'netrtwlane_13.inf' (C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_8e17ee2826ff2b07\netrtwlane_13.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:57.430
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_netwmbclass.inf_31bf3856ad364e35_10.0.10240.16392_none_d4f359d5f456fedf\netwmbclass.inf} 22:04:57.430
+!    sto:      Driver package already imported as 'netwmbclass.inf' (C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_ed51114936bfc236\netwmbclass.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:57.430
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_netrndis.inf_31bf3856ad364e35_10.0.10240.16732_none_cfc7701ce075d895\netrndis.inf} 22:04:57.430
+!    sto:      Driver package already imported as 'netrndis.inf' (C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_609a0bb012179987\netrndis.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:57.430
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\ntprint.inf} 22:04:57.430
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\ntprint.inf} 22:04:57.446
+     inf:           Driver package 'ntprint.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:04:57.446
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:04:57.446
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:04:57.446
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\UNIRES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\UNIRES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\TTFSUB.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\TTFSUB.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\UNIDRV.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\UNIDRV.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\UNIDRV.HLP' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\UNIDRV.HLP'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\PCL4RES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\PCL4RES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\PS_SCHM.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\PS_SCHM.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\MXDWDRV.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\MXDWDRV.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\PSCRIPT.HLP' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\PSCRIPT.HLP'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\PSCRIPT.NTF' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\PSCRIPT.NTF'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\PCL5ERES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\PCL5ERES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\PCL5URES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\PCL5URES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\PSCRIPT5.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\PSCRIPT5.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\PJL.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\PJL.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\STDSCHEM.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\STDSCHEM.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\STDNAMES.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\STDNAMES.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\STDSCHMX.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\STDSCHMX.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\STDDTYPE.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\STDDTYPE.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\PSCRPTFE.NTF' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\PSCRPTFE.NTF'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\MSXPSINC.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\MSXPSINC.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\UNIDRVUI.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\UNIDRVUI.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\MSXPSINC.PPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\MSXPSINC.PPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\PS5UI.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\PS5UI.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\PCLXL.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\PCLXL.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\PCLXL.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\PCLXL.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\P6DISP.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\P6DISP.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\P6FONT.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\P6FONT.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\LOCALE.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\LOCALE.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\Amd64\PJLMON.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\Amd64\PJLMON.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\ntprint.cat' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\ntprint.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_42f43e30556a151f\ntprint.inf' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\ntprint.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\ntprint.inf} 22:04:59.147
+     idb:           Created driver package object 'ntprint.inf_amd64_a101974e5e776f55' in DRIVERS database node.
+     idb:           Driver INF file object 'ntprint.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'ntprint.inf_amd64_a101974e5e776f55' with 'ntprint.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:04:59.147
+     sto:      {DRIVERSTORE IMPORT END} 22:04:59.147
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:04:59.147
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:59.166
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17184_none_5ac319cd6e973983\prnms003.inf} 22:04:59.166
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17184_none_5ac319cd6e973983\prnms003.inf} 22:04:59.166
+     inf:           Driver package 'prnms003.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:04:59.166
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:04:59.166
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:04:59.166
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17184_none_5ac319cd6e973983\Amd64\PrintConfig.dll' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_1b0f9ac834d3b069\Amd64\PrintConfig.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17184_none_5ac319cd6e973983\Amd64\unishare.gpd' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_1b0f9ac834d3b069\Amd64\unishare.gpd'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17184_none_5ac319cd6e973983\Amd64\unishare-pipelineconfig.xml' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_1b0f9ac834d3b069\Amd64\unishare-pipelineconfig.xml'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17184_none_5ac319cd6e973983\prnms003.cat' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_1b0f9ac834d3b069\prnms003.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms003.inf_31bf3856ad364e35_10.0.10240.17184_none_5ac319cd6e973983\prnms003.inf' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_1b0f9ac834d3b069\prnms003.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_1b0f9ac834d3b069\prnms003.inf} 22:04:59.430
+     idb:           Created driver package object 'prnms003.inf_amd64_1b0f9ac834d3b069' in DRIVERS database node.
+     idb:           Driver INF file object 'prnms003.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'prnms003.inf_amd64_1b0f9ac834d3b069' with 'prnms003.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:04:59.430
+     sto:      {DRIVERSTORE IMPORT END} 22:04:59.430
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:04:59.430
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:59.430
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17184_none_5b4c2c0287b575ec\prnms004.inf} 22:04:59.430
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17184_none_5b4c2c0287b575ec\prnms004.inf} 22:04:59.430
+     inf:           Driver package 'prnms004.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:04:59.430
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:04:59.430
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:04:59.430
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17184_none_5b4c2c0287b575ec\prnms004.cat' to 'C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_84e344e1b54dfd1b\prnms004.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17184_none_5b4c2c0287b575ec\prnms004.inf' to 'C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_84e344e1b54dfd1b\prnms004.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17184_none_5b4c2c0287b575ec\Amd64\unisharev4-manifest.ini' to 'C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_84e344e1b54dfd1b\Amd64\unisharev4-manifest.ini'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17184_none_5b4c2c0287b575ec\Amd64\unisharev4.gpd' to 'C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_84e344e1b54dfd1b\Amd64\unisharev4.gpd'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_prnms004.inf_31bf3856ad364e35_10.0.10240.17184_none_5b4c2c0287b575ec\Amd64\unisharev4-pipelineconfig.xml' to 'C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_84e344e1b54dfd1b\Amd64\unisharev4-pipelineconfig.xml'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_84e344e1b54dfd1b\prnms004.inf} 22:04:59.616
+     idb:           Created driver package object 'prnms004.inf_amd64_84e344e1b54dfd1b' in DRIVERS database node.
+     idb:           Driver INF file object 'prnms004.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'prnms004.inf_amd64_84e344e1b54dfd1b' with 'prnms004.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:04:59.616
+     sto:      {DRIVERSTORE IMPORT END} 22:04:59.634
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:04:59.634
+     sto: {Stage Driver Package: exit(0x00000000)} 22:04:59.634
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17184_none_4e13c4cd3f35f561\ntprint4.inf} 22:04:59.634
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17184_none_4e13c4cd3f35f561\ntprint4.inf} 22:04:59.634
+     inf:           Driver package 'ntprint4.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:04:59.634
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:04:59.634
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:04:59.634
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17184_none_4e13c4cd3f35f561\Amd64\PWGRRenderFilter.dll' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_5c630813f6a3ff28\Amd64\PWGRRenderFilter.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17184_none_4e13c4cd3f35f561\Amd64\MSxpsPS.dll' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_5c630813f6a3ff28\Amd64\MSxpsPS.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17184_none_4e13c4cd3f35f561\Amd64\MSxpsPCL6.dll' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_5c630813f6a3ff28\Amd64\MSxpsPCL6.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17184_none_4e13c4cd3f35f561\Amd64\V3HostingFilter.dll' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_5c630813f6a3ff28\Amd64\V3HostingFilter.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17184_none_4e13c4cd3f35f561\Amd64\PDFRenderFilter.dll' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_5c630813f6a3ff28\Amd64\PDFRenderFilter.dll'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17184_none_4e13c4cd3f35f561\Amd64\V3HostingFilter-pipelineconfig.xml' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_5c630813f6a3ff28\Amd64\V3HostingFilter-pipelineconfig.xml'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17184_none_4e13c4cd3f35f561\ntprint4.cat' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_5c630813f6a3ff28\ntprint4.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_ntprint4.inf_31bf3856ad364e35_10.0.10240.17184_none_4e13c4cd3f35f561\ntprint4.inf' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_5c630813f6a3ff28\ntprint4.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_5c630813f6a3ff28\ntprint4.inf} 22:05:00.147
+     idb:           Created driver package object 'ntprint4.inf_amd64_5c630813f6a3ff28' in DRIVERS database node.
+     idb:           Driver INF file object 'ntprint4.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'ntprint4.inf_amd64_5c630813f6a3ff28' with 'ntprint4.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:05:00.166
+     sto:      {DRIVERSTORE IMPORT END} 22:05:00.166
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:05:00.166
+     sto: {Stage Driver Package: exit(0x00000000)} 22:05:00.166
+     sto: {Stage Driver Package: C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17184_none_fea47e49b639c84d\prnms003.inf} 22:05:00.166
+     inf:      {Query Configurability: C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17184_none_fea47e49b639c84d\prnms003.inf} 22:05:00.178
+     inf:           Driver package is fully isolated.
+     inf:           Driver package 'prnms003.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:05:00.178
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:05:00.178
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:05:00.178
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17184_none_fea47e49b639c84d\prnms003.cat' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_bd4ca62bf20f9755\prnms003.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17184_none_fea47e49b639c84d\prnms003.inf' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_bd4ca62bf20f9755\prnms003.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17184_none_fea47e49b639c84d\I386\unishare.gpd' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_bd4ca62bf20f9755\I386\unishare.gpd'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17184_none_fea47e49b639c84d\I386\unishare-pipelineconfig.xml' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_bd4ca62bf20f9755\I386\unishare-pipelineconfig.xml'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_prnms003.inf_31bf3856ad364e35_10.0.10240.17184_none_fea47e49b639c84d\I386\PrintConfig.dll' to 'C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_bd4ca62bf20f9755\I386\PrintConfig.dll'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_bd4ca62bf20f9755\prnms003.inf} 22:05:00.413
+     idb:           Created driver package object 'prnms003.inf_x86_bd4ca62bf20f9755' in DRIVERS database node.
+     idb:           Driver INF file object 'prnms003.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'prnms003.inf_x86_bd4ca62bf20f9755' with 'prnms003.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:05:00.430
+     sto:      {DRIVERSTORE IMPORT END} 22:05:00.430
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:05:00.430
+     sto: {Stage Driver Package: exit(0x00000000)} 22:05:00.430
+     sto: {Stage Driver Package: C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\ntprint.inf} 22:05:00.430
+     inf:      {Query Configurability: C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\ntprint.inf} 22:05:00.446
+     inf:           Driver package 'ntprint.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:05:00.446
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:05:00.446
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:05:00.446
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\PCL5URES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\PCL5URES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\PSCRIPT5.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\PSCRIPT5.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\PJL.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\PJL.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\STDSCHEM.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\STDSCHEM.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\STDNAMES.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\STDNAMES.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\STDSCHMX.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\STDSCHMX.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\STDDTYPE.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\STDDTYPE.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\PSCRPTFE.NTF' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\PSCRPTFE.NTF'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\MSXPSINC.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\MSXPSINC.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\UNIDRVUI.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\UNIDRVUI.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\MSXPSINC.PPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\MSXPSINC.PPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\PS5UI.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\PS5UI.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\PCLXL.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\PCLXL.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\PCLXL.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\PCLXL.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\P6DISP.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\P6DISP.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\P6FONT.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\P6FONT.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\LOCALE.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\LOCALE.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\PJLMON.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\PJLMON.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\UNIRES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\UNIRES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\TTFSUB.GPD' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\TTFSUB.GPD'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\UNIDRV.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\UNIDRV.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\UNIDRV.HLP' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\UNIDRV.HLP'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\PCL4RES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\PCL4RES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\PS_SCHM.GDL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\PS_SCHM.GDL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\MXDWDRV.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\MXDWDRV.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\PSCRIPT.HLP' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\PSCRIPT.HLP'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\PSCRIPT.NTF' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\PSCRIPT.NTF'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\I386\PCL5ERES.DLL' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\I386\PCL5ERES.DLL'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\ntprint.cat' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\ntprint.cat'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\x86_ntprint.inf_31bf3856ad364e35_10.0.10240.17184_none_e6d5a2ac9d0ca3e9\ntprint.inf' to 'C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\ntprint.inf'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\ntprint.inf} 22:05:01.803
+     idb:           Created driver package object 'ntprint.inf_x86_a101974e5e776f55' in DRIVERS database node.
+     idb:           Driver INF file object 'ntprint.inf' already exists in DRIVERS database node.
+     idb:           Registered driver package 'ntprint.inf_x86_a101974e5e776f55' with 'ntprint.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:05:01.803
+     sto:      {DRIVERSTORE IMPORT END} 22:05:01.820
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:05:01.820
+     sto: {Stage Driver Package: exit(0x00000000)} 22:05:01.820
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_ucmucsi.inf_31bf3856ad364e35_10.0.10240.16389_none_172d148ed918ff15\ucmucsi.inf} 22:05:01.820
+!    sto:      Driver package already imported as 'ucmucsi.inf' (C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_86bd71749200d4fb\ucmucsi.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:05:01.820
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_pci.inf_31bf3856ad364e35_10.0.10240.16942_none_11ad952af51946e9\pci.inf} 22:05:01.820
+!    sto:      Driver package already imported as 'pci.inf' (C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_61ccd5db98b3abf1\pci.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:05:01.820
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_usbser.inf_31bf3856ad364e35_10.0.10240.16732_none_0a9642fe457725ba\usbser.inf} 22:05:01.820
+!    sto:      Driver package already imported as 'usbser.inf' (C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_5de2576d6f02918e\usbser.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:05:01.820
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_stornvme.inf_31bf3856ad364e35_10.0.10240.16431_none_b94d338f8f0910e2\stornvme.inf} 22:05:01.820
+!    sto:      Driver package already imported as 'stornvme.inf' (C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_5ffb10fc0bbc4ac0\stornvme.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:05:01.820
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_msports.inf_31bf3856ad364e35_10.0.10240.16732_none_009c91a4530779c0\msports.inf} 22:05:01.820
+!    sto:      Driver package already imported as 'msports.inf' (C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\msports.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:05:01.820
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_buttonconverter.inf_31bf3856ad364e35_10.0.10240.16515_none_2e186184227fb405\buttonconverter.inf} 22:05:01.820
+!    sto:      Driver package already imported as 'buttonconverter.inf' (C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_b210406b0d8c4695\buttonconverter.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:05:01.820
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_mrvlpcie8897.inf_31bf3856ad364e35_10.0.10240.16515_none_3eb55dfb31919bf1\mrvlpcie8897.inf} 22:05:01.820
+!    sto:      Driver package already imported as 'mrvlpcie8897.inf' (C:\Windows\System32\DriverStore\FileRepository\mrvlpcie8897.inf_amd64_f68a8d902ea4d964\mrvlpcie8897.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:05:01.835
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_vhdmp.inf_31bf3856ad364e35_10.0.10240.17184_none_ae83ff9664548141\vhdmp.inf} 22:05:01.835
+     inf:      {Query Configurability: C:\Windows\WinSxS\amd64_vhdmp.inf_31bf3856ad364e35_10.0.10240.17184_none_ae83ff9664548141\vhdmp.inf} 22:05:01.835
+     inf:           Driver package 'vhdmp.inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 22:05:01.835
+     sto:      {DRIVERSTORE IMPORT BEGIN} 22:05:01.835
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 22:05:01.835
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_vhdmp.inf_31bf3856ad364e35_10.0.10240.17184_none_ae83ff9664548141\vhdmp.inf' to 'C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_dc1bd1515a9b0d9d\vhdmp.inf'.
+     flq:      Hardlinking 'C:\Windows\WinSxS\amd64_vhdmp.inf_31bf3856ad364e35_10.0.10240.17184_none_ae83ff9664548141\vhdmp.sys' to 'C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_dc1bd1515a9b0d9d\vhdmp.sys'.
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_dc1bd1515a9b0d9d\vhdmp.inf} 22:05:01.928
+     idb:           Created driver package object 'vhdmp.inf_amd64_dc1bd1515a9b0d9d' in SYSTEM database node.
+     idb:           Driver INF file object 'vhdmp.inf' already exists in SYSTEM database node.
+     idb:           Registered driver package 'vhdmp.inf_amd64_dc1bd1515a9b0d9d' with 'vhdmp.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 22:05:01.928
+     sto:      {DRIVERSTORE IMPORT END} 22:05:01.928
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 22:05:01.928
+     sto: {Stage Driver Package: exit(0x00000000)} 22:05:01.928
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_msgpiowin32.inf_31bf3856ad364e35_10.0.10240.16425_none_275c9c62bee34e13\msgpiowin32.inf} 22:05:01.928
+!    sto:      Driver package already imported as 'msgpiowin32.inf' (C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_4563c8367012234f\msgpiowin32.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:05:01.928
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_wpdmtp.inf_31bf3856ad364e35_10.0.10240.16431_none_279c23d2215c89a2\wpdmtp.inf} 22:05:01.928
+!    sto:      Driver package already imported as 'wpdmtp.inf' (C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\wpdmtp.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:05:01.928
+     sto: {Stage Driver Package: C:\Windows\WinSxS\amd64_tsusbhub.inf_31bf3856ad364e35_10.0.10240.16732_none_11f5843010008a70\tsusbhub.inf} 22:05:01.928
+!    sto:      Driver package already imported as 'tsusbhub.inf' (C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_b01c6baade1c797a\tsusbhub.inf).
+     sto: {Stage Driver Package: exit(0x00000000)} 22:05:01.928
+<<<  Section end 2016/11/22 22:05:01.928
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Install Driver Updates]
+>>>  Section start 2016/11/22 22:05:01.946
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Transaction        = CbsDriversAndPrimitives
+     sto: Driver Updates     = 41
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_01ce808b39cab47d\miradisp.inf} 22:05:02.866
+     sto:      Driver Package = miradisp.inf_amd64_01ce808b39cab47d
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\miradisp.inf_amd64_01ce808b39cab47d\miradisp.inf} 22:05:02.866
+     idb:           Driver package 'miradisp.inf_amd64_01ce808b39cab47d' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:02.866
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:02.866
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_a4bdb031f38afa10\hidscanner.inf} 22:05:02.866
+     sto:      Driver Package = hidscanner.inf_amd64_a4bdb031f38afa10
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hidscanner.inf_amd64_a4bdb031f38afa10\hidscanner.inf} 22:05:02.882
+     idb:           Driver package 'hidscanner.inf_amd64_a4bdb031f38afa10' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:02.882
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:02.882
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_519ad1a6701b5cab\xusb22.inf} 22:05:02.882
+     sto:      Driver Package = xusb22.inf_amd64_519ad1a6701b5cab
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\xusb22.inf_amd64_519ad1a6701b5cab\xusb22.inf} 22:05:02.882
+     idb:           Driver package 'xusb22.inf_amd64_519ad1a6701b5cab' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:02.882
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:02.882
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_a60e43d0fd77edd8\acpi.inf} 22:05:02.882
+     sto:      Driver Package = acpi.inf_amd64_a60e43d0fd77edd8
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_a60e43d0fd77edd8\acpi.inf} 22:05:02.882
+     idb:           Changing active driver package from 'acpi.inf_amd64_19a61be22ae9944e' to 'acpi.inf_amd64_a60e43d0fd77edd8'.
+     cpy:           Unpublished 'acpi.inf'.
+     idb:           Deindexed 1 driver file for 'acpi.inf_amd64_19a61be22ae9944e'.
+     idb:           Deindexed 3 device IDs for 'acpi.inf_amd64_19a61be22ae9944e'.
+     cpy:           Published 'acpi.inf_amd64_a60e43d0fd77edd8\acpi.inf' to 'acpi.inf'.
+     idb:           Indexed 1 driver file for 'acpi.inf_amd64_a60e43d0fd77edd8'.
+     idb:           Indexed 3 device IDs for 'acpi.inf_amd64_a60e43d0fd77edd8'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.116
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.116
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_4b9b5d5319497dd4\wfcvsc.inf} 22:05:03.116
+     sto:      Driver Package = wfcvsc.inf_amd64_4b9b5d5319497dd4
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wfcvsc.inf_amd64_4b9b5d5319497dd4\wfcvsc.inf} 22:05:03.116
+     idb:           Driver package 'wfcvsc.inf_amd64_4b9b5d5319497dd4' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.132
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.132
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_57265cb2d2642968\sensorshidclassdriver.inf} 22:05:03.132
+     sto:      Driver Package = sensorshidclassdriver.inf_amd64_57265cb2d2642968
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\sensorshidclassdriver.inf_amd64_57265cb2d2642968\sensorshidclassdriver.inf} 22:05:03.132
+     idb:           Driver package 'sensorshidclassdriver.inf_amd64_57265cb2d2642968' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.132
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.132
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\bth.inf} 22:05:03.132
+     sto:      Driver Package = bth.inf_amd64_97f04f59eaecdf7a
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bth.inf_amd64_97f04f59eaecdf7a\bth.inf} 22:05:03.132
+     idb:           Driver package 'bth.inf_amd64_97f04f59eaecdf7a' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.132
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.132
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_0dabadc4461923c4\bthleenum.inf} 22:05:03.132
+     sto:      Driver Package = bthleenum.inf_amd64_0dabadc4461923c4
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthleenum.inf_amd64_0dabadc4461923c4\bthleenum.inf} 22:05:03.132
+     idb:           Driver package 'bthleenum.inf_amd64_0dabadc4461923c4' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.132
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.132
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_221654d9bb6545af\genericusbfn.inf} 22:05:03.132
+     sto:      Driver Package = genericusbfn.inf_amd64_221654d9bb6545af
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\genericusbfn.inf_amd64_221654d9bb6545af\genericusbfn.inf} 22:05:03.132
+     idb:           Driver package 'genericusbfn.inf_amd64_221654d9bb6545af' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.147
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.147
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_2780d7dc6ecda26e\usbstor.inf} 22:05:03.147
+     sto:      Driver Package = usbstor.inf_amd64_2780d7dc6ecda26e
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbstor.inf_amd64_2780d7dc6ecda26e\usbstor.inf} 22:05:03.147
+     idb:           Driver package 'usbstor.inf_amd64_2780d7dc6ecda26e' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.147
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.147
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_caa57285880769f4\usbhub3.inf} 22:05:03.147
+     sto:      Driver Package = usbhub3.inf_amd64_caa57285880769f4
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbhub3.inf_amd64_caa57285880769f4\usbhub3.inf} 22:05:03.147
+     idb:           Driver package 'usbhub3.inf_amd64_caa57285880769f4' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.147
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.147
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_7b59c1e1fa52c844\usbxhci.inf} 22:05:03.147
+     sto:      Driver Package = usbxhci.inf_amd64_7b59c1e1fa52c844
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbxhci.inf_amd64_7b59c1e1fa52c844\usbxhci.inf} 22:05:03.147
+     idb:           Driver package 'usbxhci.inf_amd64_7b59c1e1fa52c844' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.147
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.147
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbport.inf} 22:05:03.147
+     sto:      Driver Package = usbport.inf_amd64_57cc78a6a0b04383
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbport.inf} 22:05:03.147
+     idb:           Changing active driver package from 'usbport.inf_amd64_4215f546c8e8f9d6' to 'usbport.inf_amd64_57cc78a6a0b04383'.
+     cpy:           Unpublished 'usbport.inf'.
+     idb:           Deindexed 6 driver files for 'usbport.inf_amd64_4215f546c8e8f9d6'.
+     idb:           Deindexed 155 device IDs for 'usbport.inf_amd64_4215f546c8e8f9d6'.
+     cpy:           Published 'usbport.inf_amd64_57cc78a6a0b04383\usbport.inf' to 'usbport.inf'.
+     idb:           Indexed 6 driver files for 'usbport.inf_amd64_57cc78a6a0b04383'.
+     idb:           Indexed 155 device IDs for 'usbport.inf_amd64_57cc78a6a0b04383'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.914
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.914
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_b33128a95ba9fe0b\sdbus.inf} 22:05:03.914
+     sto:      Driver Package = sdbus.inf_amd64_b33128a95ba9fe0b
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\sdbus.inf_amd64_b33128a95ba9fe0b\sdbus.inf} 22:05:03.914
+     idb:           Driver package 'sdbus.inf_amd64_b33128a95ba9fe0b' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.914
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.914
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_57032036ac5b3f02\mdmbtmdm.inf} 22:05:03.914
+     sto:      Driver Package = mdmbtmdm.inf_amd64_57032036ac5b3f02
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\mdmbtmdm.inf_amd64_57032036ac5b3f02\mdmbtmdm.inf} 22:05:03.914
+     idb:           Driver package 'mdmbtmdm.inf_amd64_57032036ac5b3f02' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.930
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.930
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_47034a2e2794f3b2\bthaudhid.inf} 22:05:03.930
+     sto:      Driver Package = bthaudhid.inf_amd64_47034a2e2794f3b2
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthaudhid.inf_amd64_47034a2e2794f3b2\bthaudhid.inf} 22:05:03.930
+     idb:           Driver package 'bthaudhid.inf_amd64_47034a2e2794f3b2' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.930
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.930
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_06170919fa54ed29\bthhfenum.inf} 22:05:03.930
+     sto:      Driver Package = bthhfenum.inf_amd64_06170919fa54ed29
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\bthhfenum.inf_amd64_06170919fa54ed29\bthhfenum.inf} 22:05:03.930
+     idb:           Driver package 'bthhfenum.inf_amd64_06170919fa54ed29' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.930
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.930
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_dcc0445e956fcf69\wudfusbcciddriver.inf} 22:05:03.930
+     sto:      Driver Package = wudfusbcciddriver.inf_amd64_dcc0445e956fcf69
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wudfusbcciddriver.inf_amd64_dcc0445e956fcf69\wudfusbcciddriver.inf} 22:05:03.930
+     idb:           Driver package 'wudfusbcciddriver.inf_amd64_dcc0445e956fcf69' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.930
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.930
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_c8e3ac50c9bf5564\hdaudio.inf} 22:05:03.930
+     sto:      Driver Package = hdaudio.inf_amd64_c8e3ac50c9bf5564
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_c8e3ac50c9bf5564\hdaudio.inf} 22:05:03.930
+     idb:           Driver package 'hdaudio.inf_amd64_c8e3ac50c9bf5564' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.946
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.946
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\wdmaudio.inf} 22:05:03.946
+     sto:      Driver Package = wdmaudio.inf_amd64_58b3142a36627a91
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_58b3142a36627a91\wdmaudio.inf} 22:05:03.946
+     idb:           Driver package 'wdmaudio.inf_amd64_58b3142a36627a91' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.946
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.946
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_070bdb1ad27e2f16\hdaudbus.inf} 22:05:03.946
+     sto:      Driver Package = hdaudbus.inf_amd64_070bdb1ad27e2f16
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\hdaudbus.inf_amd64_070bdb1ad27e2f16\hdaudbus.inf} 22:05:03.946
+     idb:           Driver package 'hdaudbus.inf_amd64_070bdb1ad27e2f16' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.946
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.946
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_8e17ee2826ff2b07\netrtwlane_13.inf} 22:05:03.946
+     sto:      Driver Package = netrtwlane_13.inf_amd64_8e17ee2826ff2b07
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrtwlane_13.inf_amd64_8e17ee2826ff2b07\netrtwlane_13.inf} 22:05:03.946
+     idb:           Driver package 'netrtwlane_13.inf_amd64_8e17ee2826ff2b07' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.946
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.946
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_ed51114936bfc236\netwmbclass.inf} 22:05:03.946
+     sto:      Driver Package = netwmbclass.inf_amd64_ed51114936bfc236
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netwmbclass.inf_amd64_ed51114936bfc236\netwmbclass.inf} 22:05:03.961
+     idb:           Driver package 'netwmbclass.inf_amd64_ed51114936bfc236' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.961
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.961
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_609a0bb012179987\netrndis.inf} 22:05:03.961
+     sto:      Driver Package = netrndis.inf_amd64_609a0bb012179987
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\netrndis.inf_amd64_609a0bb012179987\netrndis.inf} 22:05:03.961
+     idb:           Driver package 'netrndis.inf_amd64_609a0bb012179987' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:03.961
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:03.961
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\ntprint.inf} 22:05:03.961
+     sto:      Driver Package = ntprint.inf_amd64_a101974e5e776f55
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\ntprint.inf} 22:05:03.961
+     idb:           Changing active driver package from 'ntprint.inf_amd64_b3cf4018952c495c' to 'ntprint.inf_amd64_a101974e5e776f55'.
+     cpy:           Unpublished 'ntprint.inf'.
+     idb:           Deindexed 28 driver files for 'ntprint.inf_amd64_b3cf4018952c495c'.
+     idb:           Deindexed 6 device IDs for 'ntprint.inf_amd64_b3cf4018952c495c'.
+     cpy:           Published 'ntprint.inf_amd64_a101974e5e776f55\ntprint.inf' to 'ntprint.inf'.
+     idb:           Indexed 28 driver files for 'ntprint.inf_amd64_a101974e5e776f55'.
+     idb:           Indexed 6 device IDs for 'ntprint.inf_amd64_a101974e5e776f55'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.198
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.198
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_1b0f9ac834d3b069\prnms003.inf} 22:05:04.198
+     sto:      Driver Package = prnms003.inf_amd64_1b0f9ac834d3b069
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_1b0f9ac834d3b069\prnms003.inf} 22:05:04.198
+     idb:           Changing active driver package from 'prnms003.inf_amd64_2da12eac1bd2c7cb' to 'prnms003.inf_amd64_1b0f9ac834d3b069'.
+     cpy:           Unpublished 'prnms003.inf'.
+     idb:           Deindexed 3 driver files for 'prnms003.inf_amd64_2da12eac1bd2c7cb'.
+     idb:           Deindexed 2 device IDs for 'prnms003.inf_amd64_2da12eac1bd2c7cb'.
+     cpy:           Published 'prnms003.inf_amd64_1b0f9ac834d3b069\prnms003.inf' to 'prnms003.inf'.
+     idb:           Indexed 3 driver files for 'prnms003.inf_amd64_1b0f9ac834d3b069'.
+     idb:           Indexed 2 device IDs for 'prnms003.inf_amd64_1b0f9ac834d3b069'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.319
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.319
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_84e344e1b54dfd1b\prnms004.inf} 22:05:04.319
+     sto:      Driver Package = prnms004.inf_amd64_84e344e1b54dfd1b
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_84e344e1b54dfd1b\prnms004.inf} 22:05:04.319
+     idb:           Changing active driver package from 'prnms004.inf_amd64_5646d0853ac66f86' to 'prnms004.inf_amd64_84e344e1b54dfd1b'.
+     cpy:           Unpublished 'prnms004.inf'.
+     idb:           Deindexed 3 driver files for 'prnms004.inf_amd64_5646d0853ac66f86'.
+     idb:           Deindexed 2 device IDs for 'prnms004.inf_amd64_5646d0853ac66f86'.
+     cpy:           Published 'prnms004.inf_amd64_84e344e1b54dfd1b\prnms004.inf' to 'prnms004.inf'.
+     idb:           Indexed 3 driver files for 'prnms004.inf_amd64_84e344e1b54dfd1b'.
+     idb:           Indexed 2 device IDs for 'prnms004.inf_amd64_84e344e1b54dfd1b'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.412
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.412
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_5c630813f6a3ff28\ntprint4.inf} 22:05:04.412
+     sto:      Driver Package = ntprint4.inf_amd64_5c630813f6a3ff28
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_5c630813f6a3ff28\ntprint4.inf} 22:05:04.412
+     idb:           Changing active driver package from 'ntprint4.inf_amd64_34fc089922f9b11d' to 'ntprint4.inf_amd64_5c630813f6a3ff28'.
+     cpy:           Unpublished 'ntprint4.inf'.
+     idb:           Deindexed 6 driver files for 'ntprint4.inf_amd64_34fc089922f9b11d'.
+     idb:           Deindexed 2 device IDs for 'ntprint4.inf_amd64_34fc089922f9b11d'.
+     cpy:           Published 'ntprint4.inf_amd64_5c630813f6a3ff28\ntprint4.inf' to 'ntprint4.inf'.
+     idb:           Indexed 6 driver files for 'ntprint4.inf_amd64_5c630813f6a3ff28'.
+     idb:           Indexed 2 device IDs for 'ntprint4.inf_amd64_5c630813f6a3ff28'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.540
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.540
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_bd4ca62bf20f9755\prnms003.inf} 22:05:04.540
+     sto:      Driver Package = prnms003.inf_x86_bd4ca62bf20f9755
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_bd4ca62bf20f9755\prnms003.inf} 22:05:04.540
+     idb:           Driver package 'prnms003.inf_amd64_1b0f9ac834d3b069' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.540
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.540
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\ntprint.inf} 22:05:04.540
+     sto:      Driver Package = ntprint.inf_x86_a101974e5e776f55
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_a101974e5e776f55\ntprint.inf} 22:05:04.558
+     idb:           Driver package 'ntprint.inf_amd64_a101974e5e776f55' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.558
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.558
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_86bd71749200d4fb\ucmucsi.inf} 22:05:04.558
+     sto:      Driver Package = ucmucsi.inf_amd64_86bd71749200d4fb
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ucmucsi.inf_amd64_86bd71749200d4fb\ucmucsi.inf} 22:05:04.558
+     idb:           Driver package 'ucmucsi.inf_amd64_86bd71749200d4fb' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.558
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.558
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_61ccd5db98b3abf1\pci.inf} 22:05:04.558
+     sto:      Driver Package = pci.inf_amd64_61ccd5db98b3abf1
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\pci.inf_amd64_61ccd5db98b3abf1\pci.inf} 22:05:04.558
+     idb:           Driver package 'pci.inf_amd64_61ccd5db98b3abf1' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.558
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.558
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_5de2576d6f02918e\usbser.inf} 22:05:04.558
+     sto:      Driver Package = usbser.inf_amd64_5de2576d6f02918e
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbser.inf_amd64_5de2576d6f02918e\usbser.inf} 22:05:04.558
+     idb:           Driver package 'usbser.inf_amd64_5de2576d6f02918e' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.558
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.558
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_5ffb10fc0bbc4ac0\stornvme.inf} 22:05:04.574
+     sto:      Driver Package = stornvme.inf_amd64_5ffb10fc0bbc4ac0
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\stornvme.inf_amd64_5ffb10fc0bbc4ac0\stornvme.inf} 22:05:04.574
+     idb:           Driver package 'stornvme.inf_amd64_5ffb10fc0bbc4ac0' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.574
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.574
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\msports.inf} 22:05:04.574
+     sto:      Driver Package = msports.inf_amd64_46e9747fe38474e5
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_46e9747fe38474e5\msports.inf} 22:05:04.574
+     idb:           Driver package 'msports.inf_amd64_46e9747fe38474e5' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.574
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.574
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_b210406b0d8c4695\buttonconverter.inf} 22:05:04.574
+     sto:      Driver Package = buttonconverter.inf_amd64_b210406b0d8c4695
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\buttonconverter.inf_amd64_b210406b0d8c4695\buttonconverter.inf} 22:05:04.574
+     idb:           Driver package 'buttonconverter.inf_amd64_b210406b0d8c4695' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.574
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.574
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\mrvlpcie8897.inf_amd64_f68a8d902ea4d964\mrvlpcie8897.inf} 22:05:04.574
+     sto:      Driver Package = mrvlpcie8897.inf_amd64_f68a8d902ea4d964
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\mrvlpcie8897.inf_amd64_f68a8d902ea4d964\mrvlpcie8897.inf} 22:05:04.574
+     idb:           Driver package 'mrvlpcie8897.inf_amd64_f68a8d902ea4d964' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.590
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.590
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_dc1bd1515a9b0d9d\vhdmp.inf} 22:05:04.590
+     sto:      Driver Package = vhdmp.inf_amd64_dc1bd1515a9b0d9d
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_dc1bd1515a9b0d9d\vhdmp.inf} 22:05:04.590
+     idb:           Changing active driver package from 'vhdmp.inf_amd64_0e346fbd37116b8f' to 'vhdmp.inf_amd64_dc1bd1515a9b0d9d'.
+     cpy:           Unpublished 'vhdmp.inf'.
+     idb:           Deindexed 1 driver file for 'vhdmp.inf_amd64_0e346fbd37116b8f'.
+     idb:           Deindexed 2 device IDs for 'vhdmp.inf_amd64_0e346fbd37116b8f'.
+     cpy:           Published 'vhdmp.inf_amd64_dc1bd1515a9b0d9d\vhdmp.inf' to 'vhdmp.inf'.
+     idb:           Indexed 1 driver file for 'vhdmp.inf_amd64_dc1bd1515a9b0d9d'.
+     idb:           Indexed 2 device IDs for 'vhdmp.inf_amd64_dc1bd1515a9b0d9d'.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.758
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.758
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_4563c8367012234f\msgpiowin32.inf} 22:05:04.758
+     sto:      Driver Package = msgpiowin32.inf_amd64_4563c8367012234f
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\msgpiowin32.inf_amd64_4563c8367012234f\msgpiowin32.inf} 22:05:04.758
+     idb:           Driver package 'msgpiowin32.inf_amd64_4563c8367012234f' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.758
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.758
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\wpdmtp.inf} 22:05:04.758
+     sto:      Driver Package = wpdmtp.inf_amd64_5bffa673ab8cb4d4
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\wpdmtp.inf_amd64_5bffa673ab8cb4d4\wpdmtp.inf} 22:05:04.758
+     idb:           Driver package 'wpdmtp.inf_amd64_5bffa673ab8cb4d4' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.758
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.758
+     sto: {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_b01c6baade1c797a\tsusbhub.inf} 22:05:04.758
+     sto:      Driver Package = tsusbhub.inf_amd64_b01c6baade1c797a
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\tsusbhub.inf_amd64_b01c6baade1c797a\tsusbhub.inf} 22:05:04.758
+     idb:           Driver package 'tsusbhub.inf_amd64_b01c6baade1c797a' is already active.
+     idb:      {Publish Driver Package: exit(0x00000000)} 22:05:04.758
+     sto: {Publish Driver Package: exit(0x00000000)} 22:05:04.758
+     sto: Driver update 'miradisp.inf' is already reflected.
+     sto: Driver update 'hidscanner.inf' is already reflected.
+     sto: Driver update 'xusb22.inf' is already reflected.
+     sto: {Cache Device Nodes} 22:05:04.774
+     sto:      Cached 61 device nodes. Time = 93ms
+     sto: {Cache Device Nodes: exit(0x00000000)} 22:05:04.866
+     sto: Devices using 'acpi.inf':
+     sto:      ACPI_HAL\PNP0C08\0 -> *PNP0C08 [ACPI_Inst.NT]
+     sto: Installed section names:
+     sto:      ACPI_Inst.NT
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_a60e43d0fd77edd8\acpi.inf}
+     inf:      Class GUID     = {4d36e97d-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           acpi.inf_amd64_a60e43d0fd77edd8 (active)
+     idb:           acpi.inf_amd64_19a61be22ae9944e
+     inf:      {Configure Driver: Microsoft ACPI-Compliant System}
+     inf:           Section Name = ACPI_Inst.NT
+     inf:           {Add Service: ACPI}
+     inf:                Start Type    = 0
+     inf:                Service Type  = 1
+     inf:                Error Control = 3
+     inf:                Image Path    = System32\drivers\ACPI.sys
+     inf:                Display Name  = Microsoft ACPI Driver
+     inf:                Updated service 'ACPI'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = *pnp0c08
+     inf:           {Configure Driver Configuration: ACPI_Inst.NT}
+     inf:                Service Name  = ACPI
+     inf:                Reboot Required
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Microsoft ACPI-Compliant System}
+     inf:           Section Name = ACPI_Inst.NT
+     inf:           Hardware Id  = pnp0c08
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_a60e43d0fd77edd8\acpi.sys' to 'C:\Windows\System32\drivers\acpi.sys'.
+     cpy:      Existing file 'C:\Windows\System32\drivers\acpi.sys' remains unchanged.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Driver update 'wfcvsc.inf' is already reflected.
+     sto: Driver update 'sensorshidclassdriver.inf' is already reflected.
+     sto: Driver update 'bth.inf' is already reflected.
+     sto: Driver update 'bthleenum.inf' is already reflected.
+     sto: Driver update 'genericusbfn.inf' is already reflected.
+     sto: Driver update 'usbstor.inf' is already reflected.
+     sto: Driver update 'usbhub3.inf' is already reflected.
+     sto: Driver update 'usbxhci.inf' is already reflected.
+     sto: Devices using 'usbport.inf':
+     sto:      PCI\VEN_106B&DEV_003F&SUBSYS_00000000&REV_00\3&267a616a&1&30 -> PCI\CC_0C0310 [OHCI.Dev.NT]
+     sto:      PCI\VEN_8086&DEV_265C&SUBSYS_00000000&REV_00\3&267a616a&1&58 -> PCI\VEN_8086&DEV_265C [EHCI.Dev.NT]
+     sto:      USB\ROOT_HUB\4&159a73f4&0 -> USB\ROOT_HUB [ROOTHUB.Dev.NT]
+     sto:      USB\ROOT_HUB20\4&3749a296&0 -> USB\ROOT_HUB20 [ROOTHUB.Dev.NT]
+     sto: Installed section names:
+     sto:      OHCI.Dev.NT
+     sto:      EHCI.Dev.NT
+     sto:      ROOTHUB.Dev.NT
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbport.inf}
+     inf:      Class GUID     = {36fc9e60-c465-11cf-8056-444553540000}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           usbport.inf_amd64_57cc78a6a0b04383 (active)
+     idb:           usbport.inf_amd64_4215f546c8e8f9d6
+     inf:      {Configure Driver: ULi USB 2.0 Enhanced Host Controller}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           {Add Service: usbehci}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\usbehci.sys
+     inf:                Display Name  = Microsoft USB 2.0 Enhanced Host Controller Miniport Driver
+     inf:                Group         = Base
+     inf:                Updated service 'usbehci'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = PCI\VEN_10B9&DEV_5239&CC_0C0320
+     inf:           {Configure Driver Configuration: EHCI.Dev.NT}
+     inf:                Service Name  = usbehci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: ATI I/O Communications Processor USB 2.0 EHCI controller}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\Ven_1002&Dev_4373
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: ATI I/O Communications Processor USB 1.1 OHCI controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           {Add Service: usbohci}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\usbohci.sys
+     inf:                Display Name  = Microsoft USB Open Host Controller Miniport Driver
+     inf:                Group         = Base
+     inf:                Updated service 'usbohci'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = PCI\Ven_1002&Dev_4374
+     inf:           {Configure Driver Configuration: OHCI.Dev.NT}
+     inf:                Service Name  = usbohci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: ATI I/O Communications Processor USB 1.1 OHCI controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\Ven_1002&Dev_4375
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: CMD USB0670 PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1095&DEV_0670&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: CMD USB0673 PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1095&DEV_0673&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Standard OpenHCD USB Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Standard Enhanced PCI to USB Host Controller}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\CC_0C0320
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB Root Hub}
+     inf:           Section Name = ROOTHUB.Dev.NT
+     inf:           {Add Service: usbhub}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\usbhub.sys
+     inf:                Display Name  = Microsoft USB Standard Hub Driver
+     inf:                Group         = Base
+     inf:                Updated service 'usbhub'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = USB\ROOT_HUB
+     inf:           {Configure Driver Configuration: ROOTHUB.Dev.NT}
+     inf:                Service Name  = usbhub
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: USB Root Hub}
+     inf:           Section Name = ROOTHUB.Dev.NT
+     inf:           Hardware Id  = USB\ROOT_HUB20
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) SM35 Express Chipset USB2 Enhanced Host Controller MPH  - 0806}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_0806
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) SM35 Express Chipset USB2 Enhanced Host Controller SPM  - 0811}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_0811
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 6 Series/C200 Series Chipset Family USB Enhanced Host Controller - 1C26}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_1C26
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 6 Series/C200 Series Chipset Family USB Enhanced Host Controller - 1C2D}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_1C2D
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) C600/X79 series chipset USB2 Enhanced Host Controller #1 - 1D26}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_1D26
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) C600/X79 series chipset USB2 Enhanced Host Controller #2 - 1D2D}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_1D2D
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 7 Series/C216 Chipset Family USB Enhanced Host Controller - 1E26}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_1E26
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 7 Series/C216 Chipset Family USB Enhanced Host Controller - 1E2D}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_1E2D
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: DH89xxCC USB 2.0 Controller 1 - 2334}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2334
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: DH89xxCC USB 2.0 Controller 1 - 2335}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2335
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801DB/DBM USB 2.0 Enhanced Host Controller - 24CD}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24CD&CC_0C0320
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801EB USB2 Enhanced Host Controller - 24DD}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24DD
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 6300ESB USB2 Enhanced Host Controller - 25AD}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_25AD
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801FB/FBM USB2 Enhanced Host Controller - 265C}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_265C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 631xESB/6321ESB/3100 Chipset USB2 Enhanced Host Controller - 268C}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_268C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801G (ICH7 Family) USB2 Enhanced Host Controller - 27CC}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_27CC
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH8 Family USB2 Enhanced Host Controller - 2836}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2836
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH8 Family USB2 Enhanced Host Controller - 283A}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_283A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH9 Family USB2 Enhanced Host Controller - 293A}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_293A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH9 Family USB2 Enhanced Host Controller - 293C}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_293C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Enhanced Host Controller - 3A3A}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A3A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Enhanced Host Controller - 3A3C}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A3C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Enhanced Host Controller - 3A6A}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A6A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Enhanced Host Controller - 3A6C}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A6C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Enhanced Host Controller - 3B34}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B34
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Enhanced Host Controller - 3B3C}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B3C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Platform Controller Hub EG20T USB OHCI Controller #4 - 8804}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_8804
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Platform Controller Hub EG20T USB OHCI Controller #5 - 8805}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_8805
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Platform Controller Hub EG20T USB OHCI Controller #6 - 8806}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_8806
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Platform Controller Hub EG20T USB2 EHCI Controller #2 - 8807}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_8807
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Platform Controller Hub EG20T USB OHCI Controller #1 - 880c}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_880C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Platform Controller Hub EG20T USB OHCI Controller #2 - 880d}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_880D
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Platform Controller Hub EG20T USB OHCI Controller #3 - 880e}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_880E
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Platform Controller Hub EG20T USB2 EHCI Controller #1 - 880f}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_880F
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 8 Series/C220 Series USB EHCI #1 - 8C26}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_8C26
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 8 Series/C220 Series USB EHCI #2 - 8C2D}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_8C2D
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 8 Series USB Enhanced Host Controller #1 - 9C26}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_9C26
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 8 Series USB Enhanced Host Controller #2 - 9C2D}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_9C2D
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) Atom(TM) processor C2000 product family USB Enhanced Host Controller - 1F2C}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_1F2C
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Lucent USB Open Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_11C1&DEV_5801&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Lucent USB Open Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_11C1&DEV_5802&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Lucent QuadraBus USB Open Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_11C1&DEV_5803&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: NEC PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1033&DEV_0035&REV_41
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: NEC PCI to USB Enhanced Host Controller (B0)}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1033&DEV_00E0&REV_01
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: NEC PCI to USB Enhanced Host Controller (B1)}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1033&DEV_00E0&REV_02
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: ServerWorks (RCC) PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1166&DEV_0220&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SMSC SLC90E66 PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1055&DEV_9462
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA USB Enhanced Host Controller}
+     inf:           Section Name = EHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3104
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: AMD 756 PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_HYDRA.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1022&DEV_740C&CC_0C0310
+     inf:           {Configure Driver Configuration: OHCI_HYDRA.Dev.NT}
+     inf:                Service Name  = usbohci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: AMD PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_NOSS.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1022&DEV_7464&REV_08
+     inf:           {Configure Driver Configuration: OHCI_NOSS.Dev.NT}
+     inf:                Service Name  = usbohci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: AMD PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_NOSS.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1022&DEV_7464&REV_09
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: AMD PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_NOSS.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1022&DEV_7464&REV_0B
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: ULi PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_HYDRA.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_10B9&DEV_5237&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Compaq PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_HYDRA.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_0E11&DEV_A0F8&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Cypress USB Open Host Controller}
+     inf:           Section Name = OHCI_HYDRA.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1080&DEV_C693&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Standard Universal PCI to USB Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           {Add Service: usbuhci}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\usbuhci.sys
+     inf:                Display Name  = Microsoft USB Universal Host Controller Miniport Driver
+     inf:                Group         = Base
+     inf:                Updated service 'usbuhci'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = PCI\CC_0C0300
+     inf:           {Configure Driver Configuration: UHCI.Dev.NT}
+     inf:                Service Name  = usbuhci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Standard EHCI-compliant Host Controller}
+     inf:           Section Name = EHCI_SOC.Dev.NT
+     inf:           Hardware Id  = *PNP0D20
+     inf:           {Configure Driver Configuration: EHCI_SOC.Dev.NT}
+     inf:                Service Name  = usbehci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Standard EHCI-compliant Host Controller}
+     inf:           Section Name = EHCI_SOC.Dev.NT
+     inf:           Hardware Id  = ACPI\PNP0D20
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Standard EHCI-compliant Host Controller}
+     inf:           Section Name = EHCI_SOC.Dev.NT
+     inf:           Hardware Id  = *PNP0FFC
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: DH89xxCC USB EHCI virtual HC #1 - 2359}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2359
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: DH89xxCC USB EHCI virtual HC #2 - 235A}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_235A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801AA USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2412&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801AB USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2422&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801BA/BAM USB Universal Host Controller - 2442}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2442&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801BA/BAM USB Universal Host Controller - 2444}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2444&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801CA/CAM USB Universal Host Controller - 2482}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2482
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801CA/CAM USB Universal Host Controller - 2484}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2484
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801CA/CAM USB Universal Host Controller - 2487}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2487
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801DB/DBM USB Universal Host Controller - 24C2}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24C2&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801DB/DBM USB Universal Host Controller - 24C4}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24C4&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801DB/DBM USB Universal Host Controller - 24C7}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24C7&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801EB USB Universal Host Controller - 24D2}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24D2
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801EB USB Universal Host Controller - 24D4}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24D4
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801EB USB Universal Host Controller - 24D7}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24D7
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801EB USB Universal Host Controller - 24DE}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_24DE
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 6300ESB USB Universal Host Controller - 25A9}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_25A9
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 6300ESB USB Universal Host Controller - 25AA}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_25AA
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801FB/FBM USB Universal Host Controller - 2658}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2658
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801FB/FBM USB Universal Host Controller - 2659}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2659
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801FB/FBM USB Universal Host Controller - 265A}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_265A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801FB/FBM USB Universal Host Controller - 265B}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_265B
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 631xESB/6321ESB/3100 Chipset USB Universal Host Controller - 2688}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2688
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 631xESB/6321ESB/3100 Chipset USB Universal Host Controller - 2689}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2689
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 631xESB/6321ESB/3100 Chipset USB Universal Host Controller - 268A}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_268A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 631xESB/6321ESB/3100 Chipset USB Universal Host Controller - 268B}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_268B
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801G (ICH7 Family) USB Universal Host Controller - 27C8}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_27C8
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801G (ICH7 Family) USB Universal Host Controller - 27C9}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_27C9
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801G (ICH7 Family) USB Universal Host Controller - 27CA}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_27CA
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82801G (ICH7 Family) USB Universal Host Controller - 27CB}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_27CB
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH8 Family USB Universal Host Controller - 2830}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2830
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH8 Family USB Universal Host Controller - 2831}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2831
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH8 Family USB Universal Host Controller - 2832}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2832
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH8 Family USB Universal Host Controller - 2834}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2834
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH8 Family USB Universal Host Controller - 2835}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2835
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH9 Family USB Universal Host Controller - 2934}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2934
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH9 Family USB Universal Host Controller - 2935}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2935
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH9 Family USB Universal Host Controller - 2936}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2936
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH9 Family USB Universal Host Controller - 2937}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2937
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH9 Family USB Universal Host Controller - 2938}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2938
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH9 Family USB Universal Host Controller - 2939}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_2939
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A34}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A34
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A35}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A35
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A36}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A36
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A37}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A37
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A38}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A38
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A39}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A39
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A64}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A64
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A65}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A65
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A66}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A66
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A67}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A67
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A68}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A68
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) ICH10 Family USB Universal Host Controller - 3A69}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3A69
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B36}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B36
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B37}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B37
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B38}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B38
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B39}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B39
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B3A}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B3A
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B3B}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B3B
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B3E}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B3E
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B3F}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B3F
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 5 Series/3400 Series Chipset Family USB Universal Host Controller - 3B40}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_3B40
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82371SB PCI to USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_7020&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82371AB/EB PCI to USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_7112&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82440MX USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_719A&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Intel(R) 82372FB PCI to USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_8086&DEV_7602&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: NEC PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_NEC.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1033&DEV_0035&CC_0C0310
+     inf:           {Configure Driver Configuration: OHCI_NEC.Dev.NT}
+     inf:                Service Name  = usbohci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: NEC PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_NEC.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1033&DEV_0035&REV_02
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: NEC PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_NOCC.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1033&DEV_0035&SUBSYS_00011179&REV_41
+     inf:           {Configure Driver Configuration: OHCI_NOCC.Dev.NT}
+     inf:                Service Name  = usbohci
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: OPTi 82C861 PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_HYDRA.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1045&DEV_C861&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: SiS 7001 PCI to USB Open Host Controller}
+     inf:           Section Name = OHCI_HYDRA.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1039&DEV_7001&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Symbios Logic SYM61C102 USB Host Controller}
+     inf:           Section Name = OHCI_HYDRA.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1000&DEV_0901&CC_0C0310
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 0 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&SUBSYS_12340925&REV_00
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 0 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&REV_00
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 1 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&SUBSYS_12340925&REV_01
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 1 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&REV_01
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 2 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&SUBSYS_12340925&REV_02
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 2 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&REV_02
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 3 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&SUBSYS_12340925&REV_03
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 3 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&REV_03
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 4 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&SUBSYS_12340925&REV_04
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 4 USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&REV_04
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 5 or later USB Universal Host Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&CC_0C0300
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 5 or later USB Universal Host Companion Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&SUBSYS_12340925&REV_50
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: VIA Rev 5 or later USB Universal Host Companion Controller}
+     inf:           Section Name = UHCI.Dev.NT
+     inf:           Hardware Id  = PCI\VEN_1106&DEV_3038&REV_50
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Unsupported Device}
+     inf:           Section Name = EHCI.UnsupportedDev.NT
+     inf:           {Configure Driver Configuration: EHCI.UnsupportedDev.NT}
+     inf:                Service Name  = <none>
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Unsupported Device}
+     inf:           Section Name = OHCI.UnsupportedDev.NT
+     inf:           {Configure Driver Configuration: OHCI.UnsupportedDev.NT}
+     inf:                Service Name  = <none>
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     inf:      {Configure Driver: Unsupported Device}
+     inf:           Section Name = UHCI.UnsupportedDev.NT
+     inf:           {Configure Driver Configuration: UHCI.UnsupportedDev.NT}
+     inf:                Service Name  = <none>
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbehci.sys' to 'C:\Windows\system32\drivers\usbehci.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\usbehci.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbport.sys' to 'C:\Windows\system32\drivers\usbport.sys'.
+     idb:      Last driver package 'usbport.inf_amd64_4215f546c8e8f9d6' to copy 'C:\Windows\system32\drivers\usbport.sys' needs reconfiguration.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbhub.sys' to 'C:\Windows\system32\drivers\usbhub.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\usbhub.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbohci.sys' to 'C:\Windows\system32\drivers\usbohci.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\usbohci.sys' remains unchanged.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbd.sys' to 'C:\Windows\system32\drivers\usbd.sys'.
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbuhci.sys' to 'C:\Windows\system32\drivers\usbuhci.sys'.
+     cpy:      Existing file 'C:\Windows\system32\drivers\usbuhci.sys' remains unchanged.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Driver update 'sdbus.inf' is already reflected.
+     sto: Driver update 'mdmbtmdm.inf' is already reflected.
+     sto: Driver update 'bthaudhid.inf' is already reflected.
+     sto: Driver update 'bthhfenum.inf' is already reflected.
+     sto: Driver update 'wudfusbcciddriver.inf' is already reflected.
+     sto: Driver update 'hdaudio.inf' is already reflected.
+     sto: Driver update 'wdmaudio.inf' is already reflected.
+     sto: Driver update 'hdaudbus.inf' is already reflected.
+     sto: Driver update 'netrtwlane_13.inf' is already reflected.
+     sto: Driver update 'netwmbclass.inf' is already reflected.
+     sto: Driver update 'netrndis.inf' is already reflected.
+     sto: No effective section names for 'ntprint.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\ntprint.inf}
+     inf:      Class GUID     = {4d36e979-e325-11ce-bfc1-08002be10318}
+     idb:      Driver packages:
+     idb:           ntprint.inf_x86_a101974e5e776f55
+     idb:           ntprint.inf_x86_b3cf4018952c495c
+     idb:           ntprint.inf_amd64_a101974e5e776f55 (active)
+     idb:           ntprint.inf_amd64_b3cf4018952c495c
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'prnms003.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_1b0f9ac834d3b069\prnms003.inf}
+     inf:      Class GUID     = {4d36e979-e325-11ce-bfc1-08002be10318}
+     idb:      Driver packages:
+     idb:           prnms003.inf_x86_bd4ca62bf20f9755
+     idb:           prnms003.inf_x86_8f17aac186c70ea6
+     idb:           prnms003.inf_amd64_1b0f9ac834d3b069 (active)
+     idb:           prnms003.inf_amd64_2da12eac1bd2c7cb
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'prnms004.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_84e344e1b54dfd1b\prnms004.inf}
+     inf:      Class GUID     = {4d36e979-e325-11ce-bfc1-08002be10318}
+     idb:      Driver packages:
+     idb:           prnms004.inf_amd64_84e344e1b54dfd1b (active)
+     idb:           prnms004.inf_amd64_5646d0853ac66f86
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: No effective section names for 'ntprint4.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_5c630813f6a3ff28\ntprint4.inf}
+     inf:      Class GUID     = {4d36e979-e325-11ce-bfc1-08002be10318}
+     idb:      Driver packages:
+     idb:           ntprint4.inf_amd64_5c630813f6a3ff28 (active)
+     idb:           ntprint4.inf_amd64_34fc089922f9b11d
+     sto:      No active drivers -- nothing to configure.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Skipping non-native x86 driver package 'prnms003.inf' on amd64.
+     sto: Skipping non-native x86 driver package 'ntprint.inf' on amd64.
+     sto: Driver update 'ucmucsi.inf' is already reflected.
+     sto: Driver update 'pci.inf' is already reflected.
+     sto: Driver update 'usbser.inf' is already reflected.
+     sto: Driver update 'stornvme.inf' is already reflected.
+     sto: Driver update 'msports.inf' is already reflected.
+     sto: Driver update 'buttonconverter.inf' is already reflected.
+     sto: Driver update 'mrvlpcie8897.inf' is already reflected.
+     sto: No effective section names for 'vhdmp.inf'.
+     sto: {Reflect Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_dc1bd1515a9b0d9d\vhdmp.inf}
+     inf:      Class GUID     = {4d36e97b-e325-11ce-bfc1-08002be10318}
+     inf:      Class Options  = Configurable BootCritical
+     idb:      Driver packages:
+     idb:           vhdmp.inf_amd64_dc1bd1515a9b0d9d (active)
+     idb:           vhdmp.inf_amd64_0e346fbd37116b8f
+     inf:      {Configure Driver: Microsoft VHD Loopback Controller}
+     inf:           Section Name = vhdmp_inst
+     inf:           {Add Service: vhdmp}
+     inf:                Start Type    = 3
+     inf:                Service Type  = 1
+     inf:                Error Control = 1
+     inf:                Image Path    = \SystemRoot\System32\drivers\vhdmp.sys
+     inf:                Group         = SCSI miniport
+     inf:                Updated service 'vhdmp'.
+     inf:           {Add Service: exit(0x00000000)}
+     inf:           Hardware Id  = {8e7bd593-6e6c-4c52-86a6-77175494dd8e}\MsVhdHba
+     inf:           {Configure Driver Configuration: vhdmp_inst}
+     inf:                Service Name  = vhdmp
+     inf:                Config Flags  = 0x00000000
+     inf:           {Configure Driver Configuration: exit(0x00000000)}
+     inf:      {Configure Driver: exit(0x00000000)}
+     flq:      Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_dc1bd1515a9b0d9d\vhdmp.sys' to 'C:\Windows\System32\drivers\vhdmp.sys'.
+     idb:      Last driver package 'vhdmp.inf_amd64_0e346fbd37116b8f' to copy 'C:\Windows\System32\drivers\vhdmp.sys' needs reconfiguration.
+     sto: {Reflect Driver Package: exit(0x00000000)}
+     sto: Driver update 'msgpiowin32.inf' is already reflected.
+     sto: Driver update 'wpdmtp.inf' is already reflected.
+     sto: Driver update 'tsusbhub.inf' is already reflected.
+     sto: {Update Device Drivers: acpi.inf} 22:05:08.131
+     sto:      Driver Version = 6/21/2006,10.0.10240.17184
+     sto:      {Update Device: ACPI_HAL\PNP0C08\0}
+     sto:           Updating installed driver version:
+     sto:                Driver Version Last     = 6/21/2006,10.0.10240.16397
+     sto:                Driver Version New      = 6/21/2006,10.0.10240.17184
+     sto:                Driver Node Strong Name = acpi.inf:db04a16ce10b0c38:ACPI_Inst.NT:10.0.10240.17184:*PNP0C08
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      Updated drivers for 1 device node.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:05:08.150
+     sto: {Update Device Drivers: usbport.inf} 22:05:08.150
+     sto:      Driver Version = 6/21/2006,10.0.10240.17184
+     sto:      {Update Device: PCI\VEN_106B&DEV_003F&SUBSYS_00000000&REV_00\3&267a616a&1&30}
+     sto:           Updating installed driver version:
+     sto:                Driver Version Last     = 6/21/2006,10.0.10240.16542
+     sto:                Driver Version New      = 6/21/2006,10.0.10240.17184
+     sto:                Driver Node Strong Name = usbport.inf:392c3d531fddeb19:OHCI.Dev.NT:10.0.10240.17184:PCI\CC_0C0310
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      {Update Device: PCI\VEN_8086&DEV_265C&SUBSYS_00000000&REV_00\3&267a616a&1&58}
+     sto:           Updating installed driver version:
+     sto:                Driver Version Last     = 6/21/2006,10.0.10240.16542
+     sto:                Driver Version New      = 6/21/2006,10.0.10240.17184
+     sto:                Driver Node Strong Name = usbport.inf:ddfda09403aa9831:EHCI.Dev.NT:10.0.10240.17184:PCI\VEN_8086&DEV_265C
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      {Update Device: USB\ROOT_HUB\4&159a73f4&0}
+     sto:           Updating installed driver version:
+     sto:                Driver Version Last     = 6/21/2006,10.0.10240.16542
+     sto:                Driver Version New      = 6/21/2006,10.0.10240.17184
+     sto:                Driver Node Strong Name = usbport.inf:392c3d536976a1f4:ROOTHUB.Dev.NT:10.0.10240.17184:USB\ROOT_HUB
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      {Update Device: USB\ROOT_HUB20\4&3749a296&0}
+     sto:           Updating installed driver version:
+     sto:                Driver Version Last     = 6/21/2006,10.0.10240.16542
+     sto:                Driver Version New      = 6/21/2006,10.0.10240.17184
+     sto:                Driver Node Strong Name = usbport.inf:392c3d536976a1f4:ROOTHUB.Dev.NT:10.0.10240.17184:USB\ROOT_HUB20
+     sto:      {Update Device: exit(0x00000000)}
+     sto:      Updated drivers for 4 device nodes.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:05:08.180
+     sto: {Update Device Drivers: ntprint.inf} 22:05:08.180
+     sto:      Driver Version = 6/21/2006,10.0.10240.17184
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:05:08.180
+     sto: {Update Device Drivers: prnms003.inf} 22:05:08.180
+     sto:      Driver Version = 6/21/2006,10.0.10240.17184
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:05:08.194
+     sto: {Update Device Drivers: prnms004.inf} 22:05:08.194
+     sto:      Driver Version = 6/21/2006,10.0.10240.17184
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:05:08.194
+     sto: {Update Device Drivers: ntprint4.inf} 22:05:08.194
+     sto:      Driver Version = 6/21/2006,10.0.10240.17184
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:05:08.194
+     sto: {Update Device Drivers: vhdmp.inf} 22:05:08.194
+     sto:      Driver Version = 6/21/2006,10.0.10240.17184
+     sto:      No device nodes require driver updates.
+     sto: {Update Device Drivers: exit(0x00000000)} 22:05:08.194
+<<<  Section end 2016/11/22 22:05:08.194
+<<<  [Exit status: SUCCESS (REBOOT_REQUIRED)]
+
+
+>>>  [Uninstall Driver Updates]
+>>>  Section start 2016/11/22 22:05:08.274
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Transaction        = CbsDriversAndPrimitives
+     sto: Driver Updates     = 9
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_0e346fbd37116b8f\vhdmp.inf} 22:05:08.350
+     sto:      Driver Package = vhdmp.inf_amd64_0e346fbd37116b8f
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_0e346fbd37116b8f\vhdmp.inf} 22:05:08.350
+     idb:           Driver package 'vhdmp.inf_amd64_dc1bd1515a9b0d9d' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 22:05:08.350
+     sto: {Unpublish Driver Package: exit(0x00000000)} 22:05:08.350
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6\prnms003.inf} 22:05:08.350
+     sto:      Driver Package = prnms003.inf_x86_8f17aac186c70ea6
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6\prnms003.inf} 22:05:08.350
+     idb:           Driver package 'prnms003.inf_amd64_1b0f9ac834d3b069' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 22:05:08.350
+     sto: {Unpublish Driver Package: exit(0x00000000)} 22:05:08.350
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\ntprint.inf} 22:05:08.350
+     sto:      Driver Package = ntprint.inf_x86_b3cf4018952c495c
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\ntprint.inf} 22:05:08.350
+     idb:           Driver package 'ntprint.inf_amd64_a101974e5e776f55' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 22:05:08.382
+     sto: {Unpublish Driver Package: exit(0x00000000)} 22:05:08.382
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\ntprint4.inf} 22:05:08.382
+     sto:      Driver Package = ntprint4.inf_amd64_34fc089922f9b11d
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\ntprint4.inf} 22:05:08.382
+     idb:           Driver package 'ntprint4.inf_amd64_5c630813f6a3ff28' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 22:05:08.382
+     sto: {Unpublish Driver Package: exit(0x00000000)} 22:05:08.382
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\ntprint.inf} 22:05:08.382
+     sto:      Driver Package = ntprint.inf_amd64_b3cf4018952c495c
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\ntprint.inf} 22:05:08.382
+     idb:           Driver package 'ntprint.inf_amd64_a101974e5e776f55' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 22:05:08.382
+     sto: {Unpublish Driver Package: exit(0x00000000)} 22:05:08.382
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86\prnms004.inf} 22:05:08.382
+     sto:      Driver Package = prnms004.inf_amd64_5646d0853ac66f86
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86\prnms004.inf} 22:05:08.398
+     idb:           Driver package 'prnms004.inf_amd64_84e344e1b54dfd1b' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 22:05:08.398
+     sto: {Unpublish Driver Package: exit(0x00000000)} 22:05:08.398
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\prnms003.inf} 22:05:08.398
+     sto:      Driver Package = prnms003.inf_amd64_2da12eac1bd2c7cb
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\prnms003.inf} 22:05:08.398
+     idb:           Driver package 'prnms003.inf_amd64_1b0f9ac834d3b069' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 22:05:08.398
+     sto: {Unpublish Driver Package: exit(0x00000000)} 22:05:08.398
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbport.inf} 22:05:08.398
+     sto:      Driver Package = usbport.inf_amd64_4215f546c8e8f9d6
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbport.inf} 22:05:08.398
+     idb:           Driver package 'usbport.inf_amd64_57cc78a6a0b04383' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 22:05:08.398
+     sto: {Unpublish Driver Package: exit(0x00000000)} 22:05:08.398
+     sto: {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_19a61be22ae9944e\acpi.inf} 22:05:08.398
+     sto:      Driver Package = acpi.inf_amd64_19a61be22ae9944e
+     idb:      {Unpublish Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_19a61be22ae9944e\acpi.inf} 22:05:08.398
+     idb:           Driver package 'acpi.inf_amd64_a60e43d0fd77edd8' is already active.
+     idb:      {Unpublish Driver Package: exit(0x00000000)} 22:05:08.413
+     sto: {Unpublish Driver Package: exit(0x00000000)} 22:05:08.413
+     sto: Higher version of 'vhdmp.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_dc1bd1515a9b0d9d\vhdmp.inf
+     sto: Skipping non-native x86 driver package 'prnms003.inf' on amd64.
+     sto: Skipping non-native x86 driver package 'ntprint.inf' on amd64.
+     sto: Higher version of 'ntprint4.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_5c630813f6a3ff28\ntprint4.inf
+     sto: Higher version of 'ntprint.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_a101974e5e776f55\ntprint.inf
+     sto: Higher version of 'prnms004.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_84e344e1b54dfd1b\prnms004.inf
+     sto: Higher version of 'prnms003.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_1b0f9ac834d3b069\prnms003.inf
+     sto: Higher version of 'usbport.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_57cc78a6a0b04383\usbport.inf
+     sto: Higher version of 'acpi.inf' is currently reflected.
+     sto:      Filename = C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_a60e43d0fd77edd8\acpi.inf
+<<<  Section end 2016/11/22 22:05:08.413
+<<<  [Exit status: SUCCESS]
+
+
+[Boot Session: 2016/11/22 22:23:59.498]
+
+>>>  [Unstage Driver Updates]
+>>>  Section start 2016/11/22 22:29:31.249
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     sto: Image State        = Specialized
+     sto: Image Architecture = amd64
+     sto: Driver Updates     = 9
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_0e346fbd37116b8f\vhdmp.inf} 22:29:33.546
+     sto:      {DRIVERSTORE DELETE BEGIN} 22:29:33.650
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 22:29:33.650
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_0e346fbd37116b8f\vhdmp.inf} 22:29:33.711
+     idb:           Unregistered driver package 'vhdmp.inf_amd64_0e346fbd37116b8f' from 'vhdmp.inf'.
+     idb:           Deleted driver package object 'vhdmp.inf_amd64_0e346fbd37116b8f' from SYSTEM database node.
+     idb:           Driver packages registered to 'vhdmp.inf':
+     idb:                vhdmp.inf_amd64_dc1bd1515a9b0d9d
+     idb:      {Unregister Driver Package: exit(0x00000000)} 22:29:33.711
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\vhdmp.inf_amd64_0e346fbd37116b8f} 22:29:33.711
+     cpy:      {Delete Directory: exit(0x00000000)} 22:29:33.996
+     sto:      {DRIVERSTORE DELETE END} 22:29:33.996
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 22:29:33.996
+     sto: {Unstage Driver Package: exit(0x00000000)} 22:29:33.996
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6\prnms003.inf} 22:29:36.635
+     sto:      {DRIVERSTORE DELETE BEGIN} 22:29:36.635
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 22:29:36.635
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6\prnms003.inf} 22:29:36.635
+     idb:           Unregistered driver package 'prnms003.inf_x86_8f17aac186c70ea6' from 'prnms003.inf'.
+     idb:           Deleted driver package object 'prnms003.inf_x86_8f17aac186c70ea6' from DRIVERS database node.
+     idb:           Driver packages registered to 'prnms003.inf':
+     idb:                prnms003.inf_x86_bd4ca62bf20f9755
+     idb:                prnms003.inf_amd64_1b0f9ac834d3b069
+     idb:                prnms003.inf_amd64_2da12eac1bd2c7cb
+     idb:      {Unregister Driver Package: exit(0x00000000)} 22:29:36.635
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6} 22:29:36.635
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_8f17aac186c70ea6\I386} 22:29:36.681
+     cpy:           {Delete Directory: exit(0x00000000)} 22:29:36.962
+     cpy:      {Delete Directory: exit(0x00000000)} 22:29:37.227
+     sto:      {DRIVERSTORE DELETE END} 22:29:37.227
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 22:29:37.227
+     sto: {Unstage Driver Package: exit(0x00000000)} 22:29:37.227
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\ntprint.inf} 22:29:37.227
+     sto:      {DRIVERSTORE DELETE BEGIN} 22:29:37.227
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 22:29:37.227
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\ntprint.inf} 22:29:37.227
+     idb:           Unregistered driver package 'ntprint.inf_x86_b3cf4018952c495c' from 'ntprint.inf'.
+     idb:           Deleted driver package object 'ntprint.inf_x86_b3cf4018952c495c' from DRIVERS database node.
+     idb:           Driver packages registered to 'ntprint.inf':
+     idb:                ntprint.inf_x86_a101974e5e776f55
+     idb:                ntprint.inf_amd64_a101974e5e776f55
+     idb:                ntprint.inf_amd64_b3cf4018952c495c
+     idb:      {Unregister Driver Package: exit(0x00000000)} 22:29:37.227
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c} 22:29:37.227
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_x86_b3cf4018952c495c\I386} 22:29:37.351
+     cpy:           {Delete Directory: exit(0x00000000)} 22:29:38.425
+     cpy:      {Delete Directory: exit(0x00000000)} 22:29:38.768
+     sto:      {DRIVERSTORE DELETE END} 22:29:38.768
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 22:29:38.768
+     sto: {Unstage Driver Package: exit(0x00000000)} 22:29:38.768
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\ntprint4.inf} 22:29:38.768
+     sto:      {DRIVERSTORE DELETE BEGIN} 22:29:38.768
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 22:29:38.768
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\ntprint4.inf} 22:29:38.799
+     idb:           Unregistered driver package 'ntprint4.inf_amd64_34fc089922f9b11d' from 'ntprint4.inf'.
+     idb:           Deleted driver package object 'ntprint4.inf_amd64_34fc089922f9b11d' from DRIVERS database node.
+     idb:           Driver packages registered to 'ntprint4.inf':
+     idb:                ntprint4.inf_amd64_5c630813f6a3ff28
+     idb:      {Unregister Driver Package: exit(0x00000000)} 22:29:38.799
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d} 22:29:38.799
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ntprint4.inf_amd64_34fc089922f9b11d\Amd64} 22:29:38.892
+     cpy:           {Delete Directory: exit(0x00000000)} 22:29:39.748
+     cpy:      {Delete Directory: exit(0x00000000)} 22:29:39.826
+     sto:      {DRIVERSTORE DELETE END} 22:29:39.826
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 22:29:39.826
+     sto: {Unstage Driver Package: exit(0x00000000)} 22:29:39.826
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\ntprint.inf} 22:29:39.826
+     sto:      {DRIVERSTORE DELETE BEGIN} 22:29:39.826
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 22:29:39.844
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\ntprint.inf} 22:29:39.844
+     idb:           Unregistered driver package 'ntprint.inf_amd64_b3cf4018952c495c' from 'ntprint.inf'.
+     idb:           Deleted driver package object 'ntprint.inf_amd64_b3cf4018952c495c' from DRIVERS database node.
+     idb:           Driver packages registered to 'ntprint.inf':
+     idb:                ntprint.inf_x86_a101974e5e776f55
+     idb:                ntprint.inf_amd64_a101974e5e776f55
+     idb:      {Unregister Driver Package: exit(0x00000000)} 22:29:39.844
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c} 22:29:39.844
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_b3cf4018952c495c\Amd64} 22:29:39.920
+     cpy:           {Delete Directory: exit(0x00000000)} 22:29:40.387
+     cpy:      {Delete Directory: exit(0x00000000)} 22:29:40.577
+     sto:      {DRIVERSTORE DELETE END} 22:29:40.577
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 22:29:40.577
+     sto: {Unstage Driver Package: exit(0x00000000)} 22:29:40.577
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86\prnms004.inf} 22:29:40.577
+     sto:      {DRIVERSTORE DELETE BEGIN} 22:29:40.577
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 22:29:40.577
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86\prnms004.inf} 22:29:40.577
+     idb:           Unregistered driver package 'prnms004.inf_amd64_5646d0853ac66f86' from 'prnms004.inf'.
+     idb:           Deleted driver package object 'prnms004.inf_amd64_5646d0853ac66f86' from DRIVERS database node.
+     idb:           Driver packages registered to 'prnms004.inf':
+     idb:                prnms004.inf_amd64_84e344e1b54dfd1b
+     idb:      {Unregister Driver Package: exit(0x00000000)} 22:29:40.577
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86} 22:29:40.577
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms004.inf_amd64_5646d0853ac66f86\Amd64} 22:29:40.689
+     cpy:           {Delete Directory: exit(0x00000000)} 22:29:40.927
+     cpy:      {Delete Directory: exit(0x00000000)} 22:29:40.970
+     sto:      {DRIVERSTORE DELETE END} 22:29:40.970
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 22:29:40.970
+     sto: {Unstage Driver Package: exit(0x00000000)} 22:29:40.970
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\prnms003.inf} 22:29:40.970
+     sto:      {DRIVERSTORE DELETE BEGIN} 22:29:40.970
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 22:29:40.970
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\prnms003.inf} 22:29:40.970
+     idb:           Unregistered driver package 'prnms003.inf_amd64_2da12eac1bd2c7cb' from 'prnms003.inf'.
+     idb:           Deleted driver package object 'prnms003.inf_amd64_2da12eac1bd2c7cb' from DRIVERS database node.
+     idb:           Driver packages registered to 'prnms003.inf':
+     idb:                prnms003.inf_x86_bd4ca62bf20f9755
+     idb:                prnms003.inf_amd64_1b0f9ac834d3b069
+     idb:      {Unregister Driver Package: exit(0x00000000)} 22:29:40.970
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb} 22:29:40.970
+     cpy:           {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_2da12eac1bd2c7cb\Amd64} 22:29:41.039
+     cpy:           {Delete Directory: exit(0x00000000)} 22:29:41.194
+     cpy:      {Delete Directory: exit(0x00000000)} 22:29:41.222
+     sto:      {DRIVERSTORE DELETE END} 22:29:41.222
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 22:29:41.222
+     sto: {Unstage Driver Package: exit(0x00000000)} 22:29:41.222
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbport.inf} 22:29:41.222
+     sto:      {DRIVERSTORE DELETE BEGIN} 22:29:41.237
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 22:29:41.237
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbport.inf} 22:29:41.237
+     idb:           Unregistered driver package 'usbport.inf_amd64_4215f546c8e8f9d6' from 'usbport.inf'.
+     idb:           Deleted driver package object 'usbport.inf_amd64_4215f546c8e8f9d6' from SYSTEM database node.
+     idb:           Driver packages registered to 'usbport.inf':
+     idb:                usbport.inf_amd64_57cc78a6a0b04383
+     idb:      {Unregister Driver Package: exit(0x00000000)} 22:29:41.237
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6} 22:29:41.237
+!    cpy:           Could not delete file 'usbehci.sys'. Error = 0x00000005
+     cpy:           File 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbehci.sys' is not in use by any processes.
+!    cpy:           Could not delete file 'usbhub.sys'. Error = 0x00000005
+     cpy:           File 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbhub.sys' is not in use by any processes.
+!    cpy:           Could not delete file 'usbohci.sys'. Error = 0x00000005
+     cpy:           File 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6\usbohci.sys' is not in use by any processes.
+     cpy:      {Delete Directory: exit(0x00000005)} 22:29:41.320
+!    sto:      Unable to delete driver package directory 'C:\Windows\System32\DriverStore\FileRepository\usbport.inf_amd64_4215f546c8e8f9d6'. Error = 0x00000005
+     sto:      {DRIVERSTORE DELETE END} 22:29:41.320
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 22:29:41.320
+     sto: {Unstage Driver Package: exit(0x00000000)} 22:29:41.320
+     sto: {Unstage Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_19a61be22ae9944e\acpi.inf} 22:29:41.320
+     sto:      {DRIVERSTORE DELETE BEGIN} 22:29:41.320
+     sto:      {DRIVERSTORE DELETE BEGIN: exit(0x00000000)} 22:29:41.334
+     idb:      {Unregister Driver Package: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_19a61be22ae9944e\acpi.inf} 22:29:41.334
+     idb:           Unregistered driver package 'acpi.inf_amd64_19a61be22ae9944e' from 'acpi.inf'.
+     idb:           Deleted driver package object 'acpi.inf_amd64_19a61be22ae9944e' from SYSTEM database node.
+     idb:           Driver packages registered to 'acpi.inf':
+     idb:                acpi.inf_amd64_a60e43d0fd77edd8
+     idb:      {Unregister Driver Package: exit(0x00000000)} 22:29:41.334
+     cpy:      {Delete Directory: C:\Windows\System32\DriverStore\FileRepository\acpi.inf_amd64_19a61be22ae9944e} 22:29:41.334
+     cpy:      {Delete Directory: exit(0x00000000)} 22:29:41.432
+     sto:      {DRIVERSTORE DELETE END} 22:29:41.432
+     sto:      {DRIVERSTORE DELETE END: exit(0x00000000)} 22:29:41.432
+     sto: {Unstage Driver Package: exit(0x00000000)} 22:29:41.432
+<<<  Section end 2016/11/22 22:29:41.432
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Enable Device Install]
+>>>  Section start 2016/11/22 22:29:41.432
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     ump: DeviceInstall service is not started.
+<<<  Section end 2016/11/22 22:29:41.516
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Enable Device Install]
+>>>  Section start 2016/11/22 22:31:16.936
+      cmd: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.10240.17020_none_1152834562020692\TiWorker.exe -Embedding
+     ump: DeviceInstall service is not disabled.
+     ump: DeviceInstall service is not started.
+<<<  Section end 2016/11/22 22:31:16.936
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Device Install (DiInstallDriver) - C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_bd4ca62bf20f9755\prnms003.inf]
+>>>  Section start 2016/11/22 22:31:50.023
+      cmd: C:\Windows\System32\spoolsv.exe
+     inf: {SetupCopyOEMInf: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_bd4ca62bf20f9755\prnms003.inf} 22:31:51.083
+     inf:      Driver Store Path: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_x86_bd4ca62bf20f9755\prnms003.inf
+     inf:      Published Inf Path: C:\Windows\INF\prnms003.inf
+     inf: {SetupCopyOEMInf exit (0x00000000)} 22:31:51.098
+<<<  Section end 2016/11/22 22:31:51.721
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Device Install (DiInstallDriver) - C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_1b0f9ac834d3b069\prnms003.inf]
+>>>  Section start 2016/11/22 22:31:59.601
+      cmd: C:\Windows\System32\spoolsv.exe
+     inf: {SetupCopyOEMInf: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_1b0f9ac834d3b069\prnms003.inf} 22:31:59.601
+     inf:      Driver Store Path: C:\Windows\System32\DriverStore\FileRepository\prnms003.inf_amd64_1b0f9ac834d3b069\prnms003.inf
+     inf:      Published Inf Path: C:\Windows\INF\prnms003.inf
+     inf: {SetupCopyOEMInf exit (0x00000000)} 22:31:59.616
+<<<  Section end 2016/11/22 22:31:59.628
+<<<  [Exit status: SUCCESS]
+
+
+[Boot Session: 2016/11/22 23:39:14.499]
+
+>>>  [Device Install (Hardware initiated) - SWD\WPDBUSENUM\_??_USBSTOR#Disk&Ven_Generic&Prod_Flash_Disk&Rev_8.07#99E2116A&0#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}]
+>>>  Section start 2016/11/22 23:50:30.938
+     dvi: {Build Driver List} 23:50:31.720
+     dvi:      Searching for compatible ID(s):
+     dvi:           wpdbusenum\fs
+     dvi:           swd\generic
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - wpdbusenum\fs
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\wpdfs.inf_amd64_8a2119498234c804\wpdfs.inf
+     dvi:           DevDesc      - WPD FileSystem Volume Driver
+     dvi:           Section      - Basic_Install
+     dvi:           Rank         - 0x00ff2000
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 06/21/2006
+     dvi:           Version      - 10.0.10240.16384
+     dvi: {Build Driver List - exit(0x00000000)} 23:50:32.580
+     dvi: {DIF_SELECTBESTCOMPATDRV} 23:50:32.580
+     dvi:      Using exported function 'WpdClassInstaller' in module 'C:\Windows\system32\wpd_ci.dll'.
+     dvi:      Class installer == wpd_ci.dll,WpdClassInstaller
+     dvi:      Class installer: Enter 23:50:35.673
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 23:50:35.673
+     dvi:           {Select Best Driver}
+     dvi:                Class GUID of device changed to: {eec5ad98-8080-425f-922a-dabf3de3f69a}.
+     dvi:                {DIF_DESTROYPRIVATEDATA} 23:50:35.673
+     dvi:                     Class installer: Enter 23:50:35.689
+     dvi:                     Class installer: Exit
+     dvi:                     Default installer: Enter 23:50:35.689
+     dvi:                     Default installer: Exit
+     dvi:                {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 23:50:35.689
+     dvi:                Selected:
+     dvi:                     Description - [WPD FileSystem Volume Driver]
+     dvi:                     InfFile     - [c:\windows\system32\driverstore\filerepository\wpdfs.inf_amd64_8a2119498234c804\wpdfs.inf]
+     dvi:                     Section     - [Basic_Install]
+     dvi:           {Select Best Driver - exit(0x00000000)}
+     dvi:      Default installer: Exit
+     dvi: {DIF_SELECTBESTCOMPATDRV - exit(0x00000000)} 23:50:35.689
+     ndv: {Core Device Install} 23:50:35.689
+     ndv:      {Installing device - SWD\WPDBUSENUM\_??_USBSTOR#DISK&VEN_GENERIC&PROD_FLASH_DISK&REV_8.07#99E2116A&0#{53F56307-B6BF-11D0-94F2-00A0C91EFB8B}} 23:50:35.689
+!    ndv:           Device class {eec5ad98-8080-425f-922a-dabf3de3f69a} is not configurable.
+     dvi:           {DIF_ALLOW_INSTALL} 23:50:36.345
+     dvi:                Using exported function 'WpdClassInstaller' in module 'C:\Windows\system32\wpd_ci.dll'.
+     dvi:                Class installer == wpd_ci.dll,WpdClassInstaller
+     dvi:                Using exported function 'CoDeviceInstall' in module 'C:\Windows\system32\WUDFCoinstaller.dll'.
+     dvi:                CoInstaller 1 == WUDFCoinstaller.dll
+     dvi:                CoInstaller 1: Enter 23:50:36.923
+     dvi:                CoInstaller 1: Exit
+     dvi:                Class installer: Enter 23:50:36.923
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 23:50:37.111
+     dvi:                Default installer: Exit
+     dvi:           {DIF_ALLOW_INSTALL - exit(0xe000020e)} 23:50:37.111
+     dvi:           {DIF_INSTALLDEVICEFILES} 23:50:37.345
+     dvi:                CoInstaller 1: Enter 23:50:37.345
+     dvi:                CoInstaller 1: Exit
+     dvi:                Class installer: Enter 23:50:37.345
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 23:50:37.361
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLDEVICEFILES - exit(0x00000000)} 23:50:37.361
+     flq:           Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wpdfs.inf_amd64_8a2119498234c804\WpdFs.dll' to 'C:\Windows\system32\DRIVERS\UMDF\WpdFs.dll'.
+     dvi:           {DIF_REGISTER_COINSTALLERS} 23:50:40.504
+     dvi:                Reset Device: Resetting device configuration. 23:50:40.720
+     dvi:                Reset Device: Resetting device configuration completed. 23:50:40.720
+     dvi:                CoInstaller 1: Enter 23:50:40.720
+     dvi:                CoInstaller 1: Exit
+     dvi:                Class installer: Enter 23:50:40.720
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 23:50:40.720
+     dvi:                     {DIF_DESTROYPRIVATEDATA} 23:50:42.110
+     dvi:                          CoInstaller 1: Enter 23:50:42.110
+     dvi:                          CoInstaller 1: Exit
+     dvi:                          Class installer: Enter 23:50:42.128
+     dvi:                          Class installer: Exit
+     dvi:                          Default installer: Enter 23:50:42.128
+     dvi:                          Default installer: Exit
+     dvi:                     {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 23:50:42.128
+     dvi:                Default installer: Exit
+     dvi:           {DIF_REGISTER_COINSTALLERS - exit(0x00000000)} 23:50:42.128
+     dvi:           {DIF_INSTALLINTERFACES} 23:50:42.128
+     dvi:                Using exported function 'CoDeviceInstall' in module 'C:\Windows\system32\WUDFCoInstaller.dll'.
+     dvi:                CoInstaller 1 == WUDFCoInstaller.dll
+     dvi:                CoInstaller 1: Enter 23:50:42.128
+     dvi:                CoInstaller 1: Exit
+     dvi:                Class installer: Enter 23:50:42.128
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 23:50:42.128
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLINTERFACES - exit(0x00000000)} 23:50:42.144
+     dvi:           {DIF_INSTALLDEVICE} 23:50:42.144
+     dvi:                CoInstaller 1: Enter 23:50:42.144
+     dvi:                CoInstaller 1: Exit
+     dvi:                Class installer: Enter 23:50:49.173
+     dvi:                     {Install DEVICE}
+     dvi:                          {Writing Device Properties}
+     dvi:                               Strong Name=WpdFs.inf:0c0663c081fd6f5b:Basic_Install:10.0.10240.16384:wpdbusenum\fs
+     dvi:                          {Writing Device Properties - Complete}
+     inf:                          AddService=WUDFWpdFs,0x000001fa,WUDFWpdFs_ServiceInstall  (wpdfs.inf line 38)
+     dvi:                          Add Service: Created service 'WUDFWpdFs'.
+     dvi:                     {Install DEVICE exit (0x00000000)}
+     dvi:                     Install Device: Configuring device class. 23:50:49.800
+     dvi:                     Install Device: Configuring device class completed. 23:50:49.800
+     dvi:                     Install Device: Starting device. 23:50:49.830
+     dvi:                     Install Device: Starting device completed. 23:50:56.016
+     dvi:                Class installer: Exit
+     dvi:                CoInstaller 1: Enter (Post Processing) 23:50:56.016
+     dvi:                CoInstaller 1: Exit (Post Processing)
+     dvi:           {DIF_INSTALLDEVICE - exit(0x00000000)} 23:50:56.126
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL} 23:50:56.126
+     dvi:                CoInstaller 1: Enter 23:50:56.144
+     dvi:                CoInstaller 1: Exit
+     dvi:                Class installer: Enter 23:50:56.144
+     dvi:                Class installer: Exit
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL - exit(0x00000000)} 23:50:58.144
+     ndv:      {Installing device - exit(0x00000000)} 23:50:58.220
+     ndv: {Core Device Install - exit(0x00000000)} 23:50:58.220
+     dvi: {DIF_DESTROYPRIVATEDATA} 23:50:58.220
+     dvi:      CoInstaller 1: Enter 23:50:58.220
+     dvi:      CoInstaller 1: Exit
+     dvi:      Class installer: Enter 23:50:58.220
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 23:50:58.220
+     dvi:      Default installer: Exit
+     dvi: {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 23:50:58.220
+<<<  Section end 2016/11/22 23:50:58.236
+<<<  [Exit status: SUCCESS]
+

--- a/test_data/setupapi.setup.log
+++ b/test_data/setupapi.setup.log
@@ -1,0 +1,1357 @@
+[Device Install Log]
+     OS Version = 10.0.10240
+     Service Pack = 0.0
+     Suite = 0x0100
+     ProductType = 1
+     Architecture = amd64
+
+[BeginLog]
+
+[Boot Session: 2015/11/22 17:52:29.492]
+
+>>>  [Sysprep Specialize - {51198c35-bd73-bb4d-a3cb-65bd5f2ab9cb}]
+>>>  Section start 2015/11/22 17:53:16.599
+<<<  Section end 2015/11/22 17:53:52.849
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup Update Driver Package Signatures]
+>>>  Section start 2015/11/22 17:53:28.973
+     set: No driver package signatures to update.
+<<<  Section end 2015/11/22 17:53:29.305
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup Plug and Play Device Install]
+>>>  Section start 2015/11/22 17:53:29.305
+     set: ACPI\ACPI0003\0 -> Configured and started [cmbatt.inf:ACPI\ACPI0003,AcAdapter_Inst] (ConfigFlags = 0x00000000).
+     set: PCI\VEN_8086&DEV_2668&SUBSYS_76808384&REV_01\3&267A616A&1&28 -> Configured and started [hdaudbus.inf:PCI\CC_0403,HDAudio_Device.NT] (ConfigFlags = 0x00000000).
+     set: PCI\VEN_80EE&DEV_BEEF&SUBSYS_00000000&REV_00\3&267A616A&1&10 -> Setting CONFIGFLAG_REINSTALL on non-started device.
+     set: ROOT\VOLMGR\0000 -> Configured and started [volmgr.inf:ROOT\VOLMGR,Volmgr] (ConfigFlags = 0x00000000).
+     set: PCI\VEN_8086&DEV_100E&SUBSYS_001E8086&REV_02\3&267A616A&1&18 -> Setting CONFIGFLAG_REINSTALL on non-started device.
+     set: ROOT\BASICDISPLAY\0000 -> Configured and started [basicdisplay.inf:ROOT\BasicDisplay,MSBDD_Fallback] (ConfigFlags = 0x00000000).
+     set: SCSI\CDROM&VEN_VBOX&PROD_CD-ROM\4&3554261F&0&010000 -> Configured and started [cdrom.inf:GenCdRom,cdrom_install] (ConfigFlags = 0x00000000).
+     set: PCI\VEN_8086&DEV_265C&SUBSYS_00000000&REV_00\3&267A616A&1&58 -> Configured and started [usbport.inf:PCI\VEN_8086&DEV_265C,EHCI.Dev.NT] (ConfigFlags = 0x00000000).
+     set: ROOT\COMPOSITEBUS\0000 -> Configured and started [compositebus.inf:ROOT\CompositeBus,CompositeBus_Device.NT] (ConfigFlags = 0x00000000).
+     set: ROOT\VDRVROOT\0000 -> Configured and started [vdrvroot.inf:ROOT\vdrvroot,VDRVROOT] (ConfigFlags = 0x00000000).
+     set: ACPI\PNP0200\4&E03A844&0 -> Configured [machine.inf:*PNP0200,NO_DRV_X] (ConfigFlags = 0x00000000).
+     set: ROOT\SPACEPORT\0000 -> Configured and started [spaceport.inf:Root\Spaceport,Spaceport_Install] (ConfigFlags = 0x00000000).
+     set: USB\VID_80EE&PID_0021\5&35F564D4&0&1 -> Configured and started [input.inf:USB\Class_03,HID_Inst.NT] (ConfigFlags = 0x00000000).
+     set: ROOT\KDNIC\0000 -> Configured and started [kdnic.inf:root\kdnic,KdNic.ndi] (ConfigFlags = 0x00000000).
+     set: ACPI\AUTHENTICAMD_-_AMD64_FAMILY_21_MODEL_2_-_AMD_FX(TM)-6300_SIX-CORE_PROCESSOR_____________\_0 -> Configured and started [cpu.inf:ACPI\AuthenticAMD_-_AMD64,AmdPPM_Inst.NT] (ConfigFlags = 0x00000000).
+     set: PCI\VEN_8086&DEV_7000&SUBSYS_00000000&REV_00\3&267A616A&1&08 -> Configured and started [machine.inf:PCI\VEN_8086&DEV_7000,MSISADRV] (ConfigFlags = 0x00000000).
+     set: ROOT\UMBUS\0000 -> Configured and started [umbus.inf:root\umbus,UmBusRoot_Device.NT] (ConfigFlags = 0x00000000).
+     set: ROOT\ACPI_HAL\0000 -> Configured and started [hal.inf:acpiapic,ACPI_AMD64_HAL] (ConfigFlags = 0x00000000).
+     set: DISPLAY\DEFAULT_MONITOR\1&8713BCA&0&UID0 -> Configured and started [monitor.inf:MONITOR\Default_Monitor,NonPnPMonitor.Install] (ConfigFlags = 0x00000000).
+     set: STORAGE\VOLUME\{DAAAB795-9184-11E5-9BC1-806E6F6E6963}#0000000000100000 -> Configured and started [volume.inf:STORAGE\Volume,volume_install.NTamd64] (ConfigFlags = 0x00000000).
+     set: ACPI\PNP0A03\0 -> Configured and started [pci.inf:*PNP0A03,PCI_ROOT] (ConfigFlags = 0x00000000).
+     set: USB\ROOT_HUB\4&159A73F4&0 -> Configured and started [usbport.inf:USB\ROOT_HUB,ROOTHUB.Dev.NT] (ConfigFlags = 0x00000000).
+     set: USB\ROOT_HUB20\4&3749A296&0 -> Configured and started [usbport.inf:USB\ROOT_HUB20,ROOTHUB.Dev.NT] (ConfigFlags = 0x00000000).
+     set: ACPI_HAL\PNP0C08\0 -> Configured and started [acpi.inf:*PNP0C08,ACPI_Inst.NT] (ConfigFlags = 0x00000000).
+     set: ROOT\BASICRENDER\0000 -> Configured and started [basicrender.inf:ROOT\BasicRender,BasicRender] (ConfigFlags = 0x00000000).
+     set: HDAUDIO\FUNC_01&VEN_8384&DEV_7680&SUBSYS_83847680&REV_1034\4&22A99211&0&0001 -> Setting CONFIGFLAG_REINSTALL on non-started device.
+     set: ACPI\FIXEDBUTTON\2&DABA3FF&1 -> Configured and started [machine.inf:ACPI\FixedButton,NO_DRV] (ConfigFlags = 0x00000000).
+     set: ACPI\PNP0000\4&E03A844&0 -> Configured [machine.inf:*PNP0000,NO_DRV_PIC] (ConfigFlags = 0x00000000).
+     set: PCI\VEN_80EE&DEV_CAFE&SUBSYS_00000000&REV_00\3&267A616A&1&20 -> Configured [null] (ConfigFlags = 0x00000040).
+     set: PCI\VEN_8086&DEV_2829&SUBSYS_00000000&REV_02\3&267A616A&1&68 -> Configured and started [mshdc.inf:PCI\CC_010601,msahci_Inst] (ConfigFlags = 0x00000000).
+     set: SWD\MMDEVAPI\MICROSOFTGSWAVETABLESYNTH -> Configured and started [c_swdevice.inf:SWD\GenericRaw,SoftwareDevice] (ConfigFlags = 0x00000000).
+     set: ROOT\NDISVIRTUALBUS\0000 -> Configured and started [ndisvirtualbus.inf:ROOT\NdisVirtualBus,NdisVirtualBus_Device.NT] (ConfigFlags = 0x00000000).
+     set: PCI\VEN_106B&DEV_003F&SUBSYS_00000000&REV_00\3&267A616A&1&30 -> Configured and started [usbport.inf:PCI\CC_0C0310,OHCI.Dev.NT] (ConfigFlags = 0x00000000).
+     set: SCSI\DISK&VEN_VBOX&PROD_HARDDISK\4&3554261F&0&000000 -> Configured and started [disk.inf:GenDisk,disk_install.NT] (ConfigFlags = 0x00000000).
+     set: STORAGE\VOLUME\{DAAAB795-9184-11E5-9BC1-806E6F6E6963}#000000001F500000 -> Configured and started [volume.inf:STORAGE\Volume,volume_install.NTamd64] (ConfigFlags = 0x00000000).
+     set: PCI\VEN_8086&DEV_1237&SUBSYS_00000000&REV_02\3&267A616A&1&00 -> Configured and started [machine.inf:PCI\VEN_8086&DEV_1237,NO_DRV] (ConfigFlags = 0x00000000).
+     set: ROOT\MSSMBIOS\0000 -> Configured and started [mssmbios.inf:ROOT\mssmbios,MSSMBIOS_DRV] (ConfigFlags = 0x00000000).
+     set: ACPI\PNP0400\4&E03A844&0 -> Configured [msports.inf:*PNP0400,LptPort.NT] (ConfigFlags = 0x00000400).
+     set: ROOT\SYSTEM\0000 -> Configured and started [swenum.inf:ROOT\SWENUM,SWENUM] (ConfigFlags = 0x00000000).
+     set: ROOT\RDPBUS\0000 -> Configured and started [rdpbus.inf:ROOT\RDPBUS,RDPBUS] (ConfigFlags = 0x00000000).
+     set: ACPI\PNP0100\4&E03A844&0 -> Configured [machine.inf:*PNP0100,NO_DRV_X] (ConfigFlags = 0x00000000).
+     set: ACPI\PNP0F03\4&E03A844&0 -> Configured and started [msmouse.inf:*PNP0F03,PS2_Inst] (ConfigFlags = 0x00000000).
+     set: HID\VID_80EE&PID_0021\6&A8E1584&0&0000 -> Configured and started [msmouse.inf:HID_DEVICE_SYSTEM_MOUSE,HID_Mouse_Inst.NT] (ConfigFlags = 0x00000000).
+     set: ACPI\PNP0303\4&E03A844&0 -> Configured and started [keyboard.inf:*PNP0303,STANDARD_Inst] (ConfigFlags = 0x00000000).
+     set: DeviceInstall service already running. 17:53:29.337
+     set: Waiting for pending device installs... 17:53:29.337
+     set: Completed pending device installs. 17:53:51.832
+<<<  Section end 2015/11/22 17:53:51.832
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup online Device Install (Hardware initiated) - PCI\VEN_80EE&DEV_BEEF&SUBSYS_00000000&REV_00\3&267a616a&1&10]
+>>>  Section start 2015/11/22 17:53:29.353
+     dvi: {Build Driver List} 17:53:29.457
+     dvi:      Searching for hardware ID(s):
+     dvi:           pci\ven_80ee&dev_beef&subsys_00000000&rev_00
+     dvi:           pci\ven_80ee&dev_beef&subsys_00000000
+     dvi:           pci\ven_80ee&dev_beef&rev_00
+     dvi:           pci\ven_80ee&dev_beef
+     dvi:           pci\ven_80ee&dev_beef&cc_030000
+     dvi:           pci\ven_80ee&dev_beef&cc_0300
+     dvi:      Searching for compatible ID(s):
+     dvi:           pci\ven_80ee&cc_030000
+     dvi:           pci\ven_80ee&cc_0300
+     dvi:           pci\ven_80ee
+     dvi:           pci\cc_030000
+     dvi:           pci\cc_0300
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - PCI\CC_0300
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\display.inf_amd64_54c15e45dc857c30\display.inf
+     dvi:           DevDesc      - Microsoft Basic Display Adapter
+     dvi:           Section      - MSBDA
+     dvi:           Rank         - 0x00fb2004
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 06/21/2006
+     dvi:           Version      - 10.0.10240.16384
+     dvi: {Build Driver List - exit(0x00000000)} 17:53:30.911
+     dvi: {DIF_SELECTBESTCOMPATDRV} 17:53:30.928
+     dvi:      Using exported function 'DisplayClassInstaller' in module 'C:\Windows\system32\DispCI.dll'.
+     dvi:      Class installer == DispCI.dll,DisplayClassInstaller
+     dvi:      Class installer: Enter 17:53:31.397
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:32.379
+     dvi:           {Select Best Driver}
+     dvi:                Class GUID of device changed to: {4d36e968-e325-11ce-bfc1-08002be10318}.
+     dvi:                {DIF_DESTROYPRIVATEDATA} 17:53:32.397
+     dvi:                     Class installer: Enter 17:53:32.397
+     dvi:                     Class installer: Exit
+     dvi:                     Default installer: Enter 17:53:32.957
+     dvi:                     Default installer: Exit
+     dvi:                {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:32.957
+     dvi:                Selected:
+     dvi:                     Description - [Microsoft Basic Display Adapter]
+     dvi:                     InfFile     - [c:\windows\system32\driverstore\filerepository\display.inf_amd64_54c15e45dc857c30\display.inf]
+     dvi:                     Section     - [MSBDA]
+     dvi:           {Select Best Driver - exit(0x00000000)}
+     dvi:      Default installer: Exit
+     dvi: {DIF_SELECTBESTCOMPATDRV - exit(0x00000000)} 17:53:32.957
+     ndv: Waiting for previous device install to complete. 17:53:32.957
+     ndv: {Core Device Install} 17:53:35.145
+     ndv:      {Installing device - PCI\VEN_80EE&DEV_BEEF&SUBSYS_00000000&REV_00\3&267A616A&1&10} 17:53:35.145
+!    ndv:           Device class {4d36e968-e325-11ce-bfc1-08002be10318} is not configurable.
+     dvi:           {DIF_ALLOW_INSTALL} 17:53:35.145
+     dvi:                Using exported function 'DisplayClassInstaller' in module 'C:\Windows\system32\DispCI.dll'.
+     dvi:                Class installer == DispCI.dll,DisplayClassInstaller
+     dvi:                Class installer: Enter 17:53:35.161
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:35.832
+     dvi:                Default installer: Exit
+     dvi:           {DIF_ALLOW_INSTALL - exit(0xe000020e)} 17:53:35.832
+     dvi:           {DIF_INSTALLDEVICEFILES} 17:53:35.832
+     dvi:                Class installer: Enter 17:53:35.832
+     dvi:                     {Build Driver List} 17:53:36.129
+!    dvi:                          Driver list already built
+     dvi:                     {Build Driver List - exit(0x00000000)} 17:53:36.129
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:36.708
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLDEVICEFILES - exit(0x00000000)} 17:53:36.723
+     dvi:           {DIF_REGISTER_COINSTALLERS} 17:53:36.723
+     dvi:                Reset Device: Resetting device configuration. 17:53:36.723
+     dvi:                Reset Device: Resetting device configuration completed. 17:53:36.723
+     dvi:                Class installer: Enter 17:53:36.723
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:37.629
+     dvi:                Default installer: Exit
+     dvi:           {DIF_REGISTER_COINSTALLERS - exit(0x00000000)} 17:53:37.629
+     dvi:           {DIF_INSTALLINTERFACES} 17:53:37.629
+     dvi:                Class installer: Enter 17:53:37.629
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:37.926
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLINTERFACES - exit(0x00000000)} 17:53:37.926
+     dvi:           {DIF_INSTALLDEVICE} 17:53:37.926
+     dvi:                Class installer: Enter 17:53:37.926
+     dvi:                     {Install DEVICE}
+     dvi:                          {Writing Device Properties}
+     dvi:                               Strong Name=display.inf:10809047d4324726:MSBDA:10.0.10240.16384:pci\cc_0300
+     dvi:                          {Writing Device Properties - Complete}
+     inf:                          AddService=BasicDisplay,0x00000002,MSBDD_Fallback_Generic_Service_Inst,  (basicdisplay.inf line 63)
+     dvi:                          Add Service: Modified existing service 'BasicDisplay'.
+     dvi:                     {Install DEVICE exit (0x00000000)}
+     dvi:                     Install Device: Configuring device class. 17:53:39.035
+     dvi:                     Install Device: Configuring device class completed. 17:53:39.035
+     dvi:                     Install Device: Starting device. 17:53:39.035
+     dvi:                     Install Device: Starting device completed. 17:53:39.165
+     dvi:                Class installer: Exit
+     dvi:           {DIF_INSTALLDEVICE - exit(0x00000000)} 17:53:39.489
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL} 17:53:39.489
+     dvi:                Class installer: Enter 17:53:39.489
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:39.785
+     dvi:                Default installer: Exit
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL - exit(0xe000020e)} 17:53:39.785
+     ndv:      {Installing device - exit(0x00000000)} 17:53:39.785
+     ndv: {Core Device Install - exit(0x00000000)} 17:53:39.785
+     dvi: {DIF_DESTROYPRIVATEDATA} 17:53:39.801
+     dvi:      Class installer: Enter 17:53:39.801
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:40.145
+     dvi:      Default installer: Exit
+     dvi: {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:40.145
+<<<  Section end 2015/11/22 17:53:40.207
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup online Device Install (Hardware initiated) - PCI\VEN_8086&DEV_100E&SUBSYS_001E8086&REV_02\3&267a616a&1&18]
+>>>  Section start 2015/11/22 17:53:29.395
+     dvi: {Build Driver List} 17:53:29.457
+     dvi:      Searching for hardware ID(s):
+     dvi:           pci\ven_8086&dev_100e&subsys_001e8086&rev_02
+     dvi:           pci\ven_8086&dev_100e&subsys_001e8086
+     dvi:           pci\ven_8086&dev_100e&cc_020000
+     dvi:           pci\ven_8086&dev_100e&cc_0200
+     dvi:      Searching for compatible ID(s):
+     dvi:           pci\ven_8086&dev_100e&rev_02
+     dvi:           pci\ven_8086&dev_100e
+     dvi:           pci\ven_8086&cc_020000
+     dvi:           pci\ven_8086&cc_0200
+     dvi:           pci\ven_8086
+     dvi:           pci\cc_020000
+     dvi:           pci\cc_0200
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - PCI\VEN_8086&DEV_100E&SUBSYS_001E8086
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\nete1g3e.inf_amd64_9c4d966af5423efc\nete1g3e.inf
+     dvi:           DevDesc      - Intel(R) PRO/1000 MT Desktop Adapter
+     dvi:           Section      - E100ECopper
+     dvi:           Rank         - 0x00ff0001
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 03/23/2010
+     dvi:           Version      - 8.4.13.0
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - PCI\VEN_8086&DEV_100E
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\nete1g3e.inf_amd64_9c4d966af5423efc\nete1g3e.inf
+     dvi:           DevDesc      - Intel(R) PRO/1000 MT Network Connection
+     dvi:           Section      - E100E
+     dvi:           Rank         - 0x00ff2001
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 03/23/2010
+     dvi:           Version      - 8.4.13.0
+     dvi: {Build Driver List - exit(0x00000000)} 17:53:31.397
+     dvi: {DIF_SELECTBESTCOMPATDRV} 17:53:31.397
+     dvi:      Default installer: Enter 17:53:31.397
+     dvi:           {Select Best Driver}
+     dvi:                Class GUID of device changed to: {4d36e972-e325-11ce-bfc1-08002be10318}.
+     dvi:                Selected:
+     dvi:                     Description - [Intel(R) PRO/1000 MT Desktop Adapter]
+     dvi:                     InfFile     - [c:\windows\system32\driverstore\filerepository\nete1g3e.inf_amd64_9c4d966af5423efc\nete1g3e.inf]
+     dvi:                     Section     - [E100ECopper]
+     dvi:           {Select Best Driver - exit(0x00000000)}
+     dvi:      Default installer: Exit
+     dvi: {DIF_SELECTBESTCOMPATDRV - exit(0x00000000)} 17:53:31.397
+     ndv: Waiting for previous device install to complete. 17:53:31.397
+     ndv: {Core Device Install} 17:53:32.739
+     ndv:      {Installing device - PCI\VEN_8086&DEV_100E&SUBSYS_001E8086&REV_02\3&267A616A&1&18} 17:53:32.739
+     sto:           {Configure Driver Package: C:\Windows\System32\DriverStore\FileRepository\nete1g3e.inf_amd64_9c4d966af5423efc\nete1g3e.inf}
+     sto:                Source Filter  = pci\ven_8086&dev_100e&subsys_001e8086
+     inf:                Class GUID     = {4d36e972-e325-11ce-bfc1-08002be10318}
+     inf:                Class Options  = Configurable
+     inf:                {Configure Driver: Intel(R) PRO/1000 MT Desktop Adapter}
+     inf:                     Section Name = E100ECopper
+     inf:                     {Add Service: E1G60}
+     inf:                          Start Type    = 3
+     inf:                          Service Type  = 1
+     inf:                          Error Control = 1
+     inf:                          Image Path    = \SystemRoot\System32\drivers\E1G6032E.sys
+     inf:                          Display Name  = Intel(R) PRO/1000 NDIS 6 Adapter Driver
+     inf:                          Group         = NDIS
+     inf:                          Created new service 'E1G60'.
+     inf:                     {Add Service: exit(0x00000000)}
+     inf:                     Hardware Id  = PCI\VEN_8086&DEV_100E&SUBSYS_001E8086
+     inf:                     {Configure Driver Configuration: E100ECopper}
+     inf:                          Service Name  = E1G60
+     inf:                          Config Flags  = 0x00000000
+     inf:                     {Configure Driver Configuration: exit(0x00000000)}
+     inf:                {Configure Driver: exit(0x00000000)}
+!    inf:                Needed section [PciIoSpaceNotRequired] found in included INF "pci.inf", not referenced from [E1027.Hw]. Code = 1313, Line = 481
+!    inf:                Needed section [PciIoSpaceNotRequired] found in included INF "pci.inf", not referenced from [E1079.Hw]. Code = 1313, Line = 555
+!    inf:                Needed section [PciIoSpaceNotRequired] found in included INF "pci.inf", not referenced from [E107A.Hw]. Code = 1313, Line = 576
+!    inf:                Needed section [PciIoSpaceNotRequired] found in included INF "pci.inf", not referenced from [E10B5.Hw]. Code = 1313, Line = 650
+     flq:                Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\nete1g3e.inf_amd64_9c4d966af5423efc\E1G6032E.sys' to 'C:\Windows\System32\drivers\E1G6032E.sys'.
+     dvi:                Existing files modified, may need to restart related services.
+     sto:           {Configure Driver Package: exit(0x00000bc3)}
+     ndv:           Restart required for any devices using this driver.
+     dvi:           Install Device: Configuring device (nete1g3e.inf:pci\ven_8086&dev_100e&subsys_001e8086,E100ECopper). 17:53:34.973
+     dvi:           Install Device: Configuring device completed. 17:53:34.973
+     dvi:           {Restarting Devices} 17:53:34.973
+     dvi:                Restart: PCI\VEN_8086&DEV_100E&SUBSYS_001E8086&REV_02\3&267A616A&1&18
+     dvi:           {Restarting Devices exit} 17:53:35.129
+     ndv:      {Installing device - exit(0x00000000)} 17:53:35.145
+     ndv: {Core Device Install - exit(0x00000000)} 17:53:35.145
+     ndv: Waiting for device post-install to complete. 17:53:35.145
+     ndv: Device post-install completed. 17:53:37.553
+<<<  Section end 2015/11/22 17:53:37.723
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup online Device Install (Hardware initiated) - HDAUDIO\FUNC_01&VEN_8384&DEV_7680&SUBSYS_83847680&REV_1034\4&22a99211&0&0001]
+>>>  Section start 2015/11/22 17:53:29.426
+     dvi: {Build Driver List} 17:53:29.473
+     dvi:      Searching for hardware ID(s):
+     dvi:           hdaudio\func_01&ven_8384&dev_7680&subsys_83847680&rev_1034
+     dvi:           hdaudio\func_01&ven_8384&dev_7680&subsys_83847680
+     dvi:      Searching for compatible ID(s):
+     dvi:           hdaudio\func_01&ctlr_ven_8086&ctlr_dev_2668&ven_8384&dev_7680&rev_1034
+     dvi:           hdaudio\func_01&ctlr_ven_8086&ven_8384&dev_7680&rev_1034
+     dvi:           hdaudio\func_01&ven_8384&dev_7680&rev_1034
+     dvi:           hdaudio\func_01&ctlr_ven_8086&ctlr_dev_2668&ven_8384&dev_7680
+     dvi:           hdaudio\func_01&ctlr_ven_8086&ven_8384&dev_7680
+     dvi:           hdaudio\func_01&ven_8384&dev_7680
+     dvi:           hdaudio\func_01&ctlr_ven_8086&ctlr_dev_2668&ven_8384
+     dvi:           hdaudio\func_01&ctlr_ven_8086&ven_8384
+     dvi:           hdaudio\func_01&ven_8384
+     dvi:           hdaudio\func_01&ctlr_ven_8086&ctlr_dev_2668
+     dvi:           hdaudio\func_01&ctlr_ven_8086
+     dvi:           hdaudio\func_01&gf&ven_8384&dev_7680&subsys_83847680&rev_1034
+     dvi:           hdaudio\func_01
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - HDAUDIO\FUNC_01
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_dab2294dc8af0030\hdaudio.inf
+     dvi:           DevDesc      - High Definition Audio Device
+     dvi:           Section      - HdAudModel
+     dvi:           Rank         - 0x00ff300c
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 07/09/2015
+     dvi:           Version      - 10.0.10240.16384
+     dvi: {Build Driver List - exit(0x00000000)} 17:53:31.429
+     dvi: {DIF_SELECTBESTCOMPATDRV} 17:53:31.429
+     dvi:      Using exported function 'MediaClassInstaller' in module 'C:\Windows\system32\mmci.dll'.
+     dvi:      Class installer == mmci.dll,MediaClassInstaller
+     dvi:      Class installer: Enter 17:53:33.381
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:33.396
+     dvi:           {Select Best Driver}
+     dvi:                Class GUID of device changed to: {4d36e96c-e325-11ce-bfc1-08002be10318}.
+     dvi:                {DIF_DESTROYPRIVATEDATA} 17:53:33.396
+     dvi:                     Class installer: Enter 17:53:33.396
+     dvi:                     Class installer: Exit
+     dvi:                     Default installer: Enter 17:53:33.396
+     dvi:                     Default installer: Exit
+     dvi:                {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:33.396
+     dvi:                Selected:
+     dvi:                     Description - [High Definition Audio Device]
+     dvi:                     InfFile     - [c:\windows\system32\driverstore\filerepository\hdaudio.inf_amd64_dab2294dc8af0030\hdaudio.inf]
+     dvi:                     Section     - [HdAudModel]
+     dvi:           {Select Best Driver - exit(0x00000000)}
+     dvi:      Default installer: Exit
+     dvi: {DIF_SELECTBESTCOMPATDRV - exit(0x00000000)} 17:53:33.396
+     ndv: Waiting for previous device install to complete. 17:53:33.396
+     ndv: {Core Device Install} 17:53:39.785
+     ndv:      {Installing device - HDAUDIO\FUNC_01&VEN_8384&DEV_7680&SUBSYS_83847680&REV_1034\4&22A99211&0&0001} 17:53:39.801
+!    ndv:           Device class {4d36e96c-e325-11ce-bfc1-08002be10318} is not configurable.
+     dvi:           {DIF_ALLOW_INSTALL} 17:53:39.801
+     dvi:                Using exported function 'MediaClassInstaller' in module 'C:\Windows\system32\mmci.dll'.
+     dvi:                Class installer == mmci.dll,MediaClassInstaller
+     dvi:                Class installer: Enter 17:53:39.942
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:39.942
+     dvi:                Default installer: Exit
+     dvi:           {DIF_ALLOW_INSTALL - exit(0xe000020e)} 17:53:39.942
+     dvi:           {DIF_INSTALLDEVICEFILES} 17:53:39.942
+     dvi:                Class installer: Enter 17:53:39.942
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:39.942
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLDEVICEFILES - exit(0x00000000)} 17:53:40.521
+     flq:           File 'C:\Windows\system32\drivers\drmk.sys' pruned from copy.
+     flq:           File 'C:\Windows\system32\drivers\portcls.sys' pruned from copy.
+     flq:           Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\hdaudio.inf_amd64_dab2294dc8af0030\HdAudio.sys' to 'C:\Windows\system32\DRIVERS\HdAudio.sys'.
+     flq:           Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_256ad046a471df0d\WMALFXGFXDSP.dll' to 'C:\Windows\system32\WMALFXGFXDSP.dll'.
+     flq:           Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_256ad046a471df0d\SysFxUI.dll' to 'C:\Windows\system32\SysFxUI.dll'.
+     dvi:           {DIF_REGISTER_COINSTALLERS} 17:53:41.723
+     dvi:                Reset Device: Resetting device configuration. 17:53:41.723
+     dvi:                Reset Device: Resetting device configuration completed. 17:53:41.723
+     dvi:                Class installer: Enter 17:53:41.723
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:41.740
+     dvi:                Default installer: Exit
+     dvi:           {DIF_REGISTER_COINSTALLERS - exit(0x00000000)} 17:53:41.740
+     dvi:           {DIF_INSTALLINTERFACES} 17:53:41.740
+     dvi:                Class installer: Enter 17:53:41.740
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:41.740
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLINTERFACES - exit(0x00000000)} 17:53:41.740
+     dvi:           {DIF_INSTALLDEVICE} 17:53:41.740
+     dvi:                Class installer: Enter 17:53:41.740
+     dvi:                     {Install DEVICE}
+     dvi:                          {Writing Device Properties}
+     dvi:                               Strong Name=hdaudio.inf:db04a16ce4e8d6ee:HdAudModel:10.0.10240.16384:hdaudio\func_01
+     dvi:                          {Writing Device Properties - Complete}
+     inf:                          AddService=HdAudAddService,0x00000002,HdAud_Service_Install  (hdaudio.inf line 91)
+     dvi:                          Add Service: Created service 'HdAudAddService'.
+     dvi:                     {Install DEVICE exit (0x00000000)}
+     sto:                     {Configure Driver Package: c:\windows\system32\driverstore\filerepository\hdaudio.inf_amd64_dab2294dc8af0030\hdaudio.inf}
+     sto:                          Source Filter  = HdAudModel
+     sto:                          Target Filter  = HDAUDIO\FUNC_01&VEN_8384&DEV_7680&SUBSYS_83847680&REV_1034\4&22A99211&0&0001
+     inf:                          Class GUID     = {4d36e96c-e325-11ce-bfc1-08002be10318}
+     inf:                          {Configure Driver: High Definition Audio Device}
+     inf:                               Section Name = HdAudModel
+     inf:                               {Configure Device: HDAUDIO\FUNC_01&VEN_8384&DEV_7680&SUBSYS_83847680&REV_1034\4&22A99211&0&0001}
+     inf:                               {Configure Device: exit(0x00000000)}
+     inf:                          {Configure Driver: exit(0x00000000)}
+     sto:                     {Configure Driver Package: exit(0x00000000)}
+     dvi:                     Install Device: Configuring device class. 17:53:41.903
+     dvi:                     Install Device: Configuring device class completed. 17:53:41.916
+     dvi:                     {Restarting Devices} 17:53:41.916
+     dvi:                          Restart: HDAUDIO\FUNC_01&VEN_8384&DEV_7680&SUBSYS_83847680&REV_1034\4&22A99211&0&0001
+     dvi:                     {Restarting Devices exit} 17:53:42.383
+     dvi:                Class installer: Exit
+     dvi:           {DIF_INSTALLDEVICE - exit(0x00000000)} 17:53:43.332
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL} 17:53:43.411
+     dvi:                Class installer: Enter 17:53:43.411
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:43.411
+     dvi:                Default installer: Exit
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL - exit(0xe000020e)} 17:53:43.411
+     ndv:      {Installing device - exit(0x00000000)} 17:53:43.429
+     ndv: {Core Device Install - exit(0x00000000)} 17:53:43.429
+     dvi: {DIF_DESTROYPRIVATEDATA} 17:53:43.429
+     dvi:      Class installer: Enter 17:53:43.429
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:43.429
+     dvi:      Default installer: Exit
+     dvi: {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:43.429
+<<<  Section end 2015/11/22 17:53:43.497
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup online Device Install (Hardware initiated) - ACPI\PNP0400\4&e03a844&0]
+>>>  Section start 2015/11/22 17:53:29.473
+     dvi: {Build Driver List} 17:53:29.489
+     dvi:      Searching for hardware ID(s):
+     dvi:           acpi\ven_pnp&dev_0400
+     dvi:           acpi\pnp0400
+     dvi:           *pnp0400
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - *PNP0400
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\msports.inf_amd64_db43c0c39a11ad06\msports.inf
+     dvi:           DevDesc      - Printer Port
+     dvi:           Section      - LptPort.NT
+     dvi:           Rank         - 0x00ff0002
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 06/21/2006
+     dvi:           Version      - 10.0.10240.16384
+     dvi: {Build Driver List - exit(0x00000000)} 17:53:30.817
+     dvi: {DIF_SELECTBESTCOMPATDRV} 17:53:30.817
+     dvi:      Using exported function 'PortsClassInstaller' in module 'C:\Windows\system32\MsPorts.Dll'.
+     dvi:      Class installer == MsPorts.Dll,PortsClassInstaller
+     dvi:      Class installer: Enter 17:53:31.380
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:31.380
+     dvi:           {Select Best Driver}
+     dvi:                Class GUID of device remains: {4d36e978-e325-11ce-bfc1-08002be10318}.
+     dvi:                Selected:
+     dvi:                     Description - [Printer Port]
+     dvi:                     InfFile     - [c:\windows\system32\driverstore\filerepository\msports.inf_amd64_db43c0c39a11ad06\msports.inf]
+     dvi:                     Section     - [LptPort]
+     dvi:           {Select Best Driver - exit(0x00000000)}
+     dvi:      Default installer: Exit
+     dvi: {DIF_SELECTBESTCOMPATDRV - exit(0x00000000)} 17:53:31.380
+     ndv: {Core Device Install} 17:53:31.380
+     ndv:      {Installing device - ACPI\PNP0400\4&E03A844&0} 17:53:31.380
+!    ndv:           Device class {4d36e978-e325-11ce-bfc1-08002be10318} is not configurable.
+     dvi:           {DIF_ALLOW_INSTALL} 17:53:31.380
+     dvi:                Class installer: Enter 17:53:31.380
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:31.397
+     dvi:                Default installer: Exit
+     dvi:           {DIF_ALLOW_INSTALL - exit(0xe000020e)} 17:53:31.397
+     dvi:           {DIF_INSTALLDEVICEFILES} 17:53:31.536
+     dvi:                Class installer: Enter 17:53:31.536
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:31.536
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLDEVICEFILES - exit(0x00000000)} 17:53:31.536
+     flq:           File 'C:\Windows\system32\DRIVERS\parport.sys' pruned from copy.
+     dvi:           {DIF_REGISTER_COINSTALLERS} 17:53:31.707
+     dvi:                Reset Device: Resetting device configuration. 17:53:31.707
+     dvi:                Reset Device: Resetting device configuration completed. 17:53:31.707
+     dvi:                Class installer: Enter 17:53:31.707
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:31.707
+     dvi:                Default installer: Exit
+     dvi:           {DIF_REGISTER_COINSTALLERS - exit(0x00000000)} 17:53:31.724
+     dvi:           {DIF_INSTALLINTERFACES} 17:53:31.724
+     dvi:                Class installer: Enter 17:53:31.724
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:31.724
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLINTERFACES - exit(0x00000000)} 17:53:31.724
+     dvi:           {DIF_INSTALLDEVICE} 17:53:31.724
+     dvi:                Class installer: Enter 17:53:31.724
+     dvi:                     {Install DEVICE}
+     dvi:                          {Writing Device Properties}
+     dvi:                               Strong Name=msports.inf:10809047c11708a1:LptPort:10.0.10240.16384:*pnp0400
+     dvi:                          {Writing Device Properties - Complete}
+     inf:                          AddService=Parport,0x00000002,Parport_Service_Inst,Parport_EventLog_Inst  (msports.inf line 140)
+     dvi:                          Add Service: Modified existing service 'Parport'.
+     dvi:                     {Install DEVICE exit (0x00000000)}
+     dvi:                     Install Device: Configuring device class. 17:53:31.741
+     dvi:                     Install Device: Configuring device class completed. 17:53:31.741
+     dvi:                     Install Device: Starting device. 17:53:31.785
+     dvi:                     Install Device: Starting device completed. 17:53:32.279
+     dvi:                Class installer: Exit
+     dvi:           {DIF_INSTALLDEVICE - exit(0x00000000)} 17:53:32.279
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL} 17:53:32.279
+     dvi:                Class installer: Enter 17:53:32.279
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:32.279
+     dvi:                Default installer: Exit
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL - exit(0xe000020e)} 17:53:32.279
+     ndv:      {Installing device - exit(0x00000000)} 17:53:32.739
+     ndv: {Core Device Install - exit(0x00000000)} 17:53:32.739
+     dvi: {DIF_DESTROYPRIVATEDATA} 17:53:32.785
+     dvi:      Class installer: Enter 17:53:32.785
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:32.785
+     dvi:      Default installer: Exit
+     dvi: {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:32.801
+<<<  Section end 2015/11/22 17:53:32.895
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup online Device Install (Hardware initiated) - SW\{97ebaacc-95bd-11d0-a3ea-00a0c9223196}\{53172480-4791-11D0-A5D6-28DB04C10000}]
+>>>  Section start 2015/11/22 17:53:43.429
+     dvi: {Build Driver List} 17:53:43.497
+     dvi:      Searching for hardware ID(s):
+     dvi:           sw\{97ebaacc-95bd-11d0-a3ea-00a0c9223196}
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - SW\{97ebaacc-95bd-11d0-a3ea-00a0c9223196}
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\ksfilter.inf_amd64_d6963b5937e6d7a5\ksfilter.inf
+     dvi:           DevDesc      - Microsoft Streaming Clock Proxy
+     dvi:           Section      - MSPCLOCK.NT
+     dvi:           Rank         - 0x00ff0000
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 06/21/2006
+     dvi:           Version      - 10.0.10240.16384
+     dvi: {Build Driver List - exit(0x00000000)} 17:53:47.181
+     dvi: {DIF_SELECTBESTCOMPATDRV} 17:53:47.181
+     dvi:      Using exported function 'MediaClassInstaller' in module 'C:\Windows\system32\mmci.dll'.
+     dvi:      Class installer == mmci.dll,MediaClassInstaller
+     dvi:      Class installer: Enter 17:53:47.397
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:47.397
+     dvi:           {Select Best Driver}
+     dvi:                Class GUID of device changed to: {4d36e96c-e325-11ce-bfc1-08002be10318}.
+     dvi:                {DIF_DESTROYPRIVATEDATA} 17:53:47.397
+     dvi:                     Class installer: Enter 17:53:47.397
+     dvi:                     Class installer: Exit
+     dvi:                     Default installer: Enter 17:53:47.397
+     dvi:                     Default installer: Exit
+     dvi:                {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:47.397
+     dvi:                Selected:
+     dvi:                     Description - [Microsoft Streaming Clock Proxy]
+     dvi:                     InfFile     - [c:\windows\system32\driverstore\filerepository\ksfilter.inf_amd64_d6963b5937e6d7a5\ksfilter.inf]
+     dvi:                     Section     - [MSPCLOCK]
+     dvi:           {Select Best Driver - exit(0x00000000)}
+     dvi:      Default installer: Exit
+     dvi: {DIF_SELECTBESTCOMPATDRV - exit(0x00000000)} 17:53:47.412
+     ndv: {Core Device Install} 17:53:47.412
+     ndv:      {Installing device - SW\{97EBAACC-95BD-11D0-A3EA-00A0C9223196}\{53172480-4791-11D0-A5D6-28DB04C10000}} 17:53:47.412
+!    ndv:           Device class {4d36e96c-e325-11ce-bfc1-08002be10318} is not configurable.
+     dvi:           {DIF_ALLOW_INSTALL} 17:53:47.412
+     dvi:                Using exported function 'MediaClassInstaller' in module 'C:\Windows\system32\mmci.dll'.
+     dvi:                Class installer == mmci.dll,MediaClassInstaller
+     dvi:                Class installer: Enter 17:53:47.569
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:47.569
+     dvi:                Default installer: Exit
+     dvi:           {DIF_ALLOW_INSTALL - exit(0xe000020e)} 17:53:47.569
+     dvi:           {DIF_INSTALLDEVICEFILES} 17:53:47.569
+     dvi:                Class installer: Enter 17:53:47.569
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:47.569
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLDEVICEFILES - exit(0x00000000)} 17:53:47.569
+     dvi:           {DIF_REGISTER_COINSTALLERS} 17:53:47.569
+     dvi:                Reset Device: Resetting device configuration. 17:53:47.569
+     dvi:                Reset Device: Resetting device configuration completed. 17:53:47.569
+     dvi:                Class installer: Enter 17:53:47.569
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:47.569
+     dvi:                Default installer: Exit
+     dvi:           {DIF_REGISTER_COINSTALLERS - exit(0x00000000)} 17:53:47.569
+     dvi:           {DIF_INSTALLINTERFACES} 17:53:47.569
+     dvi:                Class installer: Enter 17:53:47.569
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:47.569
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLINTERFACES - exit(0x00000000)} 17:53:47.569
+     dvi:           {DIF_INSTALLDEVICE} 17:53:47.569
+     dvi:                Class installer: Enter 17:53:47.569
+     dvi:                     {Install DEVICE}
+     dvi:                          {Writing Device Properties}
+     dvi:                               Strong Name=ksfilter.inf:db04a16ce73684f9:MSPCLOCK:10.0.10240.16384:sw\{97ebaacc-95bd-11d0-a3ea-00a0c9223196}
+     dvi:                          {Writing Device Properties - Complete}
+     inf:                          AddService=MSPCLOCK,0x00000002,MSPCLOCK.ServiceInstall  (ksfilter.inf line 42)
+     dvi:                          Add Service: Created service 'MSPCLOCK'.
+     dvi:                     {Install DEVICE exit (0x00000000)}
+     sto:                     {Configure Driver Package: c:\windows\system32\driverstore\filerepository\ksfilter.inf_amd64_d6963b5937e6d7a5\ksfilter.inf}
+     sto:                          Source Filter  = MSPCLOCK.NT
+     sto:                          Target Filter  = SW\{97EBAACC-95BD-11D0-A3EA-00A0C9223196}\{53172480-4791-11D0-A5D6-28DB04C10000}
+     inf:                          Class GUID     = {4d36e96c-e325-11ce-bfc1-08002be10318}
+     inf:                          {Configure Driver: Microsoft Streaming Clock Proxy}
+     inf:                               Section Name = MSPCLOCK.NT
+     inf:                               {Configure Device: SW\{97EBAACC-95BD-11D0-A3EA-00A0C9223196}\{53172480-4791-11D0-A5D6-28DB04C10000}}
+     inf:                               {Configure Device: exit(0x00000000)}
+     inf:                          {Configure Driver: exit(0x00000000)}
+     sto:                     {Configure Driver Package: exit(0x00000000)}
+     dvi:                     Install Device: Configuring device class. 17:53:47.668
+     dvi:                     Install Device: Configuring device class completed. 17:53:47.668
+     dvi:                     Install Device: Starting device. 17:53:47.682
+     dvi:                     Install Device: Starting device completed. 17:53:47.852
+     dvi:                Class installer: Exit
+     dvi:           {DIF_INSTALLDEVICE - exit(0x00000000)} 17:53:48.129
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL} 17:53:48.129
+     dvi:                Class installer: Enter 17:53:48.129
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:48.129
+     dvi:                Default installer: Exit
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL - exit(0xe000020e)} 17:53:48.129
+     ndv:      {Installing device - exit(0x00000000)} 17:53:48.129
+     ndv: {Core Device Install - exit(0x00000000)} 17:53:48.129
+     dvi: {DIF_DESTROYPRIVATEDATA} 17:53:48.161
+     dvi:      Class installer: Enter 17:53:48.161
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:48.161
+     dvi:      Default installer: Exit
+     dvi: {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:48.161
+<<<  Section end 2015/11/22 17:53:48.461
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup online Device Install (Hardware initiated) - SW\{ddf4358e-bb2c-11d0-a42f-00a0c9223196}\{97EBAACB-95BD-11D0-A3EA-00A0C9223196}]
+>>>  Section start 2015/11/22 17:53:43.429
+     dvi: {Build Driver List} 17:53:43.497
+     dvi:      Searching for hardware ID(s):
+     dvi:           sw\{ddf4358e-bb2c-11d0-a42f-00a0c9223196}
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - SW\{DDF4358E-BB2C-11D0-A42F-00A0C9223196}
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\ksfilter.inf_amd64_d6963b5937e6d7a5\ksfilter.inf
+     dvi:           DevDesc      - Microsoft Streaming Quality Manager Proxy
+     dvi:           Section      - MSPQM.NT
+     dvi:           Rank         - 0x00ff0000
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 06/21/2006
+     dvi:           Version      - 10.0.10240.16384
+     dvi: {Build Driver List - exit(0x00000000)} 17:53:47.229
+     dvi: {DIF_SELECTBESTCOMPATDRV} 17:53:47.229
+     dvi:      Using exported function 'MediaClassInstaller' in module 'C:\Windows\system32\mmci.dll'.
+     dvi:      Class installer == mmci.dll,MediaClassInstaller
+     dvi:      Class installer: Enter 17:53:47.429
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:47.429
+     dvi:           {Select Best Driver}
+     dvi:                Class GUID of device changed to: {4d36e96c-e325-11ce-bfc1-08002be10318}.
+     dvi:                {DIF_DESTROYPRIVATEDATA} 17:53:47.429
+     dvi:                     Class installer: Enter 17:53:47.429
+     dvi:                     Class installer: Exit
+     dvi:                     Default installer: Enter 17:53:47.429
+     dvi:                     Default installer: Exit
+     dvi:                {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:47.429
+     dvi:                Selected:
+     dvi:                     Description - [Microsoft Streaming Quality Manager Proxy]
+     dvi:                     InfFile     - [c:\windows\system32\driverstore\filerepository\ksfilter.inf_amd64_d6963b5937e6d7a5\ksfilter.inf]
+     dvi:                     Section     - [MSPQM]
+     dvi:           {Select Best Driver - exit(0x00000000)}
+     dvi:      Default installer: Exit
+     dvi: {DIF_SELECTBESTCOMPATDRV - exit(0x00000000)} 17:53:47.429
+     ndv: Waiting for previous device install to complete. 17:53:47.429
+     ndv: {Core Device Install} 17:53:48.709
+     ndv:      {Installing device - SW\{DDF4358E-BB2C-11D0-A42F-00A0C9223196}\{97EBAACB-95BD-11D0-A3EA-00A0C9223196}} 17:53:48.709
+!    ndv:           Device class {4d36e96c-e325-11ce-bfc1-08002be10318} is not configurable.
+     dvi:           {DIF_ALLOW_INSTALL} 17:53:48.709
+     dvi:                Using exported function 'MediaClassInstaller' in module 'C:\Windows\system32\mmci.dll'.
+     dvi:                Class installer == mmci.dll,MediaClassInstaller
+     dvi:                Class installer: Enter 17:53:48.709
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:48.709
+     dvi:                Default installer: Exit
+     dvi:           {DIF_ALLOW_INSTALL - exit(0xe000020e)} 17:53:48.725
+     dvi:           {DIF_INSTALLDEVICEFILES} 17:53:48.725
+     dvi:                Class installer: Enter 17:53:48.725
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:48.725
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLDEVICEFILES - exit(0x00000000)} 17:53:48.725
+     dvi:           {DIF_REGISTER_COINSTALLERS} 17:53:48.725
+     dvi:                Reset Device: Resetting device configuration. 17:53:48.725
+     dvi:                Reset Device: Resetting device configuration completed. 17:53:48.725
+     dvi:                Class installer: Enter 17:53:48.725
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:48.725
+     dvi:                Default installer: Exit
+     dvi:           {DIF_REGISTER_COINSTALLERS - exit(0x00000000)} 17:53:48.725
+     dvi:           {DIF_INSTALLINTERFACES} 17:53:48.725
+     dvi:                Class installer: Enter 17:53:48.725
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:48.725
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLINTERFACES - exit(0x00000000)} 17:53:48.725
+     dvi:           {DIF_INSTALLDEVICE} 17:53:48.725
+     dvi:                Class installer: Enter 17:53:48.725
+     dvi:                     {Install DEVICE}
+     dvi:                          {Writing Device Properties}
+     dvi:                               Strong Name=ksfilter.inf:db04a16c9051c531:MSPQM:10.0.10240.16384:sw\{ddf4358e-bb2c-11d0-a42f-00a0c9223196}
+     dvi:                          {Writing Device Properties - Complete}
+     inf:                          AddService=MSPQM,0x00000002,MSPQM.ServiceInstall  (ksfilter.inf line 63)
+     dvi:                          Add Service: Created service 'MSPQM'.
+     dvi:                     {Install DEVICE exit (0x00000000)}
+     sto:                     {Configure Driver Package: c:\windows\system32\driverstore\filerepository\ksfilter.inf_amd64_d6963b5937e6d7a5\ksfilter.inf}
+     sto:                          Source Filter  = MSPQM.NT
+     sto:                          Target Filter  = SW\{DDF4358E-BB2C-11D0-A42F-00A0C9223196}\{97EBAACB-95BD-11D0-A3EA-00A0C9223196}
+     inf:                          Class GUID     = {4d36e96c-e325-11ce-bfc1-08002be10318}
+     inf:                          {Configure Driver: Microsoft Streaming Quality Manager Proxy}
+     inf:                               Section Name = MSPQM.NT
+     inf:                               {Configure Device: SW\{DDF4358E-BB2C-11D0-A42F-00A0C9223196}\{97EBAACB-95BD-11D0-A3EA-00A0C9223196}}
+     inf:                               {Configure Device: exit(0x00000000)}
+     inf:                          {Configure Driver: exit(0x00000000)}
+     sto:                     {Configure Driver Package: exit(0x00000000)}
+     dvi:                     Install Device: Configuring device class. 17:53:48.789
+     dvi:                     Install Device: Configuring device class completed. 17:53:48.789
+     dvi:                     Install Device: Starting device. 17:53:48.789
+     dvi:                     Install Device: Starting device completed. 17:53:48.945
+     dvi:                Class installer: Exit
+     dvi:           {DIF_INSTALLDEVICE - exit(0x00000000)} 17:53:49.132
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL} 17:53:49.132
+     dvi:                Class installer: Enter 17:53:49.132
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:49.132
+     dvi:                Default installer: Exit
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL - exit(0xe000020e)} 17:53:49.132
+     ndv:      {Installing device - exit(0x00000000)} 17:53:49.132
+     ndv: {Core Device Install - exit(0x00000000)} 17:53:49.132
+     dvi: {DIF_DESTROYPRIVATEDATA} 17:53:49.165
+     dvi:      Class installer: Enter 17:53:49.165
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:49.165
+     dvi:      Default installer: Exit
+     dvi: {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:49.165
+<<<  Section end 2015/11/22 17:53:49.410
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup online Device Install (Hardware initiated) - SW\{96e080c7-143c-11d1-b40f-00a0c9223196}\{3C0D501A-140B-11D1-B40F-00A0C9223196}]
+>>>  Section start 2015/11/22 17:53:43.429
+     dvi: {Build Driver List} 17:53:43.497
+     dvi:      Searching for hardware ID(s):
+     dvi:           sw\{96e080c7-143c-11d1-b40f-00a0c9223196}
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - SW\{96E080C7-143C-11D1-B40F-00A0C9223196}
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\ksfilter.inf_amd64_d6963b5937e6d7a5\ksfilter.inf
+     dvi:           DevDesc      - Microsoft Streaming Service Proxy
+     dvi:           Section      - MSKSSRV.NT
+     dvi:           Rank         - 0x00ff0000
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 06/21/2006
+     dvi:           Version      - 10.0.10240.16384
+     dvi: {Build Driver List - exit(0x00000000)} 17:53:47.349
+     dvi: {DIF_SELECTBESTCOMPATDRV} 17:53:47.349
+     dvi:      Using exported function 'MediaClassInstaller' in module 'C:\Windows\system32\mmci.dll'.
+     dvi:      Class installer == mmci.dll,MediaClassInstaller
+     dvi:      Class installer: Enter 17:53:47.397
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:47.463
+     dvi:           {Select Best Driver}
+     dvi:                Class GUID of device changed to: {4d36e96c-e325-11ce-bfc1-08002be10318}.
+     dvi:                {DIF_DESTROYPRIVATEDATA} 17:53:47.463
+     dvi:                     Class installer: Enter 17:53:47.463
+     dvi:                     Class installer: Exit
+     dvi:                     Default installer: Enter 17:53:47.463
+     dvi:                     Default installer: Exit
+     dvi:                {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:47.463
+     dvi:                Selected:
+     dvi:                     Description - [Microsoft Streaming Service Proxy]
+     dvi:                     InfFile     - [c:\windows\system32\driverstore\filerepository\ksfilter.inf_amd64_d6963b5937e6d7a5\ksfilter.inf]
+     dvi:                     Section     - [MSKSSRV]
+     dvi:           {Select Best Driver - exit(0x00000000)}
+     dvi:      Default installer: Exit
+     dvi: {DIF_SELECTBESTCOMPATDRV - exit(0x00000000)} 17:53:47.463
+     ndv: Waiting for previous device install to complete. 17:53:47.463
+     ndv: {Core Device Install} 17:53:49.132
+     ndv:      {Installing device - SW\{96E080C7-143C-11D1-B40F-00A0C9223196}\{3C0D501A-140B-11D1-B40F-00A0C9223196}} 17:53:49.132
+!    ndv:           Device class {4d36e96c-e325-11ce-bfc1-08002be10318} is not configurable.
+     dvi:           {DIF_ALLOW_INSTALL} 17:53:49.132
+     dvi:                Using exported function 'MediaClassInstaller' in module 'C:\Windows\system32\mmci.dll'.
+     dvi:                Class installer == mmci.dll,MediaClassInstaller
+     dvi:                Class installer: Enter 17:53:49.152
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:49.152
+     dvi:                Default installer: Exit
+     dvi:           {DIF_ALLOW_INSTALL - exit(0xe000020e)} 17:53:49.152
+     dvi:           {DIF_INSTALLDEVICEFILES} 17:53:49.152
+     dvi:                Class installer: Enter 17:53:49.152
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:49.152
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLDEVICEFILES - exit(0x00000000)} 17:53:49.152
+     dvi:           {DIF_REGISTER_COINSTALLERS} 17:53:49.152
+     dvi:                Reset Device: Resetting device configuration. 17:53:49.152
+     dvi:                Reset Device: Resetting device configuration completed. 17:53:49.152
+     dvi:                Class installer: Enter 17:53:49.152
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:49.152
+     dvi:                Default installer: Exit
+     dvi:           {DIF_REGISTER_COINSTALLERS - exit(0x00000000)} 17:53:49.152
+     dvi:           {DIF_INSTALLINTERFACES} 17:53:49.152
+     dvi:                Class installer: Enter 17:53:49.152
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:49.152
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLINTERFACES - exit(0x00000000)} 17:53:49.165
+     dvi:           {DIF_INSTALLDEVICE} 17:53:49.165
+     dvi:                Class installer: Enter 17:53:49.165
+     dvi:                     {Install DEVICE}
+     dvi:                          {Writing Device Properties}
+     dvi:                               Strong Name=ksfilter.inf:db04a16c31e7f3b4:MSKSSRV:10.0.10240.16384:sw\{96e080c7-143c-11d1-b40f-00a0c9223196}
+     dvi:                          {Writing Device Properties - Complete}
+     inf:                          AddService=MSKSSRV,0x00000002,MSKSSRV.ServiceInstall  (ksfilter.inf line 83)
+     dvi:                          Add Service: Created service 'MSKSSRV'.
+     dvi:                     {Install DEVICE exit (0x00000000)}
+     sto:                     {Configure Driver Package: c:\windows\system32\driverstore\filerepository\ksfilter.inf_amd64_d6963b5937e6d7a5\ksfilter.inf}
+     sto:                          Source Filter  = MSKSSRV.NT
+     sto:                          Target Filter  = SW\{96E080C7-143C-11D1-B40F-00A0C9223196}\{3C0D501A-140B-11D1-B40F-00A0C9223196}
+     inf:                          Class GUID     = {4d36e96c-e325-11ce-bfc1-08002be10318}
+     inf:                          {Configure Driver: Microsoft Streaming Service Proxy}
+     inf:                               Section Name = MSKSSRV.NT
+     inf:                               {Configure Device: SW\{96E080C7-143C-11D1-B40F-00A0C9223196}\{3C0D501A-140B-11D1-B40F-00A0C9223196}}
+     inf:                               {Configure Device: exit(0x00000000)}
+     inf:                          {Configure Driver: exit(0x00000000)}
+     sto:                     {Configure Driver Package: exit(0x00000000)}
+     dvi:                     Install Device: Configuring device class. 17:53:49.197
+     dvi:                     Install Device: Configuring device class completed. 17:53:49.261
+     dvi:                     Install Device: Starting device. 17:53:49.261
+     dvi:                     Install Device: Starting device completed. 17:53:49.397
+     dvi:                Class installer: Exit
+     dvi:           {DIF_INSTALLDEVICE - exit(0x00000000)} 17:53:49.809
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL} 17:53:49.809
+     dvi:                Class installer: Enter 17:53:49.809
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:49.809
+     dvi:                Default installer: Exit
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL - exit(0xe000020e)} 17:53:49.809
+     ndv:      {Installing device - exit(0x00000000)} 17:53:49.809
+     ndv: {Core Device Install - exit(0x00000000)} 17:53:49.809
+     dvi: {DIF_DESTROYPRIVATEDATA} 17:53:49.852
+     dvi:      Class installer: Enter 17:53:49.852
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:49.852
+     dvi:      Default installer: Exit
+     dvi: {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:49.852
+<<<  Section end 2015/11/22 17:53:50.005
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup online Device Install (Hardware initiated) - SW\{cfd669f1-9bc2-11d0-8299-0000f822fe8a}\{CF1DDA2C-9743-11D0-A3EE-00A0C9223196}]
+>>>  Section start 2015/11/22 17:53:43.513
+     dvi: {Build Driver List} 17:53:43.551
+     dvi:      Searching for hardware ID(s):
+     dvi:           sw\{cfd669f1-9bc2-11d0-8299-0000f822fe8a}
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - SW\{cfd669f1-9bc2-11d0-8299-0000f822fe8a}
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\ksfilter.inf_amd64_d6963b5937e6d7a5\ksfilter.inf
+     dvi:           DevDesc      - Microsoft Streaming Tee/Sink-to-Sink Converter
+     dvi:           Section      - MSTEE.NT
+     dvi:           Rank         - 0x00ff0000
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 06/21/2006
+     dvi:           Version      - 10.0.10240.16384
+     dvi: {Build Driver List - exit(0x00000000)} 17:53:47.257
+     dvi: {DIF_SELECTBESTCOMPATDRV} 17:53:47.257
+     dvi:      Using exported function 'MediaClassInstaller' in module 'C:\Windows\system32\mmci.dll'.
+     dvi:      Class installer == mmci.dll,MediaClassInstaller
+     dvi:      Class installer: Enter 17:53:47.412
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:47.412
+     dvi:           {Select Best Driver}
+     dvi:                Class GUID of device changed to: {4d36e96c-e325-11ce-bfc1-08002be10318}.
+     dvi:                {DIF_DESTROYPRIVATEDATA} 17:53:47.412
+     dvi:                     Class installer: Enter 17:53:47.412
+     dvi:                     Class installer: Exit
+     dvi:                     Default installer: Enter 17:53:47.412
+     dvi:                     Default installer: Exit
+     dvi:                {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:47.412
+     dvi:                Selected:
+     dvi:                     Description - [Microsoft Streaming Tee/Sink-to-Sink Converter]
+     dvi:                     InfFile     - [c:\windows\system32\driverstore\filerepository\ksfilter.inf_amd64_d6963b5937e6d7a5\ksfilter.inf]
+     dvi:                     Section     - [MSTEE]
+     dvi:           {Select Best Driver - exit(0x00000000)}
+     dvi:      Default installer: Exit
+     dvi: {DIF_SELECTBESTCOMPATDRV - exit(0x00000000)} 17:53:47.429
+     ndv: Waiting for previous device install to complete. 17:53:47.429
+     ndv: {Core Device Install} 17:53:48.129
+     ndv:      {Installing device - SW\{CFD669F1-9BC2-11D0-8299-0000F822FE8A}\{CF1DDA2C-9743-11D0-A3EE-00A0C9223196}} 17:53:48.129
+!    ndv:           Device class {4d36e96c-e325-11ce-bfc1-08002be10318} is not configurable.
+     dvi:           {DIF_ALLOW_INSTALL} 17:53:48.129
+     dvi:                Using exported function 'MediaClassInstaller' in module 'C:\Windows\system32\mmci.dll'.
+     dvi:                Class installer == mmci.dll,MediaClassInstaller
+     dvi:                Class installer: Enter 17:53:48.129
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:48.129
+     dvi:                Default installer: Exit
+     dvi:           {DIF_ALLOW_INSTALL - exit(0xe000020e)} 17:53:48.129
+     dvi:           {DIF_INSTALLDEVICEFILES} 17:53:48.145
+     dvi:                Class installer: Enter 17:53:48.145
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:48.145
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLDEVICEFILES - exit(0x00000000)} 17:53:48.145
+     dvi:           {DIF_REGISTER_COINSTALLERS} 17:53:48.145
+     dvi:                Reset Device: Resetting device configuration. 17:53:48.145
+     dvi:                Reset Device: Resetting device configuration completed. 17:53:48.145
+     dvi:                Class installer: Enter 17:53:48.145
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:48.145
+     dvi:                Default installer: Exit
+     dvi:           {DIF_REGISTER_COINSTALLERS - exit(0x00000000)} 17:53:48.145
+     dvi:           {DIF_INSTALLINTERFACES} 17:53:48.145
+     dvi:                Class installer: Enter 17:53:48.145
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:48.145
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLINTERFACES - exit(0x00000000)} 17:53:48.145
+     dvi:           {DIF_INSTALLDEVICE} 17:53:48.145
+     dvi:                Class installer: Enter 17:53:48.145
+     dvi:                     {Install DEVICE}
+     dvi:                          {Writing Device Properties}
+     dvi:                               Strong Name=ksfilter.inf:db04a16c112de839:MSTEE:10.0.10240.16384:sw\{cfd669f1-9bc2-11d0-8299-0000f822fe8a}
+     dvi:                          {Writing Device Properties - Complete}
+     inf:                          AddService=MSTEE,0x00000002,MSTEE.ServiceInstall  (ksfilter.inf line 103)
+     dvi:                          Add Service: Created service 'MSTEE'.
+     dvi:                     {Install DEVICE exit (0x00000000)}
+     sto:                     {Configure Driver Package: c:\windows\system32\driverstore\filerepository\ksfilter.inf_amd64_d6963b5937e6d7a5\ksfilter.inf}
+     sto:                          Source Filter  = MSTEE.NT
+     sto:                          Target Filter  = SW\{CFD669F1-9BC2-11D0-8299-0000F822FE8A}\{CF1DDA2C-9743-11D0-A3EE-00A0C9223196}
+     inf:                          Class GUID     = {4d36e96c-e325-11ce-bfc1-08002be10318}
+     inf:                          {Configure Driver: Microsoft Streaming Tee/Sink-to-Sink Converter}
+     inf:                               Section Name = MSTEE.NT
+     inf:                               {Configure Device: SW\{CFD669F1-9BC2-11D0-8299-0000F822FE8A}\{CF1DDA2C-9743-11D0-A3EE-00A0C9223196}}
+     inf:                               {Configure Device: exit(0x00000000)}
+     inf:                          {Configure Driver: exit(0x00000000)}
+     sto:                     {Configure Driver Package: exit(0x00000000)}
+     dvi:                     Install Device: Configuring device class. 17:53:48.257
+     dvi:                     Install Device: Configuring device class completed. 17:53:48.257
+     dvi:                     Install Device: Starting device. 17:53:48.257
+     dvi:                     Install Device: Starting device completed. 17:53:48.509
+     dvi:                Class installer: Exit
+     dvi:           {DIF_INSTALLDEVICE - exit(0x00000000)} 17:53:48.709
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL} 17:53:48.709
+     dvi:                Class installer: Enter 17:53:48.709
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:48.709
+     dvi:                Default installer: Exit
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL - exit(0xe000020e)} 17:53:48.709
+     ndv:      {Installing device - exit(0x00000000)} 17:53:48.709
+     ndv: {Core Device Install - exit(0x00000000)} 17:53:48.709
+     dvi: {DIF_DESTROYPRIVATEDATA} 17:53:48.740
+     dvi:      Class installer: Enter 17:53:48.740
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:48.740
+     dvi:      Default installer: Exit
+     dvi: {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:48.740
+<<<  Section end 2015/11/22 17:53:48.945
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup online Device Install (Hardware initiated) - SW\{cfd669f1-9bc2-11d0-8299-0000f822fe8a}\{0A4252A0-7E70-11D0-A5D6-28DB04C10000}]
+>>>  Section start 2015/11/22 17:53:48.461
+     dvi: {Build Driver List} 17:53:48.557
+     dvi:      Searching for hardware ID(s):
+     dvi:           sw\{cfd669f1-9bc2-11d0-8299-0000f822fe8a}
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - SW\{cfd669f1-9bc2-11d0-8299-0000f822fe8a}
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\ksfilter.inf_amd64_d6963b5937e6d7a5\ksfilter.inf
+     dvi:           DevDesc      - Microsoft Streaming Tee/Sink-to-Sink Converter
+     dvi:           Section      - MSTEE.NT
+     dvi:           Rank         - 0x00ff0000
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 06/21/2006
+     dvi:           Version      - 10.0.10240.16384
+     dvi: {Build Driver List - exit(0x00000000)} 17:53:48.557
+     dvi: {DIF_SELECTBESTCOMPATDRV} 17:53:48.557
+     dvi:      Using exported function 'MediaClassInstaller' in module 'C:\Windows\system32\mmci.dll'.
+     dvi:      Class installer == mmci.dll,MediaClassInstaller
+     dvi:      Class installer: Enter 17:53:48.557
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:48.572
+     dvi:           {Select Best Driver}
+     dvi:                Class GUID of device changed to: {4d36e96c-e325-11ce-bfc1-08002be10318}.
+     dvi:                {DIF_DESTROYPRIVATEDATA} 17:53:48.572
+     dvi:                     Class installer: Enter 17:53:48.572
+     dvi:                     Class installer: Exit
+     dvi:                     Default installer: Enter 17:53:48.572
+     dvi:                     Default installer: Exit
+     dvi:                {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:48.572
+     dvi:                Selected:
+     dvi:                     Description - [Microsoft Streaming Tee/Sink-to-Sink Converter]
+     dvi:                     InfFile     - [c:\windows\system32\driverstore\filerepository\ksfilter.inf_amd64_d6963b5937e6d7a5\ksfilter.inf]
+     dvi:                     Section     - [MSTEE]
+     dvi:           {Select Best Driver - exit(0x00000000)}
+     dvi:      Default installer: Exit
+     dvi: {DIF_SELECTBESTCOMPATDRV - exit(0x00000000)} 17:53:48.572
+     ndv: Waiting for previous device install to complete. 17:53:48.572
+     ndv: {Core Device Install} 17:53:49.809
+     ndv:      {Installing device - SW\{CFD669F1-9BC2-11D0-8299-0000F822FE8A}\{0A4252A0-7E70-11D0-A5D6-28DB04C10000}} 17:53:49.809
+!    ndv:           Device class {4d36e96c-e325-11ce-bfc1-08002be10318} is not configurable.
+     dvi:           {DIF_ALLOW_INSTALL} 17:53:49.809
+     dvi:                Using exported function 'MediaClassInstaller' in module 'C:\Windows\system32\mmci.dll'.
+     dvi:                Class installer == mmci.dll,MediaClassInstaller
+     dvi:                Class installer: Enter 17:53:49.809
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:49.809
+     dvi:                Default installer: Exit
+     dvi:           {DIF_ALLOW_INSTALL - exit(0xe000020e)} 17:53:49.809
+     dvi:           {DIF_INSTALLDEVICEFILES} 17:53:49.809
+     dvi:                Class installer: Enter 17:53:49.809
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:49.825
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLDEVICEFILES - exit(0x00000000)} 17:53:49.825
+     dvi:           {DIF_REGISTER_COINSTALLERS} 17:53:49.825
+     dvi:                Reset Device: Resetting device configuration. 17:53:49.825
+     dvi:                Reset Device: Resetting device configuration completed. 17:53:49.825
+     dvi:                Class installer: Enter 17:53:49.825
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:49.825
+     dvi:                Default installer: Exit
+     dvi:           {DIF_REGISTER_COINSTALLERS - exit(0x00000000)} 17:53:49.825
+     dvi:           {DIF_INSTALLINTERFACES} 17:53:49.825
+     dvi:                Class installer: Enter 17:53:49.825
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:49.825
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLINTERFACES - exit(0x00000000)} 17:53:49.825
+     dvi:           {DIF_INSTALLDEVICE} 17:53:49.825
+     dvi:                Class installer: Enter 17:53:49.825
+     dvi:                     {Install DEVICE}
+     dvi:                          {Writing Device Properties}
+     dvi:                               Strong Name=ksfilter.inf:db04a16c112de839:MSTEE:10.0.10240.16384:sw\{cfd669f1-9bc2-11d0-8299-0000f822fe8a}
+     dvi:                          {Writing Device Properties - Complete}
+     inf:                          AddService=MSTEE,0x00000002,MSTEE.ServiceInstall  (ksfilter.inf line 103)
+     dvi:                          Add Service: Modified existing service 'MSTEE'.
+     dvi:                     {Install DEVICE exit (0x00000000)}
+     sto:                     {Configure Driver Package: c:\windows\system32\driverstore\filerepository\ksfilter.inf_amd64_d6963b5937e6d7a5\ksfilter.inf}
+     sto:                          Source Filter  = MSTEE.NT
+     sto:                          Target Filter  = SW\{CFD669F1-9BC2-11D0-8299-0000F822FE8A}\{0A4252A0-7E70-11D0-A5D6-28DB04C10000}
+     inf:                          Class GUID     = {4d36e96c-e325-11ce-bfc1-08002be10318}
+     inf:                          {Configure Driver: Microsoft Streaming Tee/Sink-to-Sink Converter}
+     inf:                               Section Name = MSTEE.NT
+     inf:                               {Configure Device: SW\{CFD669F1-9BC2-11D0-8299-0000F822FE8A}\{0A4252A0-7E70-11D0-A5D6-28DB04C10000}}
+     inf:                               {Configure Device: exit(0x00000000)}
+     inf:                          {Configure Driver: exit(0x00000000)}
+     sto:                     {Configure Driver Package: exit(0x00000000)}
+     dvi:                     Install Device: Configuring device class. 17:53:49.838
+     dvi:                     Install Device: Configuring device class completed. 17:53:49.897
+     dvi:                     Install Device: Starting device. 17:53:49.897
+     dvi:                     Install Device: Starting device completed. 17:53:49.989
+     dvi:                Class installer: Exit
+     dvi:           {DIF_INSTALLDEVICE - exit(0x00000000)} 17:53:50.364
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL} 17:53:50.364
+     dvi:                Class installer: Enter 17:53:50.364
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:50.364
+     dvi:                Default installer: Exit
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL - exit(0xe000020e)} 17:53:50.364
+     ndv:      {Installing device - exit(0x00000000)} 17:53:50.364
+     ndv: {Core Device Install - exit(0x00000000)} 17:53:50.364
+     dvi: {DIF_DESTROYPRIVATEDATA} 17:53:50.381
+     dvi:      Class installer: Enter 17:53:50.381
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:50.381
+     dvi:      Default installer: Exit
+     dvi: {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:50.381
+<<<  Section end 2015/11/22 17:53:50.397
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup online Device Install (Hardware initiated) - SW\{eec12db6-ad9c-4168-8658-b03daef417fe}\{ABD61E00-9350-47e2-A632-4438B90C6641}]
+>>>  Section start 2015/11/22 17:53:48.989
+     dvi: {Build Driver List} 17:53:49.088
+     dvi:      Searching for hardware ID(s):
+     dvi:           sw\{eec12db6-ad9c-4168-8658-b03daef417fe}
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - SW\{EEC12DB6-AD9C-4168-8658-B03DAEF417FE}
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_256ad046a471df0d\wdmaudio.inf
+     dvi:           DevDesc      - Microsoft Trusted Audio Drivers
+     dvi:           Section      - WDM_DRMKAUD
+     dvi:           Rank         - 0x00ff0000
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 07/09/2015
+     dvi:           Version      - 10.0.10240.16384
+     dvi: {Build Driver List - exit(0x00000000)} 17:53:49.103
+     dvi: {DIF_SELECTBESTCOMPATDRV} 17:53:49.103
+     dvi:      Using exported function 'MediaClassInstaller' in module 'C:\Windows\system32\mmci.dll'.
+     dvi:      Class installer == mmci.dll,MediaClassInstaller
+     dvi:      Class installer: Enter 17:53:49.103
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:49.103
+     dvi:           {Select Best Driver}
+     dvi:                Class GUID of device changed to: {4d36e96c-e325-11ce-bfc1-08002be10318}.
+     dvi:                {DIF_DESTROYPRIVATEDATA} 17:53:49.103
+     dvi:                     Class installer: Enter 17:53:49.103
+     dvi:                     Class installer: Exit
+     dvi:                     Default installer: Enter 17:53:49.103
+     dvi:                     Default installer: Exit
+     dvi:                {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:49.103
+     dvi:                Selected:
+     dvi:                     Description - [Microsoft Trusted Audio Drivers]
+     dvi:                     InfFile     - [c:\windows\system32\driverstore\filerepository\wdmaudio.inf_amd64_256ad046a471df0d\wdmaudio.inf]
+     dvi:                     Section     - [WDM_DRMKAUD]
+     dvi:           {Select Best Driver - exit(0x00000000)}
+     dvi:      Default installer: Exit
+     dvi: {DIF_SELECTBESTCOMPATDRV - exit(0x00000000)} 17:53:49.103
+     ndv: Waiting for previous device install to complete. 17:53:49.103
+     ndv: {Core Device Install} 17:53:50.364
+     ndv:      {Installing device - SW\{EEC12DB6-AD9C-4168-8658-B03DAEF417FE}\{ABD61E00-9350-47E2-A632-4438B90C6641}} 17:53:50.364
+!    ndv:           Device class {4d36e96c-e325-11ce-bfc1-08002be10318} is not configurable.
+     dvi:           {DIF_ALLOW_INSTALL} 17:53:50.364
+     dvi:                Using exported function 'MediaClassInstaller' in module 'C:\Windows\system32\mmci.dll'.
+     dvi:                Class installer == mmci.dll,MediaClassInstaller
+     dvi:                Class installer: Enter 17:53:50.364
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:50.364
+     dvi:                Default installer: Exit
+     dvi:           {DIF_ALLOW_INSTALL - exit(0xe000020e)} 17:53:50.381
+     dvi:           {DIF_INSTALLDEVICEFILES} 17:53:50.381
+     dvi:                Class installer: Enter 17:53:50.381
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:50.381
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLDEVICEFILES - exit(0x00000000)} 17:53:50.381
+     flq:           File 'C:\Windows\system32\drivers\drmk.sys' pruned from copy.
+     flq:           Hardlinking 'C:\Windows\System32\DriverStore\FileRepository\wdmaudio.inf_amd64_256ad046a471df0d\drmkaud.sys' to 'C:\Windows\system32\drivers\drmkaud.sys'.
+     dvi:           {DIF_REGISTER_COINSTALLERS} 17:53:51.292
+     dvi:                Reset Device: Resetting device configuration. 17:53:51.292
+     dvi:                Reset Device: Resetting device configuration completed. 17:53:51.292
+     dvi:                Class installer: Enter 17:53:51.292
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:51.292
+     dvi:                Default installer: Exit
+     dvi:           {DIF_REGISTER_COINSTALLERS - exit(0x00000000)} 17:53:51.292
+     dvi:           {DIF_INSTALLINTERFACES} 17:53:51.292
+     dvi:                Class installer: Enter 17:53:51.292
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:51.292
+     dvi:                Default installer: Exit
+     dvi:           {DIF_INSTALLINTERFACES - exit(0x00000000)} 17:53:51.292
+     dvi:           {DIF_INSTALLDEVICE} 17:53:51.292
+     dvi:                Class installer: Enter 17:53:51.292
+     dvi:                     {Install DEVICE}
+     dvi:                          {Writing Device Properties}
+     dvi:                               Strong Name=wdmaudio.inf:ed86ca11801f0e50:WDM_DRMKAUD:10.0.10240.16384:sw\{eec12db6-ad9c-4168-8658-b03daef417fe}
+     dvi:                          {Writing Device Properties - Complete}
+     inf:                          AddService=drmkaud,0x00000002,drmkaud_Service_Inst  (wdmaudio.inf line 145)
+     dvi:                          Add Service: Created service 'drmkaud'.
+     dvi:                     {Install DEVICE exit (0x00000000)}
+     sto:                     {Configure Driver Package: c:\windows\system32\driverstore\filerepository\wdmaudio.inf_amd64_256ad046a471df0d\wdmaudio.inf}
+     sto:                          Source Filter  = WDM_DRMKAUD
+     sto:                          Target Filter  = SW\{EEC12DB6-AD9C-4168-8658-B03DAEF417FE}\{ABD61E00-9350-47E2-A632-4438B90C6641}
+     inf:                          Class GUID     = {4d36e96c-e325-11ce-bfc1-08002be10318}
+     inf:                          {Configure Driver: Microsoft Trusted Audio Drivers}
+     inf:                               Section Name = WDM_DRMKAUD
+     inf:                               {Configure Device: SW\{EEC12DB6-AD9C-4168-8658-B03DAEF417FE}\{ABD61E00-9350-47E2-A632-4438B90C6641}}
+     inf:                               {Configure Device: exit(0x00000000)}
+     inf:                          {Configure Driver: exit(0x00000000)}
+     sto:                     {Configure Driver Package: exit(0x00000000)}
+     dvi:                     Install Device: Configuring device class. 17:53:51.325
+     dvi:                     Install Device: Configuring device class completed. 17:53:51.325
+     dvi:                     {Restarting Devices} 17:53:51.325
+     dvi:                          Restart: SW\{EEC12DB6-AD9C-4168-8658-B03DAEF417FE}\{ABD61E00-9350-47E2-A632-4438B90C6641}
+     dvi:                     {Restarting Devices exit} 17:53:51.509
+     dvi:                Class installer: Exit
+     dvi:           {DIF_INSTALLDEVICE - exit(0x00000000)} 17:53:51.661
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL} 17:53:51.661
+     dvi:                Class installer: Enter 17:53:51.661
+     dvi:                Class installer: Exit
+     dvi:                Default installer: Enter 17:53:51.661
+     dvi:                Default installer: Exit
+     dvi:           {DIF_NEWDEVICEWIZARD_FINISHINSTALL - exit(0xe000020e)} 17:53:51.661
+     ndv:      {Installing device - exit(0x00000000)} 17:53:51.661
+     ndv: {Core Device Install - exit(0x00000000)} 17:53:51.661
+     dvi: {DIF_DESTROYPRIVATEDATA} 17:53:51.661
+     dvi:      Class installer: Enter 17:53:51.661
+     dvi:      Class installer: Exit
+     dvi:      Default installer: Enter 17:53:51.661
+     dvi:      Default installer: Exit
+     dvi: {DIF_DESTROYPRIVATEDATA - exit(0xe000020e)} 17:53:51.661
+<<<  Section end 2015/11/22 17:53:51.832
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup online Device Install (Hardware initiated) - SWD\PRINTENUM\PrintQueues]
+>>>  Section start 2015/11/22 17:55:25.237
+     dvi: {Build Driver List} 17:55:25.256
+     dvi:      Searching for hardware ID(s):
+     dvi:           printenum\localprintqueue
+     dvi:      Searching for compatible ID(s):
+     dvi:           swd\genericraw
+     dvi:           swd\generic
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - SWD\GenericRaw
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\c_swdevice.inf_amd64_7d0967caf567eff0\c_swdevice.inf
+     dvi:           DevDesc      - Generic software device
+     dvi:           Section      - SoftwareDevice
+     dvi:           Rank         - 0x00ff3000
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 06/21/2006
+     dvi:           Version      - 10.0.10240.16384
+     dvi:      Created Driver Node:
+     dvi:           HardwareID   - PRINTENUM\LocalPrintQueue
+     dvi:           InfName      - C:\Windows\System32\DriverStore\FileRepository\printqueue.inf_amd64_d8df683074893f75\printqueue.inf
+     dvi:           DevDesc      - Local Print Queue
+     dvi:           Section      - NO_DRV_LOCAL
+     dvi:           Rank         - 0x00000000
+     dvi:           Signer Score - INBOX
+     dvi:           DrvDate      - 06/21/2006
+     dvi:           Version      - 10.0.10240.16384
+     dvi: {Build Driver List - exit(0x00000000)} 17:55:25.536
+     dvi: {DIF_SELECTBESTCOMPATDRV} 17:55:25.536
+     dvi:      Default installer: Enter 17:55:25.536
+     dvi:           {Select Best Driver}
+     dvi:                Class GUID of device changed to: {1ed2bbf9-11f0-4084-b21f-ad83a8e6dcdc}.
+     dvi:                Selected:
+     dvi:                     Description - [Local Print Queue]
+     dvi:                     InfFile     - [c:\windows\system32\driverstore\filerepository\printqueue.inf_amd64_d8df683074893f75\printqueue.inf]
+     dvi:                     Section     - [NO_DRV_LOCAL]
+     dvi:                Basic Driver Skipped:
+     dvi:                     Description - 'Generic software device'
+     dvi:                     InfFile     - C:\Windows\INF\c_swdevice.inf
+     dvi:                     Section     - [SoftwareDevice]
+     dvi:           {Select Best Driver - exit(0x00000000)}
+     dvi:      Default installer: Exit
+     dvi: {DIF_SELECTBESTCOMPATDRV - exit(0x00000000)} 17:55:25.536
+     ndv: {Core Device Install} 17:55:25.536
+     ndv:      {Installing device - SWD\PRINTENUM\PRINTQUEUES} 17:55:25.536
+     sto:           {Configure Driver Package: C:\Windows\System32\DriverStore\FileRepository\printqueue.inf_amd64_d8df683074893f75\printqueue.inf}
+     sto:                Source Filter  = printenum\localprintqueue
+     inf:                Class GUID     = {1ed2bbf9-11f0-4084-b21f-ad83a8e6dcdc}
+     inf:                Class Options  = Configurable
+     idb:                {Configure Device Setup Class: {1ed2bbf9-11f0-4084-b21f-ad83a8e6dcdc}}
+     idb:                     Updating existing class.
+     idb:                     Class Name = PrintQueue
+     idb:                {Configure Device Setup Class: exit(0x00000000)}
+     inf:                {Configure Driver: Local Print Queue}
+     inf:                     Section Name = NO_DRV_LOCAL
+     inf:                     Hardware Id  = PRINTENUM\LocalPrintQueue
+     inf:                     {Configure Driver Configuration: NO_DRV_LOCAL}
+     inf:                          Service Name  = <none>
+     inf:                          Config Flags  = 0x00000000
+     inf:                     {Configure Driver Configuration: exit(0x00000000)}
+     inf:                {Configure Driver: exit(0x00000000)}
+     sto:           {Configure Driver Package: exit(0x00000000)}
+     dvi:           Install Device: Configuring device (printqueue.inf:printenum\localprintqueue,NO_DRV_LOCAL). 17:55:25.551
+     dvi:           Install Device: Configuring device completed. 17:55:25.551
+     dvi:           Install Device: Removing device sub-tree. 17:55:25.551
+     dvi:           Install Device: Removing device sub-tree completed. 17:55:25.660
+     dvi:           Install Device: Restarting device. 17:55:25.660
+     dvi:           Install Device: Restarting device completed. 17:55:25.674
+     ndv:      {Installing device - exit(0x00000000)} 17:55:25.691
+     ndv: {Core Device Install - exit(0x00000000)} 17:55:25.691
+<<<  Section end 2015/11/22 17:55:25.691
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup Import Driver Package - C:\Windows\system32\spool\tools\Microsoft Print To PDF\prnms009.Inf]
+>>>  Section start 2015/11/22 17:57:13.548
+      cmd: C:\Windows\System32\spoolsv.exe
+     inf: Provider: Microsoft
+     inf: Class GUID: {4D36E979-E325-11CE-BFC1-08002BE10318}
+     inf: Driver Version: 06/21/2006,10.0.10240.16384
+     inf: Catalog File: prnms009.cat
+     pol: {Driver package policy check} 17:57:13.579
+     pol: {Driver package policy check - exit(0x00000000)} 17:57:13.579
+     sto: {Stage Driver Package: C:\Windows\system32\spool\tools\Microsoft Print To PDF\prnms009.Inf} 17:57:13.598
+     inf:      {Query Configurability: C:\Windows\system32\spool\tools\Microsoft Print To PDF\prnms009.Inf} 17:57:13.598
+     inf:           Driver package 'prnms009.Inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 17:57:13.598
+     flq:      Copying 'C:\Windows\system32\spool\tools\Microsoft Print To PDF\prnms009.cat' to 'C:\Windows\System32\DriverStore\Temp\{3adb8423-6211-054c-bfab-8f3d74159a46}\prnms009.cat'.
+     flq:      Copying 'C:\Windows\system32\spool\tools\Microsoft Print To PDF\prnms009.Inf' to 'C:\Windows\System32\DriverStore\Temp\{3adb8423-6211-054c-bfab-8f3d74159a46}\prnms009.Inf'.
+     flq:      Copying 'C:\Windows\system32\spool\tools\Microsoft Print To PDF\MPDW-PDC.xml' to 'C:\Windows\System32\DriverStore\Temp\{3adb8423-6211-054c-bfab-8f3d74159a46}\MPDW-PDC.xml'.
+     flq:      Copying 'C:\Windows\system32\spool\tools\Microsoft Print To PDF\MPDW-manifest.ini' to 'C:\Windows\System32\DriverStore\Temp\{3adb8423-6211-054c-bfab-8f3d74159a46}\MPDW-manifest.ini'.
+     flq:      Copying 'C:\Windows\system32\spool\tools\Microsoft Print To PDF\MPDW-pipelineconfig.xml' to 'C:\Windows\System32\DriverStore\Temp\{3adb8423-6211-054c-bfab-8f3d74159a46}\MPDW-pipelineconfig.xml'.
+     sto:      {DRIVERSTORE IMPORT VALIDATE} 17:57:13.613
+     sig:           {_VERIFY_FILE_SIGNATURE} 17:57:13.689
+     sig:                Key      = prnms009.Inf
+     sig:                FilePath = C:\Windows\System32\DriverStore\Temp\{3adb8423-6211-054c-bfab-8f3d74159a46}\prnms009.Inf
+     sig:                Catalog  = C:\Windows\System32\DriverStore\Temp\{3adb8423-6211-054c-bfab-8f3d74159a46}\prnms009.cat
+     sig:                Success: File is signed in catalog.
+     sig:           {_VERIFY_FILE_SIGNATURE exit(0x00000000)} 17:57:13.719
+     sto:      {DRIVERSTORE IMPORT VALIDATE: exit(0x00000000)} 17:57:13.751
+     sig:      Signer Score = 0x0D000003
+     sig:      Signer Name  = Microsoft Windows
+     sto:      {DRIVERSTORE IMPORT BEGIN} 17:57:13.751
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 17:57:13.751
+     cpy:      {Copy Directory: C:\Windows\System32\DriverStore\Temp\{3adb8423-6211-054c-bfab-8f3d74159a46}} 17:57:13.751
+     cpy:           Target Path = C:\Windows\System32\DriverStore\FileRepository\prnms009.inf_amd64_20240386c0c1c147
+     cpy:      {Copy Directory: exit(0x00000000)} 17:57:13.751
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms009.inf_amd64_20240386c0c1c147\prnms009.Inf} 17:57:13.751
+     idb:           Created driver package object 'prnms009.inf_amd64_20240386c0c1c147' in DRIVERS database node.
+     idb:           Created driver INF file object 'oem0.inf' in DRIVERS database node.
+     idb:           Registered driver package 'prnms009.inf_amd64_20240386c0c1c147' with 'oem0.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 17:57:13.769
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms009.inf_amd64_20240386c0c1c147\prnms009.Inf} 17:57:13.769
+     idb:           Activating driver package 'prnms009.inf_amd64_20240386c0c1c147'.
+     cpy:           Published 'prnms009.inf_amd64_20240386c0c1c147\prnms009.inf' to 'oem0.inf'.
+     idb:           Indexed 2 device IDs for 'prnms009.inf_amd64_20240386c0c1c147'.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 31 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 16 ms
+     idb:      {Publish Driver Package: exit(0x00000000)} 17:57:13.813
+     sto:      {DRIVERSTORE IMPORT END} 17:57:13.813
+     sig:           Installed catalog 'prnms009.cat' as 'oem0.cat'.
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 17:57:17.235
+     sto: {Stage Driver Package: exit(0x00000000)} 17:57:17.235
+<<<  Section end 2015/11/22 17:57:17.251
+<<<  [Exit status: SUCCESS]
+
+
+>>>  [Setup Import Driver Package - C:\Windows\system32\spool\tools\Microsoft XPS Document Writer\prnms001.Inf]
+>>>  Section start 2015/11/22 17:57:17.502
+      cmd: C:\Windows\System32\spoolsv.exe
+     inf: Provider: Microsoft
+     inf: Class GUID: {4D36E979-E325-11CE-BFC1-08002BE10318}
+     inf: Driver Version: 06/21/2006,10.0.10240.16384
+     inf: Catalog File: prnms001.cat
+     pol: {Driver package policy check} 17:57:17.532
+     pol: {Driver package policy check - exit(0x00000000)} 17:57:17.532
+     sto: {Stage Driver Package: C:\Windows\system32\spool\tools\Microsoft XPS Document Writer\prnms001.Inf} 17:57:17.549
+     inf:      {Query Configurability: C:\Windows\system32\spool\tools\Microsoft XPS Document Writer\prnms001.Inf} 17:57:17.549
+     inf:           Driver package 'prnms001.Inf' is configurable.
+     inf:      {Query Configurability: exit(0x00000000)} 17:57:17.549
+     flq:      Copying 'C:\Windows\system32\spool\tools\Microsoft XPS Document Writer\prnms001.cat' to 'C:\Windows\System32\DriverStore\Temp\{50955587-0b06-4340-8448-215abeebb509}\prnms001.cat'.
+     flq:      Copying 'C:\Windows\system32\spool\tools\Microsoft XPS Document Writer\prnms001.Inf' to 'C:\Windows\System32\DriverStore\Temp\{50955587-0b06-4340-8448-215abeebb509}\prnms001.Inf'.
+     flq:      Copying 'C:\Windows\system32\spool\tools\Microsoft XPS Document Writer\mxdwdui.dll' to 'C:\Windows\System32\DriverStore\Temp\{50955587-0b06-4340-8448-215abeebb509}\mxdwdui.dll'.
+     flq:      Copying 'C:\Windows\system32\spool\tools\Microsoft XPS Document Writer\MXDW-manifest.ini' to 'C:\Windows\System32\DriverStore\Temp\{50955587-0b06-4340-8448-215abeebb509}\MXDW-manifest.ini'.
+     flq:      Copying 'C:\Windows\system32\spool\tools\Microsoft XPS Document Writer\MXDW.gpd' to 'C:\Windows\System32\DriverStore\Temp\{50955587-0b06-4340-8448-215abeebb509}\MXDW.gpd'.
+     flq:      Copying 'C:\Windows\system32\spool\tools\Microsoft XPS Document Writer\MXDW-pipelineconfig.xml' to 'C:\Windows\System32\DriverStore\Temp\{50955587-0b06-4340-8448-215abeebb509}\MXDW-pipelineconfig.xml'.
+     sto:      {DRIVERSTORE IMPORT VALIDATE} 17:57:17.563
+     sig:           {_VERIFY_FILE_SIGNATURE} 17:57:17.579
+     sig:                Key      = prnms001.Inf
+     sig:                FilePath = C:\Windows\System32\DriverStore\Temp\{50955587-0b06-4340-8448-215abeebb509}\prnms001.Inf
+     sig:                Catalog  = C:\Windows\System32\DriverStore\Temp\{50955587-0b06-4340-8448-215abeebb509}\prnms001.cat
+     sig:                Success: File is signed in catalog.
+     sig:           {_VERIFY_FILE_SIGNATURE exit(0x00000000)} 17:57:17.579
+     sto:      {DRIVERSTORE IMPORT VALIDATE: exit(0x00000000)} 17:57:17.598
+     sig:      Signer Score = 0x0D000003
+     sig:      Signer Name  = Microsoft Windows
+     sto:      {DRIVERSTORE IMPORT BEGIN} 17:57:17.598
+     sto:      {DRIVERSTORE IMPORT BEGIN: exit(0x00000000)} 17:57:17.598
+     cpy:      {Copy Directory: C:\Windows\System32\DriverStore\Temp\{50955587-0b06-4340-8448-215abeebb509}} 17:57:17.598
+     cpy:           Target Path = C:\Windows\System32\DriverStore\FileRepository\prnms001.inf_amd64_6f53fd7f71358cf2
+     cpy:      {Copy Directory: exit(0x00000000)} 17:57:17.598
+     idb:      {Register Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms001.inf_amd64_6f53fd7f71358cf2\prnms001.Inf} 17:57:17.598
+     idb:           Created driver package object 'prnms001.inf_amd64_6f53fd7f71358cf2' in DRIVERS database node.
+     idb:           Created driver INF file object 'oem1.inf' in DRIVERS database node.
+     idb:           Registered driver package 'prnms001.inf_amd64_6f53fd7f71358cf2' with 'oem1.inf'.
+     idb:      {Register Driver Package: exit(0x00000000)} 17:57:17.598
+     idb:      {Publish Driver Package: C:\Windows\System32\DriverStore\FileRepository\prnms001.inf_amd64_6f53fd7f71358cf2\prnms001.Inf} 17:57:17.598
+     idb:           Activating driver package 'prnms001.inf_amd64_6f53fd7f71358cf2'.
+     cpy:           Published 'prnms001.inf_amd64_6f53fd7f71358cf2\prnms001.inf' to 'oem1.inf'.
+     idb:           Indexed 2 device IDs for 'prnms001.inf_amd64_6f53fd7f71358cf2'.
+     sto:           Flushed driver database node 'DRIVERS'. Time = 47 ms
+     sto:           Flushed driver database node 'SYSTEM'. Time = 0 ms
+     idb:      {Publish Driver Package: exit(0x00000000)} 17:57:17.645
+     sto:      {DRIVERSTORE IMPORT END} 17:57:17.645
+     sig:           Installed catalog 'prnms001.cat' as 'oem1.cat'.
+     sto:      {DRIVERSTORE IMPORT END: exit(0x00000000)} 17:57:17.704
+     sto: {Stage Driver Package: exit(0x00000000)} 17:57:17.704
+<<<  Section end 2015/11/22 17:57:17.704
+<<<  [Exit status: SUCCESS]
+

--- a/tests/formatters/setupapi.py
+++ b/tests/formatters/setupapi.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the Windows Setupapi log event formatter."""
+
+from __future__ import unicode_literals
+
+import unittest
+
+from plaso.formatters import setupapi
+
+from tests.formatters import test_lib
+
+
+class SetupapiLogFormatterTest(test_lib.EventFormatterTestCase):
+  """Tests for the Windows Setupapi log event formatter."""
+
+  def testInitialization(self):
+    """Tests the initialization."""
+    event_formatter = setupapi.SetupapiLogFormatter()
+    self.assertIsNotNone(event_formatter)
+
+  def testGetFormatStringAttributeNames(self):
+    """Tests the GetFormatStringAttributeNames function."""
+    event_formatter = setupapi.SetupapiLogFormatter()
+
+    expected_attribute_names = [
+        'entry_type',
+        'exit_status']
+
+    self._TestGetFormatStringAttributeNames(
+        event_formatter, expected_attribute_names)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/formatters/setupapi.py
+++ b/tests/formatters/setupapi.py
@@ -25,6 +25,7 @@ class SetupapiLogFormatterTest(test_lib.EventFormatterTestCase):
 
     expected_attribute_names = [
         'entry_type',
+        'end_time',
         'exit_status']
 
     self._TestGetFormatStringAttributeNames(

--- a/tests/formatters/setupapi.py
+++ b/tests/formatters/setupapi.py
@@ -25,8 +25,7 @@ class SetupapiLogFormatterTest(test_lib.EventFormatterTestCase):
 
     expected_attribute_names = [
         'entry_type',
-        'end_time',
-        'exit_status']
+        'entry_status']
 
     self._TestGetFormatStringAttributeNames(
         event_formatter, expected_attribute_names)

--- a/tests/parsers/setupapi.py
+++ b/tests/parsers/setupapi.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the Windows Setupapi log parser."""
+
+from __future__ import unicode_literals
+
+import unittest
+
+from plaso.formatters import setupapi as _  # pylint: disable=unused-import
+from plaso.parsers import setupapi
+
+from tests.parsers import test_lib
+
+
+class SetupapiLogUnitTest(test_lib.ParserTestCase):
+  """Tests for the Windows Setupapi log parser.
+
+  Since Setupapi logs record in local time, these tests assume that the local
+  timezone is set to UTC.
+  """
+
+  def testParseDevLog(self):
+    """Tests the Parse function on dev log."""
+    parser = setupapi.SetupapiLogParser()
+    storage_writer = self._ParseFile(['setupapi.dev.log'], parser)
+
+    self.assertEqual(storage_writer.number_of_warnings, 0)
+    self.assertEqual(storage_writer.number_of_events, 194)
+
+    events = list(storage_writer.GetEvents())
+
+    event = events[0]
+
+    self.CheckTimestamp(event.timestamp, '2015-11-22 17:59:28.110000')
+
+    event = events[1]
+
+    self.CheckTimestamp(event.timestamp, '2016-10-05 11:16:03.747000')
+
+    event = events[2]
+
+    self.CheckTimestamp(event.timestamp, '2016-10-05 11:16:16.471000')
+
+    expected_message = (
+        'Description: Device Install (Hardware initiated) - SWD\\IP_TUNNEL_VBUS'
+        '\\Teredo_Tunnel_Device | Exit status: SUCCESS')
+    expected_short_message = (
+        'Device Install (Hardware initiated) - SWD\\IP_TUNNEL_VBUS'
+        '\\Teredo_Tunnel_Device')
+    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+
+    event = events[28]
+    expected_message = (
+        'Description: Device Install (DiInstallDriver) - C:\\Windows\\System32'
+        '\\DriverStore\\FileRepository\\prnms003.inf_x86_8f17aac186c70ea6'
+        '\\prnms003.inf | Exit status: SUCCESS')
+    expected_short_message = (
+        'Device Install (DiInstallDriver) - C:\\Windows\\System32\\DriverStore'
+        '\\FileReposi...')
+    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+
+    event = events[193]
+
+    self.CheckTimestamp(event.timestamp, '2016-11-22 23:50:30.938000')
+
+    expected_message = (
+        'Description: Device Install (Hardware initiated) - SWD\\WPDBUSENUM'
+        '\\_??_USBSTOR#Disk&Ven_Generic&Prod_Flash_Disk&Rev_8.07#99E2116A&0'
+        '#{53f56307-b6bf-11d0-94f2-00a0c91efb8b} | Exit status: SUCCESS')
+    expected_short_message = (
+        'Device Install (Hardware initiated) - SWD\\WPDBUSENUM'
+        '\\_??_USBSTOR#Disk&Ven_Gen...')
+    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+
+  def testParseSetupLog(self):
+    """Tests the Parse function on setup log."""
+    parser = setupapi.SetupapiLogParser()
+    storage_writer = self._ParseFile(['setupapi.setup.log'], parser)
+
+    self.assertEqual(storage_writer.number_of_warnings, 0)
+    self.assertEqual(storage_writer.number_of_events, 16)
+
+    events = list(storage_writer.GetEvents())
+
+    event = events[0]
+
+    self.CheckTimestamp(event.timestamp, '2015-11-22 17:53:16.599000')
+
+    event = events[1]
+
+    self.CheckTimestamp(event.timestamp, '2015-11-22 17:53:28.973000')
+
+    event = events[2]
+
+    self.CheckTimestamp(event.timestamp, '2015-11-22 17:53:29.305000')
+
+    expected_message = (
+        'Description: Setup Plug and Play Device Install '
+        '| Exit status: SUCCESS')
+    expected_short_message = ('Setup Plug and Play Device Install')
+    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+
+    event = events[7]
+    expected_message = (
+        'Description: Setup online Device Install (Hardware initiated) - SW'
+        '\\{97ebaacc-95bd-11d0-a3ea-00a0c9223196}'
+        '\\{53172480-4791-11D0-A5D6-28DB04C10000} | Exit status: SUCCESS')
+    expected_short_message = (
+        'Setup online Device Install (Hardware initiated) - SW'
+        '\\{97ebaacc-95bd-11d0-a3e...')
+    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+
+    event = events[15]
+
+    self.CheckTimestamp(event.timestamp, '2015-11-22 17:57:17.502000')
+
+    expected_message = (
+        'Description: Setup Import Driver Package - C:\\Windows\\system32'
+        '\\spool\\tools\\Microsoft XPS Document Writer\\prnms001.Inf '
+        '| Exit status: SUCCESS')
+    expected_short_message = (
+        'Setup Import Driver Package - C:\\Windows\\system32\\spool'
+        '\\tools\\Microsoft XPS D...')
+    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/parsers/setupapi.py
+++ b/tests/parsers/setupapi.py
@@ -25,7 +25,7 @@ class SetupapiLogUnitTest(test_lib.ParserTestCase):
     storage_writer = self._ParseFile(['setupapi.dev.log'], parser)
 
     self.assertEqual(storage_writer.number_of_warnings, 0)
-    self.assertEqual(storage_writer.number_of_events, 194)
+    self.assertEqual(storage_writer.number_of_events, 388)
 
     events = list(storage_writer.GetEvents())
 
@@ -33,37 +33,37 @@ class SetupapiLogUnitTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2015-11-22 17:59:28.110000')
 
-    event = events[1]
+    event = events[2]
 
     self.CheckTimestamp(event.timestamp, '2016-10-05 11:16:03.747000')
 
-    event = events[2]
+    event = events[4]
     event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     self.CheckTimestamp(event.timestamp, '2016-10-05 11:16:16.471000')
 
     expected_message = (
         'Device Install (Hardware initiated) - SWD\\IP_TUNNEL_VBUS'
-        '\\Teredo_Tunnel_Device [SUCCESS 2016-10-05 11:16:26.388 UTC]')
+        '\\Teredo_Tunnel_Device - START')
     expected_short_message = (
-        'Device Install (Hardware initiated) - SWD\\IP_TUNNEL_VBUS'
-        '\\Teredo_Tunnel_Device')
+        'START - Device Install (Hardware initiated) - SWD\\IP_TUNNEL_VBUS'
+        '\\Teredo_Tunne...')
     self._TestGetMessageStrings(
         event_data, expected_message, expected_short_message)
 
-    event = events[28]
+    event = events[57]
     event_data = self._GetEventDataOfEvent(storage_writer, event)
     expected_message = (
         'Device Install (DiInstallDriver) - C:\\Windows\\System32'
         '\\DriverStore\\FileRepository\\prnms003.inf_x86_8f17aac186c70ea6'
-        '\\prnms003.inf [SUCCESS 2016-10-12 03:36:30.998 UTC]')
+        '\\prnms003.inf - SUCCESS')
     expected_short_message = (
-        'Device Install (DiInstallDriver) - C:\\Windows\\System32\\DriverStore'
-        '\\FileReposi...')
+        'SUCCESS - Device Install (DiInstallDriver) - C:\\Windows\\System32'
+        '\\DriverStore\\...')
     self._TestGetMessageStrings(
         event_data, expected_message, expected_short_message)
 
-    event = events[193]
+    event = events[386]
     event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     self.CheckTimestamp(event.timestamp, '2016-11-22 23:50:30.938000')
@@ -71,11 +71,10 @@ class SetupapiLogUnitTest(test_lib.ParserTestCase):
     expected_message = (
         'Device Install (Hardware initiated) - SWD\\WPDBUSENUM'
         '\\_??_USBSTOR#Disk&Ven_Generic&Prod_Flash_Disk&Rev_8.07#99E2116A&0'
-        '#{53f56307-b6bf-11d0-94f2-00a0c91efb8b} '
-        '[SUCCESS 2016-11-22 23:50:58.236 UTC]')
+        '#{53f56307-b6bf-11d0-94f2-00a0c91efb8b} - START')
     expected_short_message = (
-        'Device Install (Hardware initiated) - SWD\\WPDBUSENUM'
-        '\\_??_USBSTOR#Disk&Ven_Gen...')
+        'START - Device Install (Hardware initiated) - SWD\\WPDBUSENUM'
+        '\\_??_USBSTOR#Disk...')
     self._TestGetMessageStrings(
         event_data, expected_message, expected_short_message)
 
@@ -85,7 +84,7 @@ class SetupapiLogUnitTest(test_lib.ParserTestCase):
     storage_writer = self._ParseFile(['setupapi.setup.log'], parser)
 
     self.assertEqual(storage_writer.number_of_warnings, 0)
-    self.assertEqual(storage_writer.number_of_events, 16)
+    self.assertEqual(storage_writer.number_of_events, 32)
 
     events = list(storage_writer.GetEvents())
 
@@ -93,48 +92,44 @@ class SetupapiLogUnitTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2015-11-22 17:53:16.599000')
 
-    event = events[1]
+    event = events[2]
 
     self.CheckTimestamp(event.timestamp, '2015-11-22 17:53:28.973000')
 
-    event = events[2]
+    event = events[4]
     event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     self.CheckTimestamp(event.timestamp, '2015-11-22 17:53:29.305000')
 
-    expected_message = (
-        'Setup Plug and Play Device Install '
-        '[SUCCESS 2015-11-22 17:53:51.832 UTC]')
-    expected_short_message = ('Setup Plug and Play Device Install')
+    expected_message = ('Setup Plug and Play Device Install - START')
+    expected_short_message = ('START - Setup Plug and Play Device Install')
     self._TestGetMessageStrings(
         event_data, expected_message, expected_short_message)
 
-    event = events[7]
+    event = events[14]
     event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     expected_message = (
         'Setup online Device Install (Hardware initiated) - SW'
         '\\{97ebaacc-95bd-11d0-a3ea-00a0c9223196}'
-        '\\{53172480-4791-11D0-A5D6-28DB04C10000} '
-        '[SUCCESS 2015-11-22 17:53:48.461 UTC]')
+        '\\{53172480-4791-11D0-A5D6-28DB04C10000} - START')
     expected_short_message = (
-        'Setup online Device Install (Hardware initiated) - SW'
-        '\\{97ebaacc-95bd-11d0-a3e...')
+        'START - Setup online Device Install (Hardware initiated) - SW'
+        '\\{97ebaacc-95bd-...')
     self._TestGetMessageStrings(
         event_data, expected_message, expected_short_message)
 
-    event = events[15]
+    event = events[30]
     event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     self.CheckTimestamp(event.timestamp, '2015-11-22 17:57:17.502000')
 
     expected_message = (
         'Setup Import Driver Package - C:\\Windows\\system32'
-        '\\spool\\tools\\Microsoft XPS Document Writer\\prnms001.Inf '
-        '[SUCCESS 2015-11-22 17:57:17.704 UTC]')
+        '\\spool\\tools\\Microsoft XPS Document Writer\\prnms001.Inf - START')
     expected_short_message = (
-        'Setup Import Driver Package - C:\\Windows\\system32\\spool'
-        '\\tools\\Microsoft XPS D...')
+        'START - Setup Import Driver Package - C:\\Windows\\system32\\spool'
+        '\\tools\\Microso...')
     self._TestGetMessageStrings(
         event_data, expected_message, expected_short_message)
 

--- a/tests/parsers/setupapi.py
+++ b/tests/parsers/setupapi.py
@@ -20,7 +20,7 @@ class SetupapiLogUnitTest(test_lib.ParserTestCase):
   """
 
   def testParseDevLog(self):
-    """Tests the Parse function on dev log."""
+    """Tests the Parse function on setupapi.dev.log."""
     parser = setupapi.SetupapiLogParser()
     storage_writer = self._ParseFile(['setupapi.dev.log'], parser)
 
@@ -73,7 +73,7 @@ class SetupapiLogUnitTest(test_lib.ParserTestCase):
     self._TestGetMessageStrings(event, expected_message, expected_short_message)
 
   def testParseSetupLog(self):
-    """Tests the Parse function on setup log."""
+    """Tests the Parse function on setupapi.setup.log."""
     parser = setupapi.SetupapiLogParser()
     storage_writer = self._ParseFile(['setupapi.setup.log'], parser)
 

--- a/tests/parsers/setupapi.py
+++ b/tests/parsers/setupapi.py
@@ -38,39 +38,46 @@ class SetupapiLogUnitTest(test_lib.ParserTestCase):
     self.CheckTimestamp(event.timestamp, '2016-10-05 11:16:03.747000')
 
     event = events[2]
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     self.CheckTimestamp(event.timestamp, '2016-10-05 11:16:16.471000')
 
     expected_message = (
-        'Description: Device Install (Hardware initiated) - SWD\\IP_TUNNEL_VBUS'
-        '\\Teredo_Tunnel_Device | Exit status: SUCCESS')
+        'Device Install (Hardware initiated) - SWD\\IP_TUNNEL_VBUS'
+        '\\Teredo_Tunnel_Device [SUCCESS 2016-10-05 11:16:26.388 UTC]')
     expected_short_message = (
         'Device Install (Hardware initiated) - SWD\\IP_TUNNEL_VBUS'
         '\\Teredo_Tunnel_Device')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[28]
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
     expected_message = (
-        'Description: Device Install (DiInstallDriver) - C:\\Windows\\System32'
+        'Device Install (DiInstallDriver) - C:\\Windows\\System32'
         '\\DriverStore\\FileRepository\\prnms003.inf_x86_8f17aac186c70ea6'
-        '\\prnms003.inf | Exit status: SUCCESS')
+        '\\prnms003.inf [SUCCESS 2016-10-12 03:36:30.998 UTC]')
     expected_short_message = (
         'Device Install (DiInstallDriver) - C:\\Windows\\System32\\DriverStore'
         '\\FileReposi...')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[193]
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     self.CheckTimestamp(event.timestamp, '2016-11-22 23:50:30.938000')
 
     expected_message = (
-        'Description: Device Install (Hardware initiated) - SWD\\WPDBUSENUM'
+        'Device Install (Hardware initiated) - SWD\\WPDBUSENUM'
         '\\_??_USBSTOR#Disk&Ven_Generic&Prod_Flash_Disk&Rev_8.07#99E2116A&0'
-        '#{53f56307-b6bf-11d0-94f2-00a0c91efb8b} | Exit status: SUCCESS')
+        '#{53f56307-b6bf-11d0-94f2-00a0c91efb8b} '
+        '[SUCCESS 2016-11-22 23:50:58.236 UTC]')
     expected_short_message = (
         'Device Install (Hardware initiated) - SWD\\WPDBUSENUM'
         '\\_??_USBSTOR#Disk&Ven_Gen...')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testParseSetupLog(self):
     """Tests the Parse function on setupapi.setup.log."""
@@ -91,37 +98,45 @@ class SetupapiLogUnitTest(test_lib.ParserTestCase):
     self.CheckTimestamp(event.timestamp, '2015-11-22 17:53:28.973000')
 
     event = events[2]
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     self.CheckTimestamp(event.timestamp, '2015-11-22 17:53:29.305000')
 
     expected_message = (
-        'Description: Setup Plug and Play Device Install '
-        '| Exit status: SUCCESS')
+        'Setup Plug and Play Device Install '
+        '[SUCCESS 2015-11-22 17:53:51.832 UTC]')
     expected_short_message = ('Setup Plug and Play Device Install')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[7]
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
-        'Description: Setup online Device Install (Hardware initiated) - SW'
+        'Setup online Device Install (Hardware initiated) - SW'
         '\\{97ebaacc-95bd-11d0-a3ea-00a0c9223196}'
-        '\\{53172480-4791-11D0-A5D6-28DB04C10000} | Exit status: SUCCESS')
+        '\\{53172480-4791-11D0-A5D6-28DB04C10000} '
+        '[SUCCESS 2015-11-22 17:53:48.461 UTC]')
     expected_short_message = (
         'Setup online Device Install (Hardware initiated) - SW'
         '\\{97ebaacc-95bd-11d0-a3e...')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[15]
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     self.CheckTimestamp(event.timestamp, '2015-11-22 17:57:17.502000')
 
     expected_message = (
-        'Description: Setup Import Driver Package - C:\\Windows\\system32'
+        'Setup Import Driver Package - C:\\Windows\\system32'
         '\\spool\\tools\\Microsoft XPS Document Writer\\prnms001.Inf '
-        '| Exit status: SUCCESS')
+        '[SUCCESS 2015-11-22 17:57:17.704 UTC]')
     expected_short_message = (
         'Setup Import Driver Package - C:\\Windows\\system32\\spool'
         '\\tools\\Microsoft XPS D...')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Initial setupapi parser



## Description:
Initial version of Windows Setupapi log parser
@joachimmetz 

**Related issue (if applicable):** #2549 

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [x] Reviewer assigned
