### PR TITLE
Changed _TestGetMessageStrings tests to use event_data #2684

### DIFF
--- a/plaso/formatters/winlnk.py
+++ b/plaso/formatters/winlnk.py
@@ -44,23 +44,19 @@ class WinLnkLinkFormatter(interface.ConditionalEventFormatter):
       event_data (EventData): event_data data.
 
     Returns:
-      str: linked path.
+      str: linked path or "Unknown" if not set.
     """
-    if hasattr(event_data, 'local_path'):
-      return event_data.local_path
+    linked_path = getattr(event_data, 'local_path', None)
+    if not linked_path:
+      linked_path = getattr(event_data, 'network_path', None)
 
-    if hasattr(event_data, 'network_path'):
-      return event_data.network_path
+    if not linked_path:
+      linked_path = getattr(event_data, 'relative_path', None)
+      working_directory = getattr(event_data, 'working_directory', None)
+      if working_directory:
+        linked_path = '\\'.join([working_directory, linked_path])
 
-    if hasattr(event_data, 'relative_path'):
-      paths = []
-      if hasattr(event_data, 'working_directory'):
-        paths.append(event_data.working_directory)
-      paths.append(event_data.relative_path)
-
-      return '\\'.join(paths)
-
-    return 'Unknown'
+    return linked_path or 'Unknown'
 
   # pylint: disable=unused-argument
   def GetMessages(self, formatter_mediator, event_data):

--- a/tests/parsers/android_app_usage.py
+++ b/tests/parsers/android_app_usage.py
@@ -44,7 +44,8 @@ class AndroidAppUsageParserTest(test_lib.ParserTestCase):
         'Package: com.sec.android.widgetapp.ap.hero.accuweather '
         'Component: com.sec.and...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[17]
 
@@ -62,7 +63,8 @@ class AndroidAppUsageParserTest(test_lib.ParserTestCase):
         'Package: com.google.android.gsf.login '
         'Component: com.google.android.gsf.login...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/apache_access.py
+++ b/tests/parsers/apache_access.py
@@ -58,7 +58,8 @@ class ApacheAccessUnitTest(test_lib.ParserTestCase):
         'GET /wp-content/themes/darkmode/evil.php?cmd=uname+-a HTTP/1.1 from: '
         '192.168.0.2')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test common log format parser event.
     event = events[3]
@@ -84,7 +85,8 @@ class ApacheAccessUnitTest(test_lib.ParserTestCase):
         'GET /wp-content/themes/darkmode/header.php?install2 HTTP/1.1 from: '
         '10.0.0.1')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test the extraction warning.
     warnings = list(storage_writer.GetWarnings())
@@ -125,7 +127,8 @@ class ApacheAccessUnitTest(test_lib.ParserTestCase):
     expected_short_message = (
         'GET /wp-content/themes/darkmode/evil.php HTTP/1.1 from: 192.168.0.2')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/asl.py
+++ b/tests/parsers/asl.py
@@ -74,7 +74,8 @@ class ASLParserTest(test_lib.ParserTestCase):
         'Sender: locationd '
         'Facility: com.apple.locationd')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/bencode_plugins/transmission.py
+++ b/tests/parsers/bencode_plugins/transmission.py
@@ -41,6 +41,8 @@ class BencodeTest(test_lib.BencodePluginTestCase):
     event = events[1]
 
     self.CheckTimestamp(event.timestamp, '2013-11-08 18:24:24.000000')
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_FILE_DOWNLOADED)
 
@@ -52,7 +54,8 @@ class BencodeTest(test_lib.BencodePluginTestCase):
         'Saved to /Users/brian/Downloads; '
         'Minutes seeded: 4')
 
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/bencode_plugins/utorrent.py
+++ b/tests/parsers/bencode_plugins/utorrent.py
@@ -30,9 +30,6 @@ class UTorrentPluginTest(test_lib.BencodePluginTestCase):
     # hence we sort the events.
     events = list(storage_writer.GetSortedEvents())
 
-    expected_caption = 'plaso test'
-    expected_path = 'e:\\torrent\\files\\plaso test'
-
     # First test on when the torrent was added to the client.
     event = events[0]
 
@@ -40,8 +37,8 @@ class UTorrentPluginTest(test_lib.BencodePluginTestCase):
     self.assertEqual(event.timestamp_desc, definitions.TIME_DESCRIPTION_ADDED)
 
     event_data = self._GetEventDataOfEvent(storage_writer, event)
-    self.assertEqual(event_data.caption, expected_caption)
-    self.assertEqual(event_data.path, expected_path)
+    self.assertEqual(event_data.caption, 'plaso test')
+    self.assertEqual(event_data.path, 'e:\\torrent\\files\\plaso test')
     self.assertEqual(event_data.seedtime, 511)
 
     # Second test on when the torrent file was completely downloaded.
@@ -52,8 +49,8 @@ class UTorrentPluginTest(test_lib.BencodePluginTestCase):
         event.timestamp_desc, definitions.TIME_DESCRIPTION_FILE_DOWNLOADED)
 
     event_data = self._GetEventDataOfEvent(storage_writer, event)
-    self.assertEqual(event_data.caption, expected_caption)
-    self.assertEqual(event_data.path, expected_path)
+    self.assertEqual(event_data.caption, 'plaso test')
+    self.assertEqual(event_data.path, 'e:\\torrent\\files\\plaso test')
     self.assertEqual(event_data.seedtime, 511)
 
     # Third test on when the torrent was first modified.
@@ -64,8 +61,8 @@ class UTorrentPluginTest(test_lib.BencodePluginTestCase):
         event.timestamp_desc, definitions.TIME_DESCRIPTION_MODIFICATION)
 
     event_data = self._GetEventDataOfEvent(storage_writer, event)
-    self.assertEqual(event_data.caption, expected_caption)
-    self.assertEqual(event_data.path, expected_path)
+    self.assertEqual(event_data.caption, 'plaso test')
+    self.assertEqual(event_data.path, 'e:\\torrent\\files\\plaso test')
     self.assertEqual(event_data.seedtime, 511)
 
     # Fourth test on when the torrent was again modified.
@@ -76,15 +73,16 @@ class UTorrentPluginTest(test_lib.BencodePluginTestCase):
         event.timestamp_desc, definitions.TIME_DESCRIPTION_MODIFICATION)
 
     event_data = self._GetEventDataOfEvent(storage_writer, event)
-    self.assertEqual(event_data.caption, expected_caption)
-    self.assertEqual(event_data.path, expected_path)
+    self.assertEqual(event_data.caption, 'plaso test')
+    self.assertEqual(event_data.path, 'e:\\torrent\\files\\plaso test')
     self.assertEqual(event_data.seedtime, 511)
 
     expected_message = (
         'Torrent plaso test; Saved to e:\\torrent\\files\\plaso test; '
         'Minutes seeded: 511')
 
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/chrome_cache.py
+++ b/tests/parsers/chrome_cache.py
@@ -36,7 +36,8 @@ class ChromeCacheParserTest(test_lib.ParserTestCase):
 
     expected_message = 'Original URL: {0:s}'.format(expected_original_url)
 
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/chrome_preferences.py
+++ b/tests/parsers/chrome_preferences.py
@@ -29,39 +29,45 @@ class ChromePreferencesParserTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2014-11-12 13:01:43.926143')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = 'Chrome extensions autoupdater last run'
     expected_short_message = 'Chrome extensions autoupdater last run'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[18]
 
     self.CheckTimestamp(event.timestamp, '2014-11-12 18:20:21.519200')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = 'Chrome extensions autoupdater next run'
     expected_short_message = 'Chrome extensions autoupdater next run'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[22]
 
     self.CheckTimestamp(event.timestamp, '2016-06-08 16:17:47.453766')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = 'Chrome history was cleared by user'
     expected_short_message = 'Chrome history was cleared by user'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[6]
+
+    self.CheckTimestamp(event.timestamp, '2014-11-05 18:31:24.154837')
 
     event_data = self._GetEventDataOfEvent(storage_writer, event)
     self.assertEqual(
         event_data.data_type, 'chrome:preferences:extension_installation')
-
-    self.CheckTimestamp(event.timestamp, '2014-11-05 18:31:24.154837')
-
-    expected_id = 'mgndgikekgjfcpckkfioiadnlibdjbkf'
-    self.assertEqual(event_data.extension_id, expected_id)
-
-    expected_name = 'Chrome'
-    self.assertEqual(event_data.extension_name, expected_name)
+    self.assertEqual(
+        event_data.extension_id, 'mgndgikekgjfcpckkfioiadnlibdjbkf')
+    self.assertEqual(event_data.extension_name, 'Chrome')
 
     expected_path = (
         'C:\\Program Files\\Google\\Chrome\\Application\\38.0.2125.111\\'
@@ -69,62 +75,81 @@ class ChromePreferencesParserTest(test_lib.ParserTestCase):
     self.assertEqual(event_data.path, expected_path)
 
     expected_message = (
-        'CRX ID: {0:s} CRX Name: {1:s} Path: {2:s}'.format(
-            expected_id, expected_name, expected_path))
+        'CRX ID: mgndgikekgjfcpckkfioiadnlibdjbkf '
+        'CRX Name: Chrome '
+        'Path: {0:s}'.format(expected_path))
     expected_short_message = (
-        '{0:s} '
-        'C:\\Program Files\\Google\\Chrome\\Application\\3...').format(
-            expected_id)
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+        'mgndgikekgjfcpckkfioiadnlibdjbkf '
+        'C:\\Program Files\\Google\\Chrome\\Application\\3...')
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[25]
 
     self.CheckTimestamp(event.timestamp, '2016-11-14 14:12:50.588974')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = 'Permission geolocation used by local file'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[23]
 
     self.CheckTimestamp(event.timestamp, '2016-11-11 16:20:09.866137')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'Permission midi_sysex used by https://rawgit.com:443')
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[29]
 
     self.CheckTimestamp(event.timestamp, '2016-11-14 14:13:00.639332')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'Permission notifications used by https://rawgit.com:443')
     expected_short_message = (
         'Permission notifications used by https://rawgit.com:443')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[28]
 
     self.CheckTimestamp(event.timestamp, '2016-11-14 14:13:00.627093')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'Permission notifications used by https://rawgit.com:443')
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[27]
 
     self.CheckTimestamp(event.timestamp, '2016-11-14 14:12:54.899474')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'Permission media_stream_mic used by local file')
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[26]
 
     self.CheckTimestamp(event.timestamp, '2016-11-14 14:12:53.667838')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'Permission media_stream_mic used by https://rawgit.com:443')
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/cookie_plugins/ganalytics.py
+++ b/tests/parsers/cookie_plugins/ganalytics.py
@@ -61,7 +61,8 @@ class GoogleAnalyticsPluginTest(sqlite_plugins_test_lib.SQLitePluginTestCase):
         'maelt_med_kerfisbundnum_hydingum/')
     expected_short_message = 'http://ads.aha.is/ (__utmz)'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testParsingChromeCookieDatabase(self):
     """Test the process function on a Chrome cookie database."""
@@ -92,7 +93,8 @@ class GoogleAnalyticsPluginTest(sqlite_plugins_test_lib.SQLitePluginTestCase):
         'used to find site: enders game')
     expected_short_message = 'http://imdb.com/ (__utmz)'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Check the UTMA Google Analytics event.
     event = events[41]
@@ -112,7 +114,8 @@ class GoogleAnalyticsPluginTest(sqlite_plugins_test_lib.SQLitePluginTestCase):
         'Visitor ID: 1827102436')
     expected_short_message = 'http://assets.tumblr.com/ (__utma)'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Check the UTMB Google Analytics event.
     event = events[34]
@@ -131,7 +134,8 @@ class GoogleAnalyticsPluginTest(sqlite_plugins_test_lib.SQLitePluginTestCase):
         '154523900')
     expected_short_message = 'http://upressonline.com/ (__utmb)'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/cups_ipp.py
+++ b/tests/parsers/cups_ipp.py
@@ -330,7 +330,8 @@ class CupsIppParserTest(test_lib.ParserTestCase):
         'Application: LibreOffice '
         'Printer: RHULBW')
     expected_short_message = 'Job Name: Assignament 1'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[1]
 

--- a/tests/parsers/custom_destinations.py
+++ b/tests/parsers/custom_destinations.py
@@ -49,6 +49,8 @@ class CustomDestinationsParserTest(test_lib.ParserTestCase):
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_MODIFICATION)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         '[@%systemroot%\\system32\\oobefldr.dll,-1262] '
         'File size: 11776 '
@@ -66,12 +68,15 @@ class CustomDestinationsParserTest(test_lib.ParserTestCase):
         '[@%systemroot%\\system32\\oobefldr.dll,-1262] '
         'C:\\Windows\\System32\\GettingStarte...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # A shell item event.
     event = events[18]
 
     self.CheckTimestamp(event.timestamp, '2010-11-10 07:41:04.000000')
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     expected_message = (
         'Name: System32 '
@@ -85,12 +90,15 @@ class CustomDestinationsParserTest(test_lib.ParserTestCase):
         'NTFS file reference: 2331-1 '
         'Origin: 5afe4de1b92fc382.customDes...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # A distributed link tracking event.
     event = events[12]
 
     self.CheckTimestamp(event.timestamp, '2010-11-10 19:08:32.656260')
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     expected_message = (
         'e9215b24-ecfd-11df-a81c-000c29031e1e '
@@ -101,7 +109,8 @@ class CustomDestinationsParserTest(test_lib.ParserTestCase):
         'e9215b24-ecfd-11df-a81c-000c29031e1e '
         'Origin: 5afe4de1b92fc382.customDestinati...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/czip_plugins/oxml.py
+++ b/tests/parsers/czip_plugins/oxml.py
@@ -160,7 +160,8 @@ class OXMLTest(test_lib.CompoundZIPPluginTestCase):
     expected_short_message = (
         'Author: Nides')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/docker.py
+++ b/tests/parsers/docker.py
@@ -61,12 +61,12 @@ class DockerJSONUnitTest(test_lib.ParserTestCase):
       self.CheckTimestamp(event.timestamp, expected_times[index])
 
       event_data = self._GetEventDataOfEvent(storage_writer, event)
-
       self.assertEqual(event_data.container_id, container_identifier)
       self.assertEqual(event_data.log_line, expected_log)
       self.assertEqual(event_data.log_source, 'stdout')
+
       self._TestGetMessageStrings(
-          event, expected_message, expected_short_message)
+          event_data, expected_message, expected_short_message)
 
   def testParseContainerConfig(self):
     """Tests the _ParseContainerConfigJSON function."""

--- a/tests/parsers/esedb_plugins/file_history.py
+++ b/tests/parsers/esedb_plugins/file_history.py
@@ -49,7 +49,8 @@ class FileHistoryESEDBPluginTest(test_lib.ESEDBPluginTestCase):
 
     expected_short_message = 'Filename: {0:s}'.format(filename)
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/esedb_plugins/msie_webcache.py
+++ b/tests/parsers/esedb_plugins/msie_webcache.py
@@ -49,7 +49,8 @@ class MsieWebCacheESEDBPluginTest(test_lib.ESEDBPluginTestCase):
         'Directory: C:\\Users\\test\\AppData\\Local\\Microsoft\\Windows\\'
         'INetCache\\IE\\')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/esedb_plugins/srum.py
+++ b/tests/parsers/esedb_plugins/srum.py
@@ -53,7 +53,8 @@ class SystemResourceUsageMonitorESEDBPluginTest(test_lib.ESEDBPluginTestCase):
 
     expected_short_message = 'Memory Compression'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test event with data type windows:srum:network_connectivity
     event = events[0]
@@ -71,7 +72,8 @@ class SystemResourceUsageMonitorESEDBPluginTest(test_lib.ESEDBPluginTestCase):
 
     expected_short_message = '1'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test event with data type windows:srum:network_usage
     event = events[14]
@@ -91,7 +93,8 @@ class SystemResourceUsageMonitorESEDBPluginTest(test_lib.ESEDBPluginTestCase):
 
     expected_short_message = 'DiagTrack'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/filestat.py
+++ b/tests/parsers/filestat.py
@@ -55,7 +55,8 @@ class FileStatTest(test_lib.ParserTestCase):
         'TSK:/passwords.txt '
         'Type: file')
     expected_short_message = '/passwords.txt'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testZipFile(self):
     """Test a ZIP file."""
@@ -91,7 +92,8 @@ class FileStatTest(test_lib.ParserTestCase):
         'ZIP:/syslog '
         'Type: file')
     expected_short_message = '/syslog'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testGzipFile(self):
     """Test a GZIP file."""
@@ -127,7 +129,8 @@ class FileStatTest(test_lib.ParserTestCase):
         'GZIP:{0:s} '
         'Type: file').format(test_path)
     expected_short_message = self._GetShortMessage(test_path)
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testTarFile(self):
     """Test a TAR file."""
@@ -163,7 +166,8 @@ class FileStatTest(test_lib.ParserTestCase):
         'TAR:/syslog '
         'Type: file')
     expected_short_message = '/syslog'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testNestedFile(self):
     """Test a nested file."""
@@ -201,7 +205,8 @@ class FileStatTest(test_lib.ParserTestCase):
         'TAR:/syslog '
         'Type: file')
     expected_short_message = '/syslog'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     test_file_path = self._GetTestFilePath(['syslog.tgz'])
     self._SkipIfPathNotExists(test_file_path)
@@ -233,7 +238,8 @@ class FileStatTest(test_lib.ParserTestCase):
         'GZIP:{0:s} '
         'Type: file').format(test_path)
     expected_short_message = self._GetShortMessage(test_path)
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testNestedTSK(self):
     """Test a nested TSK file."""
@@ -272,7 +278,8 @@ class FileStatTest(test_lib.ParserTestCase):
         'ZIP:/syslog '
         'Type: file')
     expected_short_message = '/syslog'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/firefox_cache.py
+++ b/tests/parsers/firefox_cache.py
@@ -52,7 +52,7 @@ class FirefoxCacheParserTest(test_lib.ParserTestCase):
         '"HTTP:http://start.ubuntu.com/12.04/sprite.png"')
 
     self._TestGetMessageStrings(
-        event, expected_message, expected_short_message)
+        event_data, expected_message, expected_short_message)
 
     for event in events:
       event_data = self._GetEventDataOfEvent(storage_writer, event)
@@ -140,6 +140,8 @@ class FirefoxCacheParserTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2014-05-02 14:15:03.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'Fetched 1 time(s) '
         '[HTTP/1.1 200 OK] GET '
@@ -149,7 +151,7 @@ class FirefoxCacheParserTest(test_lib.ParserTestCase):
         '"HTTP:http://start.mozilla.org/en-US/"')
 
     self._TestGetMessageStrings(
-        event, expected_message, expected_short_message)
+        event_data, expected_message, expected_short_message)
 
   def testParseLegacyCache_002(self):
     """Test Firefox 3 cache file _CACHE_002_ parsing."""

--- a/tests/parsers/fseventsd.py
+++ b/tests/parsers/fseventsd.py
@@ -57,7 +57,8 @@ class FSEventsdParserTest(test_lib.ParserTestCase):
         'Flags: 0x01000080 Event Identifier: 47747061')
     expected_short_message = (
         '.Spotlight-V100/Store-V1 DirectoryCreated, IsDirectory')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testParseV2(self):
     """Tests the Parse function on a version 2 file."""
@@ -96,7 +97,8 @@ class FSEventsdParserTest(test_lib.ParserTestCase):
         'Flags: 0x01000008 '
         'Event Identifier: 1706838')
     expected_short_message = 'Hi, Sierra Renamed, IsDirectory'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/gdrive_synclog.py
+++ b/tests/parsers/gdrive_synclog.py
@@ -37,14 +37,20 @@ class GoogleDriveSyncLogUnitTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2018-01-25 02:25:08.456000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         '[INFO pid=2376 7780:MainThread logging_config.py:299]  SSL: OpenSSL '
         '1.0.2m  2 Nov 2017')
     expected_short_message = (
         ' SSL: OpenSSL 1.0.2m  2 Nov 2017')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[30]
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         '[INFO pid=2376 6560:RunAsync-_InitializeSyncAppAsync-1 persistence.'
         'py:38]  Initialize factory with policy PlatformPolicy('
@@ -54,11 +60,14 @@ class GoogleDriveSyncLogUnitTest(test_lib.ParserTestCase):
     expected_short_message = (
         ' Initialize factory with policy '
         'PlatformPolicy(google_drive_config_directory_...')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[82]
 
     self.CheckTimestamp(event.timestamp, '2018-01-25 02:25:18.563000')
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     expected_message = (
         '[INFO pid=2376 5712:ExternalBrowserFlow proxy_manager.py:141]  '
@@ -73,7 +82,8 @@ class GoogleDriveSyncLogUnitTest(test_lib.ParserTestCase):
     expected_short_message = (
         ' Exception while auto resolving proxy. Traceback (most recent call '
         'last):   F...')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testOSXParseLog(self):
     """Tests the Parse function on OS X log.
@@ -91,11 +101,15 @@ class GoogleDriveSyncLogUnitTest(test_lib.ParserTestCase):
     event = events[0]
 
     self.CheckTimestamp(event.timestamp, '2018-03-01 20:48:14.224000')
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         '[INFO pid=1730 140736280556352:MainThread logging_config.pyo:295]  '
         'OS: Darwin/10.13.3')
     expected_short_message = ' OS: Darwin/10.13.3'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Log file contains a change in local system time from -0800 to UTC, around
     # line 215. Confirm the switch is handled correctly.
@@ -103,14 +117,19 @@ class GoogleDriveSyncLogUnitTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2018-03-01 20:57:33.499000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         '[INFO pid=2590 140736280556352:MainThread logging_config.pyo:299]  SSL'
         ': OpenSSL 1.0.2n  7 Dec 2017')
     expected_short_message = ' SSL: OpenSSL 1.0.2n  7 Dec 2017'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Ensure Unicode characters in filenames are handled cleanly.
     event = events[1400]
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     expected_message = (
         '[INFO pid=2608 123145558327296:Worker-1 snapshot_sqlite.pyo:219]  '
@@ -121,7 +140,8 @@ class GoogleDriveSyncLogUnitTest(test_lib.ParserTestCase):
     expected_short_message = (
         ' Updating local entry local_id=LocalID(inode=870321, '
         'volume=\'60228B87-A626-4F...')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/iis.py
+++ b/tests/parsers/iis.py
@@ -44,7 +44,8 @@ class WinIISUnitTest(test_lib.ParserTestCase):
         'GET /some/image/path/something.jpg '
         '[ 10.10.10.100 > 10.10.10.100 : 80 ]')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[5]
 
@@ -58,6 +59,8 @@ class WinIISUnitTest(test_lib.ParserTestCase):
 
     event = events[1]
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'GET /some/image/path/something.htm '
         '[ 22.22.22.200 > 10.10.10.100 : 80 ] '
@@ -69,7 +72,8 @@ class WinIISUnitTest(test_lib.ParserTestCase):
         'GET /some/image/path/something.htm '
         '[ 22.22.22.200 > 10.10.10.100 : 80 ]')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[11]
     event_data = self._GetEventDataOfEvent(storage_writer, event)

--- a/tests/parsers/mac_appfirewall.py
+++ b/tests/parsers/mac_appfirewall.py
@@ -49,7 +49,8 @@ class MacAppFirewallUnitTest(test_lib.ParserTestCase):
         'Process name: Logging '
         'Status: Error')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[9]
 
@@ -72,7 +73,8 @@ class MacAppFirewallUnitTest(test_lib.ParserTestCase):
         'Process name: Dropbox '
         'Status: Info')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Check repeated lines.
     event = events[38]

--- a/tests/parsers/mac_keychain.py
+++ b/tests/parsers/mac_keychain.py
@@ -40,7 +40,8 @@ class MacKeychainParserTest(test_lib.ParserTestCase):
     self.assertEqual(event_data.ssgp_hash, expected_ssgp)
     expected_message = 'Name: Secret Application Account: moxilo'
     expected_short_message = 'Secret Application'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[1]
 
@@ -60,7 +61,8 @@ class MacKeychainParserTest(test_lib.ParserTestCase):
     self.assertEqual(len(event_data.ssgp_hash), 1696)
     expected_message = 'Name: Secret Note'
     expected_short_message = 'Secret Note'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[4]
 
@@ -82,7 +84,8 @@ class MacKeychainParserTest(test_lib.ParserTestCase):
         'Where: plaso.kiddaland.net '
         'Protocol: http (dflt)')
     expected_short_message = 'plaso.kiddaland.net'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/mac_securityd.py
+++ b/tests/parsers/mac_securityd.py
@@ -53,7 +53,8 @@ class MacOSSecurityUnitTest(test_lib.ParserTestCase):
     expected_short_message = (
         'Text: securityd_xpc_dictionary_handler '
         'EscrowSecurityAl[3273] DeviceInCircle ...')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[1]
 

--- a/tests/parsers/mac_wifi.py
+++ b/tests/parsers/mac_wifi.py
@@ -94,7 +94,8 @@ class MacWifiUnitTest(test_lib.ParserTestCase):
     expected_short_message = (
         'Action: Interface en0 turn up.')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[2]
 

--- a/tests/parsers/mactime.py
+++ b/tests/parsers/mactime.py
@@ -62,7 +62,8 @@ class MactimeTest(test_lib.ParserTestCase):
     self.assertEqual(event_data.filename, expected_filename)
     self.assertEqual(event_data.mode_as_string, 'r/rrw-------')
 
-    self._TestGetMessageStrings(event, expected_filename, expected_filename)
+    self._TestGetMessageStrings(
+        event_data, expected_filename, expected_filename)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/mcafeeav.py
+++ b/tests/parsers/mcafeeav.py
@@ -62,7 +62,8 @@ class McafeeAccessProtectionUnitTest(test_lib.ParserTestCase):
         'C:\\Windows\\System32\\procexp64.exe '
         'Action blocked : Terminate')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/msiecf.py
+++ b/tests/parsers/msiecf.py
@@ -85,7 +85,8 @@ class MSIECFParserTest(test_lib.ParserTestCase):
         'Location: Visited: testing@http://www.trafficfusionx.com/download'
         '/tfscrn2/fun...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testParseLeakAndRedirect(self):
     """Tests the Parse function with leak and redirected records."""
@@ -126,7 +127,8 @@ class MSIECFParserTest(test_lib.ParserTestCase):
         'Location: http://col.stc.s-msn.com/br/gbl/lg/csl/favicon.ico '
         'Cached file: R6Q...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[21]
     expected_url = (
@@ -153,7 +155,8 @@ class MSIECFParserTest(test_lib.ParserTestCase):
     expected_short_message = (
         'Cached file: VUQHQA73\\ADSAdClient31[1].htm')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[21]
     self.assertEqual(event.timestamp, 0)
@@ -173,7 +176,8 @@ class MSIECFParserTest(test_lib.ParserTestCase):
         'Location: http://ad.doubleclick.net/ad/N2724.Meebo/B5343067.13;'
         'sz=1x1;pc=[TPA...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/ntfs.py
+++ b/tests/parsers/ntfs.py
@@ -43,6 +43,8 @@ class NTFSMFTParserTest(test_lib.ParserTestCase):
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_CREATION)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         '9fe44b69-2709-11dc-a06b-db3099beae3c '
         'MAC address: db:30:99:be:ae:3c '
@@ -52,7 +54,8 @@ class NTFSMFTParserTest(test_lib.ParserTestCase):
         '9fe44b69-2709-11dc-a06b-db3099beae3c '
         'Origin: $MFT: 462-1')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testParseImage(self):
     """Tests the Parse function on a storage media image."""
@@ -79,50 +82,50 @@ class NTFSMFTParserTest(test_lib.ParserTestCase):
     # The creation timestamp.
     event = events[0]
 
-    event_data = self._GetEventDataOfEvent(storage_writer, event)
-    # Check that the allocation status is set correctly.
-    self.assertIsInstance(event_data.is_allocated, bool)
-    self.assertTrue(event_data.is_allocated)
-
     self.CheckTimestamp(event.timestamp, '2013-12-03 06:30:41.807908')
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_CREATION)
 
-    # The last modification timestamp.
-    event = events[1]
-
     event_data = self._GetEventDataOfEvent(storage_writer, event)
     # Check that the allocation status is set correctly.
     self.assertIsInstance(event_data.is_allocated, bool)
     self.assertTrue(event_data.is_allocated)
+
+    # The last modification timestamp.
+    event = events[1]
 
     self.CheckTimestamp(event.timestamp, '2013-12-03 06:30:41.807908')
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_MODIFICATION)
 
-    # The last accessed timestamp.
-    event = events[2]
-
     event_data = self._GetEventDataOfEvent(storage_writer, event)
     # Check that the allocation status is set correctly.
     self.assertIsInstance(event_data.is_allocated, bool)
     self.assertTrue(event_data.is_allocated)
+
+    # The last accessed timestamp.
+    event = events[2]
 
     self.CheckTimestamp(event.timestamp, '2013-12-03 06:30:41.807908')
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_LAST_ACCESS)
 
-    # The entry modification timestamp.
-    event = events[3]
-
     event_data = self._GetEventDataOfEvent(storage_writer, event)
     # Check that the allocation status is set correctly.
     self.assertIsInstance(event_data.is_allocated, bool)
     self.assertTrue(event_data.is_allocated)
 
+    # The entry modification timestamp.
+    event = events[3]
+
     self.CheckTimestamp(event.timestamp, '2013-12-03 06:30:41.807908')
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_ENTRY_MODIFICATION)
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+    # Check that the allocation status is set correctly.
+    self.assertIsInstance(event_data.is_allocated, bool)
+    self.assertTrue(event_data.is_allocated)
 
     expected_message = (
         'TSK:/$MFT '
@@ -132,19 +135,20 @@ class NTFSMFTParserTest(test_lib.ParserTestCase):
     expected_short_message = (
         '/$MFT 0-1 $STANDARD_INFORMATION')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # The creation timestamp.
     event = events[4]
+
+    self.CheckTimestamp(event.timestamp, '2013-12-03 06:30:41.807908')
+    self.assertEqual(
+        event.timestamp_desc, definitions.TIME_DESCRIPTION_CREATION)
 
     event_data = self._GetEventDataOfEvent(storage_writer, event)
     # Check that the allocation status is set correctly.
     self.assertIsInstance(event_data.is_allocated, bool)
     self.assertTrue(event_data.is_allocated)
-
-    self.CheckTimestamp(event.timestamp, '2013-12-03 06:30:41.807908')
-    self.assertEqual(
-        event.timestamp_desc, definitions.TIME_DESCRIPTION_CREATION)
 
     expected_message = (
         'TSK:/$MFT '
@@ -156,7 +160,8 @@ class NTFSMFTParserTest(test_lib.ParserTestCase):
     expected_short_message = (
         '/$MFT 0-1 $FILE_NAME')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Note that the source file is a RAW (VMDK flat) image.
     test_file_path = self._GetTestFilePath(['multi_partition_image.vmdk'])
@@ -210,6 +215,8 @@ class NTFSUsnJrnlParser(test_lib.ParserTestCase):
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_ENTRY_MODIFICATION)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'Nieuw - Tekstdocument.txt '
         'File reference: 30-1 '
@@ -219,7 +226,8 @@ class NTFSUsnJrnlParser(test_lib.ParserTestCase):
     expected_short_message = (
         'Nieuw - Tekstdocument.txt 30-1 USN_REASON_FILE_CREATE')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/olecf_plugins/automatic_destinations.py
+++ b/tests/parsers/olecf_plugins/automatic_destinations.py
@@ -40,8 +40,8 @@ class TestAutomaticDestinationsOLECFPlugin(test_lib.OLECFPluginTestCase):
         event.timestamp_desc, definitions.TIME_DESCRIPTION_MODIFICATION)
 
     event_data = self._GetEventDataOfEvent(storage_writer, event)
-    self.assertEqual(event_data.offset, 32)
     self.assertEqual(event_data.data_type, 'olecf:dest_list:entry')
+    self.assertEqual(event_data.offset, 32)
     self.assertEqual(event_data.pin_status, -1)
 
     expected_message = (
@@ -61,15 +61,15 @@ class TestAutomaticDestinationsOLECFPlugin(test_lib.OLECFPluginTestCase):
         'Path: C:\\Users\\nfury\\Pictures\\The SHIELD')
 
     self._TestGetMessageStrings(
-        event, expected_message, expected_short_message)
+        event_data, expected_message, expected_short_message)
 
     # Check a WinLnkLinkEvent.
     event = events[1]
 
+    self.CheckTimestamp(event.timestamp, '2010-11-10 07:51:16.749125')
+
     event_data = self._GetEventDataOfEvent(storage_writer, event)
     self.assertEqual(event_data.data_type, 'windows:lnk:link')
-
-    self.CheckTimestamp(event.timestamp, '2010-11-10 07:51:16.749125')
 
     expected_message = (
         '[Empty description] '
@@ -86,16 +86,16 @@ class TestAutomaticDestinationsOLECFPlugin(test_lib.OLECFPluginTestCase):
         'C:\\Users\\nfury\\AppData\\Roaming\\Microsoft\\Windows\\Librarie...')
 
     self._TestGetMessageStrings(
-        event, expected_message, expected_short_message)
+        event_data, expected_message, expected_short_message)
 
     # Check a WindowsDistributedLinkTrackingCreationEvent.
     event = events[5]
 
+    self.CheckTimestamp(event.timestamp, '2012-03-31 23:01:03.527742')
+
     event_data = self._GetEventDataOfEvent(storage_writer, event)
     self.assertEqual(
         event_data.data_type, 'windows:distributed_link_tracking:creation')
-
-    self.CheckTimestamp(event.timestamp, '2012-03-31 23:01:03.527742')
 
     expected_message = (
         '63eea867-7b85-11e1-8950-005056a50b40 '
@@ -107,7 +107,7 @@ class TestAutomaticDestinationsOLECFPlugin(test_lib.OLECFPluginTestCase):
         'Origin: DestList entry at offset: 0x0000...')
 
     self._TestGetMessageStrings(
-        event, expected_message, expected_short_message)
+        event_data, expected_message, expected_short_message)
 
   def testProcessVersion3(self):
     """Tests the Process function on version 3 .automaticDestinations-ms."""
@@ -134,8 +134,8 @@ class TestAutomaticDestinationsOLECFPlugin(test_lib.OLECFPluginTestCase):
         event.timestamp_desc, definitions.TIME_DESCRIPTION_MODIFICATION)
 
     event_data = self._GetEventDataOfEvent(storage_writer, event)
-    self.assertEqual(event_data.offset, 32)
     self.assertEqual(event_data.data_type, 'olecf:dest_list:entry')
+    self.assertEqual(event_data.offset, 32)
     self.assertEqual(event_data.pin_status, -1)
 
     expected_message = (
@@ -153,7 +153,8 @@ class TestAutomaticDestinationsOLECFPlugin(test_lib.OLECFPluginTestCase):
         'Pin status: Unpinned '
         'Path: http://support.microsoft.com/kb/3124263')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Check a WinLnkLinkEvent.
     event = events[0]

--- a/tests/parsers/olecf_plugins/default.py
+++ b/tests/parsers/olecf_plugins/default.py
@@ -39,15 +39,19 @@ class TestDefaultPluginOLECF(test_lib.OLECFPluginTestCase):
     expected_string = (
         'Name: Root Entry')
 
-    self._TestGetMessageStrings(event, expected_string, expected_string)
+    self._TestGetMessageStrings(
+        event_data, expected_string, expected_string)
 
     # Check one other entry.
     event = events[1]
 
     self.CheckTimestamp(event.timestamp, '2013-05-16 02:29:49.704000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_string = 'Name: MsoDataStore'
-    self._TestGetMessageStrings(event, expected_string, expected_string)
+    self._TestGetMessageStrings(
+        event_data, expected_string, expected_string)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/olecf_plugins/summary.py
+++ b/tests/parsers/olecf_plugins/summary.py
@@ -61,7 +61,8 @@ class TestSummaryInformationOLECFPlugin(test_lib.OLECFPluginTestCase):
     # TODO: add support for:
     #    'Total edit time (secs): 0 '
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 class TestDocumentSummaryInformationOLECFPlugin(test_lib.OLECFPluginTestCase):
@@ -100,7 +101,8 @@ class TestDocumentSummaryInformationOLECFPlugin(test_lib.OLECFPluginTestCase):
     expected_short_message = (
         'Company: KPMG')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/opera.py
+++ b/tests/parsers/opera.py
@@ -34,7 +34,8 @@ class OperaTypedParserTest(test_lib.ParserTestCase):
 
     expected_string = 'plaso.kiddaland.net (Filled from autocomplete.)'
 
-    self._TestGetMessageStrings(event, expected_string, expected_string)
+    self._TestGetMessageStrings(
+        event_data, expected_string, expected_string)
 
     event = events[3]
 
@@ -45,7 +46,8 @@ class OperaTypedParserTest(test_lib.ParserTestCase):
 
     expected_string = 'theonion.com (Manually typed.)'
 
-    self._TestGetMessageStrings(event, expected_string, expected_string)
+    self._TestGetMessageStrings(
+        event_data, expected_string, expected_string)
 
 
 class OperaGlobalParserTest(test_lib.ParserTestCase):
@@ -65,6 +67,8 @@ class OperaGlobalParserTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2013-11-11 22:45:46.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'http://www.mbl.is/frettir/erlent/2013/11/11/'
         'karl_bretaprins_faer_ellilifeyri/ (Karl Bretaprins fær ellilífeyri'
@@ -73,7 +77,8 @@ class OperaGlobalParserTest(test_lib.ParserTestCase):
         'http://www.mbl.is/frettir/erlent/2013/11/11/'
         'karl_bretaprins_faer_ellilifeyri/...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[10]
 
@@ -82,6 +87,8 @@ class OperaGlobalParserTest(test_lib.ParserTestCase):
     event = events[16]
 
     self.CheckTimestamp(event.timestamp, '2013-11-11 22:46:16.000000')
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     expected_title = (
         '10 Celebrities You Never Knew Were Abducted And Murdered '

--- a/tests/parsers/plist_plugins/airport.py
+++ b/tests/parsers/plist_plugins/airport.py
@@ -49,7 +49,8 @@ class AirportPluginTest(test_lib.PlistPluginTestCase):
     expected_message = '/RememberedNetworks/item {0:s}'.format(
         expected_description)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/plist_plugins/appleaccount.py
+++ b/tests/parsers/plist_plugins/appleaccount.py
@@ -51,7 +51,8 @@ class AppleAccountPluginTest(test_lib.PlistPluginTestCase):
     expected_message = '/Accounts/email@domain.com {0:s}'.format(
         expected_description)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[1]
 

--- a/tests/parsers/plist_plugins/bluetooth.py
+++ b/tests/parsers/plist_plugins/bluetooth.py
@@ -66,12 +66,15 @@ class TestBluetoothPlugin(test_lib.PlistPluginTestCase):
 
     event = events[10]
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_string = (
         '/DeviceCache/44-00-00-00-00-04 '
         'Paired:True '
         'Name:Apple Magic Trackpad 2')
 
-    self._TestGetMessageStrings(event, expected_string, expected_string)
+    self._TestGetMessageStrings(
+        event_data, expected_string, expected_string)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/plist_plugins/default.py
+++ b/tests/parsers/plist_plugins/default.py
@@ -48,7 +48,8 @@ class TestDefaultPlist(test_lib.PlistPluginTestCase):
     expected_string = (
         '/DE-00-AD-00-BE-EF/LastUsed')
 
-    self._TestGetMessageStrings(event, expected_string, expected_string)
+    self._TestGetMessageStrings(
+        event_data, expected_string, expected_string)
 
   def testProcessMulti(self):
     """Tests Process on a plist containing five keys with date values."""

--- a/tests/parsers/plist_plugins/install_history.py
+++ b/tests/parsers/plist_plugins/install_history.py
@@ -58,7 +58,8 @@ class InstallHistoryPluginTest(test_lib.PlistPluginTestCase):
 
     expected_message = '/item/ {0:s}'.format(expected_description)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/plist_plugins/ipod.py
+++ b/tests/parsers/plist_plugins/ipod.py
@@ -41,17 +41,6 @@ class TestIPodPlugin(test_lib.PlistPluginTestCase):
     event = events[2]
 
     self.CheckTimestamp(event.timestamp, '2013-10-09 19:27:54.000000')
-
-    expected_message = (
-        'Device ID: 4C6F6F6E65000000 '
-        'Type: iPhone [10016] '
-        'Connected 1 times '
-        'Serial nr: 526F676572 '
-        'IMEI [012345678901234]')
-    expected_short_message = '{0:s}...'.format(expected_message[:77])
-
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
-
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_LAST_CONNECTED)
 
@@ -61,6 +50,17 @@ class TestIPodPlugin(test_lib.PlistPluginTestCase):
     self.assertEqual(event_data.firmware_version, 256)
     self.assertEqual(event_data.imei, '012345678901234')
     self.assertEqual(event_data.use_count, 1)
+
+    expected_message = (
+        'Device ID: 4C6F6F6E65000000 '
+        'Type: iPhone [10016] '
+        'Connected 1 times '
+        'Serial nr: 526F676572 '
+        'IMEI [012345678901234]')
+    expected_short_message = '{0:s}...'.format(expected_message[:77])
+
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/plist_plugins/macuser.py
+++ b/tests/parsers/plist_plugins/macuser.py
@@ -50,7 +50,8 @@ class MacUserPluginTest(test_lib.PlistPluginTestCase):
 
     expected_string = '//passwordLastSetTime {}'.format(expected_description)
     expected_short = '{0:s}...'.format(expected_string[:77])
-    self._TestGetMessageStrings(event, expected_string, expected_short)
+    self._TestGetMessageStrings(
+        event_data, expected_string, expected_short)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/plist_plugins/safari.py
+++ b/tests/parsers/plist_plugins/safari.py
@@ -45,7 +45,8 @@ class SafariPluginTest(test_lib.PlistPluginTestCase):
         'Visited: {0:s} (Am\xedn\xf3s\xfdrur ) '
         'Visit Count: 1').format(expected_url)
 
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/plist_plugins/softwareupdate.py
+++ b/tests/parsers/plist_plugins/softwareupdate.py
@@ -47,8 +47,10 @@ class SoftwareUpdatePluginTest(test_lib.PlistPluginTestCase):
     self.assertEqual(event_data.root, '/')
     expected_description = 'Last MacOS 10.9.1 (13B42) full update.'
     self.assertEqual(event_data.desc, expected_description)
+
     expected_string = '// {0:s}'.format(expected_description)
-    self._TestGetMessageStrings(event, expected_string, expected_string)
+    self._TestGetMessageStrings(
+        event_data, expected_string, expected_string)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/plist_plugins/spotlight.py
+++ b/tests/parsers/plist_plugins/spotlight.py
@@ -51,7 +51,8 @@ class SpotlightPluginTest(test_lib.PlistPluginTestCase):
 
     expected_message = '/UserShortcuts/gr {0:s}'.format(expected_description)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/plist_plugins/spotlight_volume.py
+++ b/tests/parsers/plist_plugins/spotlight_volume.py
@@ -48,7 +48,8 @@ class SpotlightVolumePluginTest(test_lib.PlistPluginTestCase):
 
     expected_message = '/Stores/ {0:s}'.format(expected_description)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/plist_plugins/timemachine.py
+++ b/tests/parsers/plist_plugins/timemachine.py
@@ -53,7 +53,8 @@ class TimeMachinePluginTest(test_lib.PlistPluginTestCase):
     expected_message = '/Destinations/item/SnapshotDates {0:s}'.format(
         expected_description)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/pls_recall.py
+++ b/tests/parsers/pls_recall.py
@@ -46,7 +46,8 @@ class PlsRecallTest(test_lib.ParserTestCase):
 
     expected_short_message = '206 tsltmp DB11 {0:s}'.format(expected_query)
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/popcontest.py
+++ b/tests/parsers/popcontest.py
@@ -31,11 +31,14 @@ class PopularityContestUnitTest(test_lib.ParserTestCase):
     self.CheckTimestamp(event.timestamp, '2010-06-22 05:41:41.000000')
     self.assertEqual(event.timestamp_desc, definitions.TIME_DESCRIPTION_ADDED)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'Session 0 start '
         'ID 12345678901234567890123456789012 [ARCH:i386 POPCONVER:1.38]')
     expected_short_message = 'Session 0 start'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[1]
 
@@ -43,9 +46,12 @@ class PopularityContestUnitTest(test_lib.ParserTestCase):
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_LAST_ACCESS)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = 'mru [/usr/sbin/atd] package [at]'
     expected_short_message = '/usr/sbin/atd'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[3]
 
@@ -53,11 +59,14 @@ class PopularityContestUnitTest(test_lib.ParserTestCase):
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_LAST_ACCESS)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'mru [/usr/lib/python2.5/lib-dynload/_struct.so] '
         'package [python2.5-minimal]')
     expected_short_message = '/usr/lib/python2.5/lib-dynload/_struct.so'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[5]
 
@@ -65,10 +74,13 @@ class PopularityContestUnitTest(test_lib.ParserTestCase):
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_LAST_ACCESS)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'mru [/usr/bin/empathy] package [empathy] tag [RECENT-CTIME]')
     expected_short_message = '/usr/bin/empathy'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[6]
 
@@ -76,10 +88,13 @@ class PopularityContestUnitTest(test_lib.ParserTestCase):
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_ENTRY_MODIFICATION)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'mru [/usr/bin/empathy] package [empathy] tag [RECENT-CTIME]')
     expected_short_message = '/usr/bin/empathy'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[11]
 
@@ -87,29 +102,38 @@ class PopularityContestUnitTest(test_lib.ParserTestCase):
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_LAST_ACCESS)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = 'mru [/usr/bin/orca] package [gnome-orca] tag [OLD]'
     expected_short_message = '/usr/bin/orca'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[13]
 
     self.CheckTimestamp(event.timestamp, '2010-06-22 05:41:41.000000')
     self.assertEqual(event.timestamp_desc, definitions.TIME_DESCRIPTION_ADDED)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = 'Session 0 end'
     expected_short_message = expected_message
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[14]
 
     self.CheckTimestamp(event.timestamp, '2010-06-22 05:41:41.000000')
     self.assertEqual(event.timestamp_desc, definitions.TIME_DESCRIPTION_ADDED)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'Session 1 start '
         'ID 12345678901234567890123456789012 [ARCH:i386 POPCONVER:1.38]')
     expected_short_message = 'Session 1 start'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[15]
 
@@ -117,9 +141,12 @@ class PopularityContestUnitTest(test_lib.ParserTestCase):
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_LAST_ACCESS)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = 'mru [/super/cool/plasuz] package [plaso]'
     expected_short_message = '/super/cool/plasuz'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[18]
 
@@ -127,9 +154,12 @@ class PopularityContestUnitTest(test_lib.ParserTestCase):
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_LAST_ACCESS)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = 'mru [/super/cool/plasuz] package [miss_ctime]'
     expected_short_message = '/super/cool/plasuz'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[19]
 
@@ -137,18 +167,24 @@ class PopularityContestUnitTest(test_lib.ParserTestCase):
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_LAST_ACCESS)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = 'mru [/super/cóól] package [plaso] tag [WRONG_TAG]'
     expected_short_message = '/super/cóól'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[21]
 
     self.CheckTimestamp(event.timestamp, '2010-06-22 05:41:41.000000')
     self.assertEqual(event.timestamp_desc, definitions.TIME_DESCRIPTION_ADDED)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = 'Session 1 end'
     expected_short_message = expected_message
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/recycler.py
+++ b/tests/parsers/recycler.py
@@ -38,7 +38,8 @@ class WinRecycleBinParserTest(test_lib.ParserTestCase):
 
     expected_message = '{0:s} (from drive: UNKNOWN)'.format(expected_filename)
     expected_short_message = 'Deleted file: {0:s}'.format(expected_filename)
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testParseWindows10(self):
     """Tests the Parse function on a Windows 10 RecycleBin file."""
@@ -62,7 +63,8 @@ class WinRecycleBinParserTest(test_lib.ParserTestCase):
 
     expected_message = '{0:s} (from drive: UNKNOWN)'.format(expected_filename)
     expected_short_message = 'Deleted file: {0:s}'.format(expected_filename)
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 class WinRecyclerInfo2ParserTest(test_lib.ParserTestCase):
@@ -91,6 +93,8 @@ class WinRecyclerInfo2ParserTest(test_lib.ParserTestCase):
 
     event = events[1]
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'DC2 -> C:\\Documents and Settings\\Mr. Evil\\Desktop'
         '\\netstumblerinstaller_0_4_0.exe (from drive: C)')
@@ -98,7 +102,8 @@ class WinRecyclerInfo2ParserTest(test_lib.ParserTestCase):
         'Deleted file: C:\\Documents and Settings\\Mr. Evil\\Desktop'
         '\\netstumblerinstaller...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[2]
 

--- a/tests/parsers/safari_cookies.py
+++ b/tests/parsers/safari_cookies.py
@@ -58,7 +58,7 @@ class SafariCookieParserTest(test_lib.ParserTestCase):
     expected_short_message = '.ebay.com (nonsession)'
 
     self._TestGetMessageStrings(
-        event, expected_message, expected_short_message)
+        event_data, expected_message, expected_short_message)
 
     event = cookie_events[52]
     event_data = self._GetEventDataOfEvent(storage_writer, event)

--- a/tests/parsers/santa.py
+++ b/tests/parsers/santa.py
@@ -47,7 +47,8 @@ class SantaUnitTest(test_lib.ParserTestCase):
     expected_short_message = (
         'ALLOW process: /Applications/Skype.app/Contents/MacOS/Skype')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # File operation event log
     event = events[159]
@@ -73,7 +74,8 @@ class SantaUnitTest(test_lib.ParserTestCase):
         '/System/Library/CoreServices/Finder.app/Contents/MacOS/Finder')
     expected_short_message = 'File WRITE on: /Users/qwerty/newfile'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Disk mounts event log.
     event = events[38]
@@ -97,7 +99,8 @@ class SantaUnitTest(test_lib.ParserTestCase):
         'Santa DISKAPPEAR for (/Users/qwerty/Downloads/Skype-8.28.0.41.dmg)')
     expected_short_message = 'DISKAPPEAR Skype'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test Disk event created from appearance timestamp.
     event = events[35]

--- a/tests/parsers/sccm.py
+++ b/tests/parsers/sccm.py
@@ -51,6 +51,9 @@ class SCCMLogsUnitTest(test_lib.ParserTestCase):
 
     # Test full and short message formats.
     event = events[4]
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'ContentAccess Releasing content request '
         '{4EA97AD6-E7E2-4583-92B9-21F532501337}')
@@ -59,7 +62,8 @@ class SCCMLogsUnitTest(test_lib.ParserTestCase):
         'Releasing content request '
         '{4EA97AD6-E7E2-4583-92B9-21F532501337}')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/selinux.py
+++ b/tests/parsers/selinux.py
@@ -33,6 +33,8 @@ class SELinuxUnitTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2012-05-24 07:40:01.174000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         '[audit_type: LOGIN, pid: 25443] pid=25443 uid=0 old '
         'auid=4294967295 new auid=0 old ses=4294967295 new ses=1165')
@@ -40,30 +42,39 @@ class SELinuxUnitTest(test_lib.ParserTestCase):
         '[audit_type: LOGIN, pid: 25443] pid=25443 uid=0 old '
         'auid=4294967295 new auid=...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test case: short date.
     event = events[1]
 
     self.CheckTimestamp(event.timestamp, '2012-05-24 07:40:01.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_string = '[audit_type: SHORTDATE] check rounding'
 
-    self._TestGetMessageStrings(event, expected_string, expected_string)
+    self._TestGetMessageStrings(
+        event_data, expected_string, expected_string)
 
     # Test case: no msg.
     event = events[2]
 
     self.CheckTimestamp(event.timestamp, '2012-05-24 07:40:22.174000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_string = '[audit_type: NOMSG]'
 
-    self._TestGetMessageStrings(event, expected_string, expected_string)
+    self._TestGetMessageStrings(
+        event_data, expected_string, expected_string)
 
     # Test case: under score.
     event = events[3]
 
     self.CheckTimestamp(event.timestamp, '2012-05-24 07:47:46.174000')
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     expected_message = (
         '[audit_type: UNDER_SCORE, pid: 25444] pid=25444 uid=0 old '
@@ -72,7 +83,8 @@ class SELinuxUnitTest(test_lib.ParserTestCase):
         '[audit_type: UNDER_SCORE, pid: 25444] pid=25444 uid=0 old '
         'auid=4294967295 new...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/skydrivelog.py
+++ b/tests/parsers/skydrivelog.py
@@ -29,28 +29,36 @@ class SkyDriveLogUnitTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2013-07-25 16:03:23.291000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'Logging started. Version= 17.0.2011.0627 StartLocalTime: '
         '2013-07-25-180323.291 PID=0x8f4 TID=0x718 ContinuedFrom=')
     expected_short_message = (
         'Logging started. Version= 17.0.2011.0627 StartLocalTime: '
         '2013-07-25-180323.29...')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[1]
 
     self.CheckTimestamp(event.timestamp, '2013-07-25 16:03:24.649000')
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     expected_message = (
         '[AUTH authapi.cpp(280) ERR] Sign in failed : '
         'DRX_E_AUTH_NO_VALID_CREDENTIALS,')
     expected_short_message = (
         'Sign in failed : DRX_E_AUTH_NO_VALID_CREDENTIALS,')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[18]
 
     self.CheckTimestamp(event.timestamp, '2013-08-01 21:27:44.124000')
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     expected_message = (
         '[WNS absconn.cpp(177) VRB] Received data from server,'
@@ -59,7 +67,8 @@ class SkyDriveLogUnitTest(test_lib.ParserTestCase):
     expected_short_message = (
         'Received data from server,dwID=0x0;dwSize=0x3e;pbData=PNG 9 CON 48  '
         '<ping-res...')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testParseErrorLogUnicode(self):
     """Tests the Parse function on Unicode error log."""
@@ -102,6 +111,8 @@ class SkyDriveLogUnitTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2013-08-12 02:52:32.976000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         '[WNS absconn.cpp(177) VRB] Received data from server,dwID=0x0;'
         'dwSize=0x15a;pbData=GET 5 WNS 331 Context: 2891  <channel-response>'
@@ -113,11 +124,14 @@ class SkyDriveLogUnitTest(test_lib.ParserTestCase):
     expected_short_message = (
         'Received data from server,dwID=0x0;dwSize=0x15a;pbData=GET 5 WNS '
         '331 Context:...')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[13]
 
     self.CheckTimestamp(event.timestamp, '2013-08-12 03:18:57.232000')
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     expected_message = (
         'Logging started. Version= 17.0.2011.0627 StartLocalTime: '
@@ -125,11 +139,14 @@ class SkyDriveLogUnitTest(test_lib.ParserTestCase):
     expected_short_message = (
         'Logging started. Version= 17.0.2011.0627 StartLocalTime: '
         '2013-08-11-231857.23...')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[15]
 
     self.CheckTimestamp(event.timestamp, '2013-08-31 03:45:37.940000')
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     expected_message = (
         '[PAL cwinhttp.cpp(1581) VRB] ,output=GET <- /MyData/LiveFolders?'
@@ -140,7 +157,8 @@ class SkyDriveLogUnitTest(test_lib.ParserTestCase):
     expected_short_message = (
         ',output=GET <- /MyData/LiveFolders?Filter=changes&InlineBlobs='
         'false&MaxItemCo...')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 class SkyDriveOldLogUnitTest(test_lib.ParserTestCase):
@@ -160,11 +178,14 @@ class SkyDriveOldLogUnitTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2013-08-01 21:22:28.999000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         '[global.cpp:626!logVersionInfo] (DETAIL) 17.0.2011.0627 (Ship)')
     expected_short_message = (
         '17.0.2011.0627 (Ship)')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[1]
 
@@ -178,13 +199,16 @@ class SkyDriveOldLogUnitTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2013-08-01 21:22:29.702000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'SyncToken = LM%3d12345678905670%3bID%3d1234567890E059C0!'
         '103%3bLR%3d12345678905623%3aEP%3d2')
     expected_short_message = (
         'SyncToken = LM%3d12345678905670%3bID%3d1234567890E059C0!'
         '103%3bLR%3d1234567890...')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[4]
 
@@ -198,9 +222,12 @@ class SkyDriveOldLogUnitTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2013-08-01 21:28:46.742000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'SyncToken = Not a sync token (\xe0\xe8\xec\xf2\xf9)!')
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sophos_av.py
+++ b/tests/parsers/sophos_av.py
@@ -29,11 +29,14 @@ class SophosAVLogParserTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2010-07-20 18:38:14.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'File "C:\\Documents and Settings\\Administrator\\Desktop\\'
         'sxl_test_50.com" belongs to virus/spyware \'LiveProtectTest\'.')
     expected_short_message = '{0:s}...'.format(expected_message[:77])
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/android_calls.py
+++ b/tests/parsers/sqlite_plugins/android_calls.py
@@ -46,7 +46,8 @@ class AndroidCallSQLitePluginTest(test_lib.SQLitePluginTestCase):
         'Name: Barney '
         'Duration: 0 seconds')
     expected_short_message = 'MISSED Call'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[3]
 

--- a/tests/parsers/sqlite_plugins/android_sms.py
+++ b/tests/parsers/sqlite_plugins/android_sms.py
@@ -44,7 +44,8 @@ class AndroidSMSTest(test_lib.SQLitePluginTestCase):
         'Status: READ '
         'Message: Yo Fred this is my new number.')
     expected_short_message = 'Yo Fred this is my new number.'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/android_webviewcache.py
+++ b/tests/parsers/sqlite_plugins/android_webviewcache.py
@@ -42,7 +42,8 @@ class AndroidWebViewCache(test_lib.SQLitePluginTestCase):
         'URL: {0:s} '
         'Content Length: 1821').format(expected_url)
     expected_short_message = '{0:s}...'.format(expected_url[:77])
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/appusage.py
+++ b/tests/parsers/sqlite_plugins/appusage.py
@@ -44,7 +44,8 @@ class ApplicationUsagePluginTest(test_lib.SQLitePluginTestCase):
 
     expected_short_message = '/Applications/Safari.app (1 time(s))'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/chrome.py
+++ b/tests/parsers/sqlite_plugins/chrome.py
@@ -50,7 +50,8 @@ class GoogleChrome8HistoryPluginTest(test_lib.SQLitePluginTestCase):
     expected_short_message = '{0:s} ({1:s})'.format(
         expected_url, expected_title)
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Check the first file downloaded entry.
     event = events[69]
@@ -74,7 +75,8 @@ class GoogleChrome8HistoryPluginTest(test_lib.SQLitePluginTestCase):
         '1132155 bytes.').format(expected_url, expected_full_path)
     expected_short_message = '{0:s} downloaded (1132155 bytes)'.format(
         expected_full_path)
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 class GoogleChrome27HistoryPluginTest(test_lib.SQLitePluginTestCase):
@@ -115,7 +117,8 @@ class GoogleChrome27HistoryPluginTest(test_lib.SQLitePluginTestCase):
         '(URL not typed directly - no typed count)').format(expected_url)
     expected_short_message = '{0:s}...'.format(expected_url[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Check the file downloaded event.
     event = events[1]
@@ -139,7 +142,8 @@ class GoogleChrome27HistoryPluginTest(test_lib.SQLitePluginTestCase):
             expected_url, expected_full_path)
     expected_short_message = '{0:s} downloaded (3080192 bytes)'.format(
         expected_full_path)
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testProcess58(self):
     """Tests the Process function on a Google Chrome 58 History database."""
@@ -176,7 +180,8 @@ class GoogleChrome27HistoryPluginTest(test_lib.SQLitePluginTestCase):
         '(URL not typed directly - no typed count)').format(expected_url)
     expected_short_message = '{0:s}...'.format(expected_url[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Check the file downloaded event.
     event = events[1]
@@ -200,7 +205,8 @@ class GoogleChrome27HistoryPluginTest(test_lib.SQLitePluginTestCase):
             expected_url, expected_full_path)
     expected_short_message = '{0:s} downloaded (3080192 bytes)'.format(
         expected_full_path)
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testProcess59(self):
     """Tests the Process function on a Google Chrome 59 History database."""
@@ -237,7 +243,8 @@ class GoogleChrome27HistoryPluginTest(test_lib.SQLitePluginTestCase):
         '(URL not typed directly - no typed count)').format(expected_url)
     expected_short_message = '{0:s}...'.format(expected_url[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Check the file downloaded event.
     event = events[1]
@@ -261,7 +268,8 @@ class GoogleChrome27HistoryPluginTest(test_lib.SQLitePluginTestCase):
             expected_url, expected_full_path)
     expected_short_message = '{0:s} downloaded (3080192 bytes)'.format(
         expected_full_path)
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/chrome_autofill.py
+++ b/tests/parsers/sqlite_plugins/chrome_autofill.py
@@ -45,7 +45,8 @@ class ChromeAutofillPluginTest(test_lib.SQLitePluginTestCase):
     expected_short_message = (
         'repo: log2timeline/plaso (1)')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/chrome_cookies.py
+++ b/tests/parsers/sqlite_plugins/chrome_cookies.py
@@ -67,7 +67,8 @@ class Chrome17CookiesPluginTest(test_lib.SQLitePluginTestCase):
         'http://www.linkedin.com/ (leo_auth_token) Flags: [HTTP only] = False '
         '[Persistent] = True')
     expected_short_message = 'www.linkedin.com (leo_auth_token)'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Check one of the visits to rubiconproject.com.
     event = events[379]
@@ -174,7 +175,8 @@ class Chrome66CookiesPluginTest(test_lib.SQLitePluginTestCase):
         'http://google.com/gmail/about/ (__utma) '
         'Flags: [HTTP only] = False [Persistent] = True')
     expected_short_message = 'google.com (__utma)'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Check one of the visits to fbi.gov for last accessed time.
     event = events[10]

--- a/tests/parsers/sqlite_plugins/chrome_extension_activity.py
+++ b/tests/parsers/sqlite_plugins/chrome_extension_activity.py
@@ -49,7 +49,8 @@ class ChromeExtensionActivityPluginTest(test_lib.SQLitePluginTestCase):
     expected_short_message = (
         'ognampngfcbddbfemdapefohjiobgbdl browserAction.onClicked')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/firefox.py
+++ b/tests/parsers/sqlite_plugins/firefox.py
@@ -57,7 +57,8 @@ class FirefoxHistoryPluginTest(test_lib.SQLitePluginTestCase):
             expected_url, expected_title)
     expected_short_message = 'URL: {0:s}'.format(expected_url)
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Check the first bookmark event.
     event = events[1]
@@ -98,7 +99,8 @@ class FirefoxHistoryPluginTest(test_lib.SQLitePluginTestCase):
         'Bookmarked Recently Bookmarked '
         '(place:folder=BOOKMARKS_MENU&folder=UNFILED_BO...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Check the first bookmark annotation event.
     event = events[183]
@@ -133,7 +135,8 @@ class FirefoxHistoryPluginTest(test_lib.SQLitePluginTestCase):
         '[{0:s}] ({1:s})').format(
             expected_title, expected_url)
     expected_short_message = 'Bookmark Annotation: Recent Tags'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Check the second last bookmark folder event.
     event = events[200]
@@ -162,7 +165,8 @@ class FirefoxHistoryPluginTest(test_lib.SQLitePluginTestCase):
 
     expected_message = expected_title
     expected_short_message = expected_title
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testProcessVersion25(self):
     """Tests the Process function on a Firefox History database file v 25."""
@@ -195,12 +199,15 @@ class FirefoxHistoryPluginTest(test_lib.SQLitePluginTestCase):
 
     self.CheckTimestamp(event.timestamp, '2013-10-30 21:57:11.281942')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'http://code.google.com/p/plaso [count: 1] Host: code.google.com '
         '(URL not typed directly) Transition: TYPED')
     expected_short_message = 'URL: http://code.google.com/p/plaso'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 class FirefoxDownloadsPluginTest(test_lib.SQLitePluginTestCase):

--- a/tests/parsers/sqlite_plugins/firefox_cookies.py
+++ b/tests/parsers/sqlite_plugins/firefox_cookies.py
@@ -66,7 +66,8 @@ class FirefoxCookiesPluginTest(test_lib.SQLitePluginTestCase):
     expected_message = (
         'http://s.greenqloud.com/ (__utma) Flags: [HTTP only]: False')
     expected_short_message = 's.greenqloud.com (__utma)'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Check one of the visits to pubmatic.com.
     event = test_events[62]
@@ -83,7 +84,8 @@ class FirefoxCookiesPluginTest(test_lib.SQLitePluginTestCase):
     expected_message = (
         'http://pubmatic.com/ (KRTBCOOKIE_391) Flags: [HTTP only]: False')
     expected_short_message = 'pubmatic.com (KRTBCOOKIE_391)'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/gdrive.py
+++ b/tests/parsers/sqlite_plugins/gdrive.py
@@ -54,7 +54,8 @@ class GoogleDrivePluginTest(test_lib.SQLitePluginTestCase):
 
     expected_message = 'File Path: {0:s} Size: 184'.format(file_path)
 
-    self._TestGetMessageStrings(event, expected_message, file_path)
+    self._TestGetMessageStrings(
+        event_data, expected_message, file_path)
 
     event = cloud_entries[16]
 
@@ -77,7 +78,8 @@ class GoogleDrivePluginTest(test_lib.SQLitePluginTestCase):
         'Type: DOCUMENT').format(expected_url)
     expected_short_message = '/Almenningur/Saklausa hliðin'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/hangouts_messages.py
+++ b/tests/parsers/sqlite_plugins/hangouts_messages.py
@@ -46,7 +46,8 @@ class HangoutsMessagesTest(test_lib.SQLitePluginTestCase):
         'Status: READ '
         'Type: RECEIVED')
     expected_short_message = 'How are you?'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/imessage.py
+++ b/tests/parsers/sqlite_plugins/imessage.py
@@ -49,7 +49,8 @@ class IMessageTest(test_lib.SQLitePluginTestCase):
         'Service: iMessage '
         'Message Content: Did you try to send me a message?')
     expected_short_message = 'Did you try to send me a message?'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/kik_ios.py
+++ b/tests/parsers/sqlite_plugins/kik_ios.py
@@ -46,7 +46,8 @@ class KikMessageTest(test_lib.SQLitePluginTestCase):
         'Type: sent '
         'Message: Hello')
     expected_short_message = 'Hello'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/kodi.py
+++ b/tests/parsers/sqlite_plugins/kodi.py
@@ -44,7 +44,8 @@ class KodiVideosTest(test_lib.SQLitePluginTestCase):
         'Video: plugin://plugin.video.youtube/play/?video_id=7WX0-O_ENlk '
         'Play Count: 1')
     expected_short_message = expected_filename
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/ls_quarantine.py
+++ b/tests/parsers/sqlite_plugins/ls_quarantine.py
@@ -50,6 +50,8 @@ class LSQuarantinePluginTest(test_lib.SQLitePluginTestCase):
 
     self.CheckTimestamp(event.timestamp, '2013-07-12 19:30:16.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         '[Google Chrome] Downloaded: http://mackeeperapp.zeobit.com/aff/'
         'speedtest.net.6/download.php?affid=460245286&trt=5&utm_campaign='
@@ -60,7 +62,8 @@ class LSQuarantinePluginTest(test_lib.SQLitePluginTestCase):
         'http://mackeeperapp.zeobit.com/aff/speedtest.net.6/download.php?'
         'affid=4602452...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/mac_document_versions.py
+++ b/tests/parsers/sqlite_plugins/mac_document_versions.py
@@ -50,7 +50,8 @@ class MacDocumentVersionsTest(test_lib.SQLitePluginTestCase):
             event_data.user_sid))
     expected_short_message = 'Stored a document version of [{0:s}]'.format(
         event_data.name)
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/mac_knowledgec.py
+++ b/tests/parsers/sqlite_plugins/mac_knowledgec.py
@@ -36,7 +36,8 @@ class MacKnowledgecTest(test_lib.SQLitePluginTestCase):
     expected_message = (
         'Application com.apple.Installer-Progress executed for 1 seconds')
     expected_short_message = 'Application com.apple.Installer-Progress'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testProcessMojave(self):
     """Tests the Process function on a MacOS High Sierra database."""
@@ -59,7 +60,8 @@ class MacKnowledgecTest(test_lib.SQLitePluginTestCase):
     expected_message = (
         'Application com.apple.Terminal executed for 1041 seconds')
     expected_short_message = 'Application com.apple.Terminal'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[212]
     self.CheckTimestamp(event.timestamp, '2019-05-08 13:57:20.000000')
@@ -73,7 +75,8 @@ class MacKnowledgecTest(test_lib.SQLitePluginTestCase):
     expected_message = (
         'Visited: https://www.instagram.com/ (Instagram) Duration: 0')
     expected_short_message = 'Safari: https://www.instagram.com/'
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/mac_notes.py
+++ b/tests/parsers/sqlite_plugins/mac_notes.py
@@ -30,19 +30,22 @@ class MacNotesTest(test_lib.SQLitePluginTestCase):
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_CREATION)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_title = 'building 4th brandy gibs'
-    self.assertEqual(event.title, expected_title)
+    self.assertEqual(event_data.title, expected_title)
     expected_text = (
         'building 4th brandy gibs microsoft office body soul and peace '
         'example.com 3015555555: plumbing and heating claim#123456 Small '
         'business ')
-    self.assertEqual(event.text, expected_text)
+    self.assertEqual(event_data.text, expected_text)
 
     expected_short_message = 'title:{0:s}'.format(expected_title)
     expected_message = 'title:{0:s} note_text:{1:s}'.format(
         expected_title, expected_text)
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/parsers/sqlite_plugins/mac_notificationcenter.py
+++ b/tests/parsers/sqlite_plugins/mac_notificationcenter.py
@@ -43,7 +43,8 @@ class MacNotificationCenterTest(test_lib.SQLitePluginTestCase):
         'Content: KeePassXC can now be run')
     expected_short_message = (
         'Title: Santa, Content: KeePassXC can now be run')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[2]
     self.CheckTimestamp(event.timestamp, '2018-05-02 11:13:21.531085')
@@ -64,7 +65,8 @@ class MacNotificationCenterTest(test_lib.SQLitePluginTestCase):
     expected_short_message = (
         'Title: Drive File Stream, Content: Drive File Stream is loading your '
         'files…')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[5]
     self.CheckTimestamp(event.timestamp, '2018-05-16 16:38:04.686080')
@@ -83,7 +85,8 @@ class MacNotificationCenterTest(test_lib.SQLitePluginTestCase):
         'Content: PyCharm can now be run')
     expected_short_message = (
         'Title: Santa, Content: PyCharm can now be run')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/mackeeper_cache.py
+++ b/tests/parsers/sqlite_plugins/mackeeper_cache.py
@@ -30,6 +30,8 @@ class MacKeeperCachePluginTest(test_lib.SQLitePluginTestCase):
 
     self.CheckTimestamp(event.timestamp, '2013-07-12 19:30:31.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'Chat Outgoing Message : I have received your system scan report and '
         'I will start analyzing it right now. [ URL: http://support.kromtech.'
@@ -42,7 +44,8 @@ class MacKeeperCachePluginTest(test_lib.SQLitePluginTestCase):
         'I have received your system scan report and I will start analyzing '
         'it right now.')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/safari.py
+++ b/tests/parsers/sqlite_plugins/safari.py
@@ -41,7 +41,8 @@ class SafariHistoryPluginTest(test_lib.SQLitePluginTestCase):
         'URL: http://facebook.com/ '
         '[count: 2] http_non_get: False')
 
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/skype.py
+++ b/tests/parsers/sqlite_plugins/skype.py
@@ -67,13 +67,16 @@ class SkypePluginTest(test_lib.SQLitePluginTestCase):
     # Test cache processing and format strings.
     event = events[17]
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'Source: gen.beringer <Gen Beringer> Destination: '
         'european.bbq.competitor <European BBQ> File: secret-project.pdf '
         '[SENDSOLICITUDE]')
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     sms_event = events[16]
 

--- a/tests/parsers/sqlite_plugins/tango_android.py
+++ b/tests/parsers/sqlite_plugins/tango_android.py
@@ -53,7 +53,8 @@ class TangoAndroidProfileTest(test_lib.SQLitePluginTestCase):
 
     expected_short_message = 'Rouel Henry Status: Praying!'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test tango contact last access time event.
     event = events[57]
@@ -99,7 +100,8 @@ class TangoAndroidTCTest(test_lib.SQLitePluginTestCase):
     expected_message = 'Conversation (DyGWr_010wQM_ozkIe-9Ww)'
     expected_short_message = 'Conversation (DyGWr_010wQM_ozkIe-9Ww)'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test tango message creation time event
     event = events[21]
@@ -115,7 +117,8 @@ class TangoAndroidTCTest(test_lib.SQLitePluginTestCase):
     expected_message = 'Outgoing Message (16777224)'
     expected_short_message = 'Outgoing Message (16777224)'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test tango message sent time event
     event = events[22]

--- a/tests/parsers/sqlite_plugins/twitter_android.py
+++ b/tests/parsers/sqlite_plugins/twitter_android.py
@@ -55,7 +55,8 @@ class TwitterAndroidTest(test_lib.SQLitePluginTestCase):
         'User: CarolMovieFans Status: @CarolMovie wins BEST PICTURE at '
         '#NYFCC!!! CONGR...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test search event data
     event = events[837]
@@ -71,7 +72,8 @@ class TwitterAndroidTest(test_lib.SQLitePluginTestCase):
 
     expected_short_message = 'Query: rosegold'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test all three timestamps for contact event data.
 
@@ -118,7 +120,8 @@ class TwitterAndroidTest(test_lib.SQLitePluginTestCase):
         'Screen name: timbuk2 Description: Started in a San Francisco by bike '
         'messenge...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test friended time.
     event = events[581]

--- a/tests/parsers/sqlite_plugins/twitter_ios.py
+++ b/tests/parsers/sqlite_plugins/twitter_ios.py
@@ -74,7 +74,8 @@ class TwitterIOSTest(test_lib.SQLitePluginTestCase):
         'Screen name: BBCBreaking Description: Breaking news alerts and '
         'updates from t...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test first contact modification event.
     event = events[1]
@@ -120,7 +121,8 @@ class TwitterIOSTest(test_lib.SQLitePluginTestCase):
         'Screen name: BBCBreaking Description: Breaking news alerts and '
         'updates from t...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test first status creation event.
     event = events[50]
@@ -146,7 +148,8 @@ class TwitterIOSTest(test_lib.SQLitePluginTestCase):
     expected_short_message = (
         'Name: Heather Mahalik Message: Never forget. http://t.co/L7bjWue1A2')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test first status update event.
     event = events[51]
@@ -172,7 +175,8 @@ class TwitterIOSTest(test_lib.SQLitePluginTestCase):
     expected_short_message = (
         'Name: Heather Mahalik Message: Never forget. http://t.co/L7bjWue1A2')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/sqlite_plugins/zeitgeist.py
+++ b/tests/parsers/sqlite_plugins/zeitgeist.py
@@ -35,7 +35,8 @@ class ZeitgeistActivityDatabasePluginTest(test_lib.SQLitePluginTestCase):
     self.assertEqual(event_data.subject_uri, 'application://rhythmbox.desktop')
 
     expected_message = 'application://rhythmbox.desktop'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/symantec.py
+++ b/tests/parsers/symantec.py
@@ -68,7 +68,8 @@ class SymantecAccessProtectionUnitTest(test_lib.ParserTestCase):
         'W32.Changeup!gen33; '
         'Unknown; ...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/syslog.py
+++ b/tests/parsers/syslog.py
@@ -60,7 +60,8 @@ class SyslogParserTest(test_lib.ParserTestCase):
 
     expected_message = (
         'INFO [periodic_scheduler, pid: 13707] cleanup_logs: job completed')
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[2]
 
@@ -97,7 +98,8 @@ class SyslogParserTest(test_lib.ParserTestCase):
     expected_short_message = (
         'INFO [aprocess] [  316.587330] cfg80211: This is a multi-line\t'
         'message that sc...')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testParse(self):
     """Tests the Parse function."""
@@ -123,7 +125,8 @@ class SyslogParserTest(test_lib.ParserTestCase):
 
     expected_message = (
         '[client, pid: 30840] INFO No new content in ímynd.dd.')
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[6]
 
@@ -163,7 +166,8 @@ class SyslogParserTest(test_lib.ParserTestCase):
     expected_short_message = (
         '[aprocess, pid: 10100] This is a multi-line message that screws up'
         '\tmany syslo...')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[14]
 
@@ -176,7 +180,8 @@ class SyslogParserTest(test_lib.ParserTestCase):
         '[kernel] [997.390602] sda2: rw=0, want=65, limit=2')
     expected_short_message = (
         '[kernel] [997.390602] sda2: rw=0, want=65, limit=2')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Testing non-leap year.
     parser = syslog.SyslogParser()

--- a/tests/parsers/systemd_journal.py
+++ b/tests/parsers/systemd_journal.py
@@ -33,20 +33,26 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2017-01-27 09:40:55.913258')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'test-VirtualBox [systemd, pid: 1] Started User Manager for '
         'UID 1000.')
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     # This event uses XZ compressed data
     event = events[2098]
 
     self.CheckTimestamp(event.timestamp, '2017-02-06 16:24:32.564585')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = 'test-VirtualBox [root, pid: 22921] {0:s}'.format(
         'a' * 692)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testParseLZ4(self):
     """Tests the Parse function on a journal with LZ4 compressed events."""
@@ -63,13 +69,18 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2018-07-03 15:00:16.682340')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = 'testlol [systemd, pid: 822] Reached target Paths.'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     # This event uses LZ4 compressed data
     event = events[84]
 
     self.CheckTimestamp(event.timestamp, '2018-07-03 15:19:04.667807')
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     # source: https://github.com/systemd/systemd/issues/6237
     # The text used in the test message was triplicated to make it long enough
@@ -81,7 +92,8 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
          'permitting numeric first characters is done on purpose: to avoid '
          'ambiguities between numeric UID and textual user names.'*3))
     expected_short_message = '{0:s}...'.format(expected_message[:77])
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testParseDirty(self):
     """Tests the Parse function on a 'dirty' journal file."""
@@ -106,11 +118,14 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2016-10-24 13:20:01.063423')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'test-VirtualBox [systemd-journald, pid: 569] Runtime journal '
         '(/run/log/journal/) is 1.2M, max 9.9M, 8.6M free.')
     expected_short_message = '{0:s}...'.format(expected_message[:77])
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     self.assertEqual(storage_writer.number_of_warnings, 1)
 

--- a/tests/parsers/test_lib.py
+++ b/tests/parsers/test_lib.py
@@ -169,15 +169,15 @@ class ParserTestCase(shared_test_lib.BaseTestCase):
     return storage_writer
 
   def _TestGetMessageStrings(
-      self, event, expected_message, expected_short_message):
+      self, event_data, expected_message, expected_short_message):
     """Tests the formatting of the message strings.
 
-    This function invokes the GetMessageStrings function of the event
-    formatter on the event and compares the resulting messages
-    strings with those expected.
+    This function invokes the GetMessageStrings function of the event data
+    formatter on the event data and compares the resulting messages strings
+    with those expected.
 
     Args:
-      event (EventObject): event.
+      event_data (EventData): event data.
       expected_message (str): expected message string.
       expected_short_message (str): expected short message string.
     """
@@ -185,7 +185,7 @@ class ParserTestCase(shared_test_lib.BaseTestCase):
         data_location=self._DATA_PATH)
     message, message_short = (
         formatters_manager.FormattersManager.GetMessageStrings(
-            formatter_mediator, event))
+            formatter_mediator, event_data))
     self.assertEqual(message, expected_message)
     self.assertEqual(message_short, expected_short_message)
 

--- a/tests/parsers/trendmicroav.py
+++ b/tests/parsers/trendmicroav.py
@@ -46,7 +46,8 @@ class TrendMicroUnitTest(test_lib.ParserTestCase):
         r'Eicar_test_1 : Failure (clean), moved (Real-time scan)')
     expected_short_message = r'C:\temp\ eicar.com_.gstmp Failure (clean), moved'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testWebReputationParse(self):
     """Tests the Parse function."""
@@ -79,7 +80,8 @@ class TrendMicroUnitTest(test_lib.ParserTestCase):
     expected_short_message = (
         'http://www.eicar.org/download/eicar.com Malware Accomplice')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/parsers/utmp.py
+++ b/tests/parsers/utmp.py
@@ -62,7 +62,8 @@ class UtmpParserTest(test_lib.ParserTestCase):
         'User: LOGIN '
         'PID: 1115 '
         'Status: LOGIN_PROCESS')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[12]
 
@@ -90,7 +91,8 @@ class UtmpParserTest(test_lib.ParserTestCase):
         'User: moxilo '
         'PID: 2684 '
         'Status: USER_PROCESS')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testParseWtmpFile(self):
     """Tests the Parse function on a wtmp file."""
@@ -129,7 +131,8 @@ class UtmpParserTest(test_lib.ParserTestCase):
         'User: userA '
         'PID: 20060 '
         'Status: USER_PROCESS')
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/utmpx.py
+++ b/tests/parsers/utmpx.py
@@ -29,6 +29,8 @@ class UtmpxParserTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2013-11-13 17:52:34.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         'Status: BOOT_TIME '
         'Hostname: localhost '
@@ -38,7 +40,8 @@ class UtmpxParserTest(test_lib.ParserTestCase):
         'PID: 1 '
         'Status: BOOT_TIME')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[1]
 
@@ -62,7 +65,8 @@ class UtmpxParserTest(test_lib.ParserTestCase):
         'PID: 67 '
         'Status: USER_PROCESS')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[4]
 
@@ -85,7 +89,8 @@ class UtmpxParserTest(test_lib.ParserTestCase):
         'PID: 6899 '
         'Status: DEAD_PROCESS')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winevt.py
+++ b/tests/parsers/winevt.py
@@ -92,7 +92,8 @@ class WinEvtParserTest(test_lib.ParserTestCase):
         'Strings: [\'cifs/CONTROLLER\', '
         '\'"The system detected a possibl...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winevtx.py
+++ b/tests/parsers/winevtx.py
@@ -120,7 +120,8 @@ class WinEvtxParserTest(test_lib.ParserTestCase):
         'Strings: [\'Windows Modules Installer\', \'stopped\', '
         '\'5400720075...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testParseTruncated(self):
     """Tests the Parse function on a truncated file."""

--- a/tests/parsers/winfirewall.py
+++ b/tests/parsers/winfirewall.py
@@ -53,7 +53,8 @@ class WinFirewallParserTest(test_lib.ParserTestCase):
     expected_short_message = (
         'DROP [TCP] 123.45.78.90 : 80 > 123.156.78.90 : 1774')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[9]
 

--- a/tests/parsers/winjob.py
+++ b/tests/parsers/winjob.py
@@ -63,7 +63,8 @@ class WinJobTest(test_lib.ParserTestCase):
     expected_short_message = (
         'Application: {0:s} /ua /insta...').format(expected_application)
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winlnk.py
+++ b/tests/parsers/winlnk.py
@@ -45,19 +45,15 @@ class WinLnkParserTest(test_lib.ParserTestCase):
         event.timestamp_desc, definitions.TIME_DESCRIPTION_LAST_ACCESS)
 
     event_data = self._GetEventDataOfEvent(storage_writer, event)
-
-    expected_string = '@%windir%\\system32\\migwiz\\wet.dll,-590'
-    self.assertEqual(event_data.description, expected_string)
-
-    expected_string = '.\\migwiz\\migwiz.exe'
-    self.assertEqual(event_data.relative_path, expected_string)
-
-    expected_string = '%windir%\\system32\\migwiz'
-    self.assertEqual(event_data.working_directory, expected_string)
-
-    expected_string = '%windir%\\system32\\migwiz\\migwiz.exe'
-    self.assertEqual(event_data.icon_location, expected_string)
-    self.assertEqual(event_data.env_var_location, expected_string)
+    self.assertEqual(event_data.data_type, 'windows:lnk:link')
+    self.assertEqual(
+        event_data.description, '@%windir%\\system32\\migwiz\\wet.dll,-590')
+    self.assertEqual(event_data.relative_path, '.\\migwiz\\migwiz.exe')
+    self.assertEqual(event_data.working_directory, '%windir%\\system32\\migwiz')
+    self.assertEqual(
+        event_data.icon_location, '%windir%\\system32\\migwiz\\migwiz.exe')
+    self.assertEqual(
+        event_data.env_var_location, '%windir%\\system32\\migwiz\\migwiz.exe')
 
     # The creation timestamp.
     event = events[1]
@@ -73,6 +69,9 @@ class WinLnkParserTest(test_lib.ParserTestCase):
     self.assertEqual(
         event.timestamp_desc, definitions.TIME_DESCRIPTION_MODIFICATION)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+    self.assertEqual(event_data.data_type, 'windows:lnk:link')
+
     expected_message = (
         '[@%windir%\\system32\\migwiz\\wet.dll,-590] '
         'File size: 544768 '
@@ -86,7 +85,8 @@ class WinLnkParserTest(test_lib.ParserTestCase):
         '[@%windir%\\system32\\migwiz\\wet.dll,-590] '
         '%windir%\\system32\\migwiz\\.\\migwiz\\mi...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # A distributed link tracking event.
     event = events[4]
@@ -114,6 +114,8 @@ class WinLnkParserTest(test_lib.ParserTestCase):
     # A shortcut event.
     event = events[16]
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = (
         '[Nero InfoTool provides you with information about the most '
         'important features of installed drives, inserted discs, installed '
@@ -139,12 +141,15 @@ class WinLnkParserTest(test_lib.ParserTestCase):
         '[Nero InfoTool provides you with information about the most '
         'important feature...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # A shell item event.
     event = events[12]
 
     self.CheckTimestamp(event.timestamp, '2009-06-05 20:13:20.000000')
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     expected_message = (
         'Name: InfoTool.exe '
@@ -159,7 +164,8 @@ class WinLnkParserTest(test_lib.ParserTestCase):
         'NTFS file reference: 81349-1 '
         'Origin: NeroInfoTool.lnk')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winprefetch.py
+++ b/tests/parsers/winprefetch.py
@@ -102,7 +102,8 @@ class WinPrefetchParserTest(test_lib.ParserTestCase):
         '\\DEVICE\\HARDDISKVOLUME1 '
         'Origin: CMD.EXE-087B4001.pf')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testParse23(self):
     """Tests the Parse function on a version 23 Prefetch file."""
@@ -141,7 +142,8 @@ class WinPrefetchParserTest(test_lib.ParserTestCase):
 
     expected_short_message = 'PING.EXE was run 14 time(s)'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # The volume creation event.
     event = events[0]
@@ -200,7 +202,8 @@ class WinPrefetchParserTest(test_lib.ParserTestCase):
 
     expected_short_message = 'WUAUCLT.EXE was run 25 time(s)'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # The volume creation event.
     event = events[0]
@@ -221,7 +224,8 @@ class WinPrefetchParserTest(test_lib.ParserTestCase):
         '\\DEVICE\\HARDDISKVOLUME1 '
         'Origin: WUAUCLT.EXE-830BCC14.pf')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testParse26(self):
     """Tests the Parse function on a version 26 Prefetch file."""

--- a/tests/parsers/winreg_plugins/appcompatcache.py
+++ b/tests/parsers/winreg_plugins/appcompatcache.py
@@ -315,7 +315,8 @@ class AppCompatCacheWindowsRegistryPluginTest(test_lib.RegistryPluginTestCase):
         event_data.key_path, event_index + 1, expected_path)
     expected_short_message = 'Path: {0:s}'.format(expected_path)
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testProcessWindows2003(self):
     """Tests the Process function for Windows 2003 AppCompatCache data."""
@@ -343,7 +344,8 @@ class AppCompatCacheWindowsRegistryPluginTest(test_lib.RegistryPluginTestCase):
         event_data.key_path, event_index + 1, expected_path)
     expected_short_message = 'Path: {0:s}'.format(expected_path)
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # TODO: implement 64 bit
 
@@ -372,7 +374,8 @@ class AppCompatCacheWindowsRegistryPluginTest(test_lib.RegistryPluginTestCase):
         event_data.key_path, event_index + 1, expected_path)
     expected_short_message = 'Path: {0:s}'.format(expected_path)
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # TODO: implement 64 bit
 
@@ -412,7 +415,8 @@ class AppCompatCacheWindowsRegistryPluginTest(test_lib.RegistryPluginTestCase):
         event_data.key_path, event_index + 1, expected_path)
     expected_short_message = 'Path: {0:s}'.format(expected_path)
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # TODO: implement 64 bit
 
@@ -441,7 +445,8 @@ class AppCompatCacheWindowsRegistryPluginTest(test_lib.RegistryPluginTestCase):
         event_data.key_path, event_index + 1, expected_path)
     expected_short_message = 'Path: {0:s}'.format(expected_path)
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testProcessWindows8_1(self):
     """Tests the Process function for Windows 8.1 AppCompatCache data."""
@@ -468,7 +473,8 @@ class AppCompatCacheWindowsRegistryPluginTest(test_lib.RegistryPluginTestCase):
         event_data.key_path, event_index + 1, expected_path)
     expected_short_message = 'Path: {0:s}'.format(expected_path)
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testProcessWindows10(self):
     """Tests the Process function for Windows 10 AppCompatCache data."""
@@ -495,7 +501,8 @@ class AppCompatCacheWindowsRegistryPluginTest(test_lib.RegistryPluginTestCase):
         event_data.key_path, event_index + 1, expected_path)
     expected_short_message = 'Path: {0:s}'.format(expected_path)
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testProcessWindows10Creator(self):
     """Tests the Process function for Windows 10 Creator AppCompatCache data."""
@@ -522,7 +529,8 @@ class AppCompatCacheWindowsRegistryPluginTest(test_lib.RegistryPluginTestCase):
         event_data.key_path, event_index + 1, expected_path)
     expected_short_message = 'Path: {0:s}'.format(expected_path)
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/bagmru.py
+++ b/tests/parsers/winreg_plugins/bagmru.py
@@ -85,11 +85,14 @@ class TestBagMRUWindowsRegistryPlugin(test_lib.RegistryPluginTestCase):
         'Shell item path: <My Computer>').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[1]
 
     self.CheckTimestamp(event.timestamp, '2009-08-04 15:19:10.669625')
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
 
     expected_message = (
         '[{0:s}\\0] '
@@ -97,17 +100,21 @@ class TestBagMRUWindowsRegistryPlugin(test_lib.RegistryPluginTestCase):
         'Shell item path: <My Computer> C:\\').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[14]
 
     self.CheckTimestamp(event.timestamp, '2009-08-04 15:19:16.997750')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     # The winreg_formatter will add a space after the key path even when there
     # is not text.
     expected_message = '[{0:s}\\0\\0\\0\\0\\0] '.format(key_path)
 
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/ccleaner.py
+++ b/tests/parsers/winreg_plugins/ccleaner.py
@@ -56,7 +56,8 @@ class CCleanerRegistryPluginTest(test_lib.RegistryPluginTestCase):
 
     expected_message = 'Origin: {0:s}'.format(key_path)
 
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[1]
 
@@ -87,7 +88,8 @@ class CCleanerRegistryPluginTest(test_lib.RegistryPluginTestCase):
 
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/default.py
+++ b/tests/parsers/winreg_plugins/default.py
@@ -93,7 +93,8 @@ class TestDefaultRegistry(test_lib.RegistryPluginTestCase):
         'c: [REG_SZ] C:/looks_legit.exe').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/lfu.py
+++ b/tests/parsers/winreg_plugins/lfu.py
@@ -132,7 +132,8 @@ class BootExecutePluginTest(test_lib.RegistryPluginTestCase):
         'BootExecute: autocheck autochk *').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[1]
 
@@ -154,7 +155,8 @@ class BootExecutePluginTest(test_lib.RegistryPluginTestCase):
         'NumberOfInitialSessions: [REG_SZ] 2').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 class BootVerificationPluginTest(test_lib.RegistryPluginTestCase):
@@ -227,7 +229,8 @@ class BootVerificationPluginTest(test_lib.RegistryPluginTestCase):
             key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/mountpoints.py
+++ b/tests/parsers/winreg_plugins/mountpoints.py
@@ -67,7 +67,8 @@ class MountPoints2PluginTest(test_lib.RegistryPluginTestCase):
         'Volume: ##controller#home#nfury').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/mrulist.py
+++ b/tests/parsers/winreg_plugins/mrulist.py
@@ -124,7 +124,8 @@ class TestMRUListStringWindowsRegistryPlugin(test_lib.RegistryPluginTestCase):
         'Index: 3 [MRU Value b]: c:/evil.exe').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 class TestMRUListShellItemListWindowsRegistryPlugin(
@@ -221,7 +222,8 @@ class TestMRUListShellItemListWindowsRegistryPlugin(
             key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # A shell item event.
     event = events[0]
@@ -240,7 +242,8 @@ class TestMRUListShellItemListWindowsRegistryPlugin(
         'Origin: HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\'
         'CurrentVersi...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/mrulistex.py
+++ b/tests/parsers/winreg_plugins/mrulistex.py
@@ -131,7 +131,8 @@ class TestMRUListExStringWindowsRegistryPlugin(test_lib.RegistryPluginTestCase):
         'Index: 3 [MRU Value 1]: c:\\evil.exe').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 class TestMRUListExShellItemListWindowsRegistryPlugin(
@@ -195,7 +196,8 @@ class TestMRUListExShellItemListWindowsRegistryPlugin(
         '').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # A shell item event.
     event = events[0]
@@ -218,7 +220,8 @@ class TestMRUListExShellItemListWindowsRegistryPlugin(
         'NTFS file reference: 44518-33 '
         'Origin: HKEY_CURRENT_USER\\...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 class TestMRUListExStringAndShellItemWindowsRegistryPlugin(
@@ -312,7 +315,8 @@ class TestMRUListExStringAndShellItemWindowsRegistryPlugin(
         'Shell item: [wallpaper_medium.lnk]').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 class TestMRUListExStringAndShellItemListWindowsRegistryPlugin(
@@ -390,7 +394,8 @@ class TestMRUListExStringAndShellItemListWindowsRegistryPlugin(
         'Shell item path: <Users Libraries> <UNKNOWN: 0x00>').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/msie_zones.py
+++ b/tests/parsers/winreg_plugins/msie_zones.py
@@ -87,7 +87,7 @@ class MSIEZoneSettingsPluginTest(test_lib.RegistryPluginTestCase):
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
     self._TestGetMessageStrings(
-        event, expected_message, expected_short_message)
+        event_data, expected_message, expected_short_message)
 
   def testProcessNtuserZones(self):
     """Tests the Process function on a Zones key."""
@@ -139,7 +139,7 @@ class MSIEZoneSettingsPluginTest(test_lib.RegistryPluginTestCase):
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
     self._TestGetMessageStrings(
-        event, expected_message, expected_short_message)
+        event_data, expected_message, expected_short_message)
 
   def testProcessSoftwareLockdownZones(self):
     """Tests the Process function on a Lockdown_Zones key."""
@@ -268,7 +268,7 @@ class MSIEZoneSettingsPluginTest(test_lib.RegistryPluginTestCase):
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
     self._TestGetMessageStrings(
-        event, expected_message, expected_short_message)
+        event_data, expected_message, expected_short_message)
 
   def testProcessSoftwareZones(self):
     """Tests the Process function on a Zones key."""
@@ -401,7 +401,7 @@ class MSIEZoneSettingsPluginTest(test_lib.RegistryPluginTestCase):
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
     self._TestGetMessageStrings(
-        event, expected_message, expected_short_message)
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/network_drives.py
+++ b/tests/parsers/winreg_plugins/network_drives.py
@@ -169,7 +169,8 @@ class NetworkDrivesPluginTest(test_lib.RegistryPluginTestCase):
         'Type: Mapped Drive').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/networks.py
+++ b/tests/parsers/winreg_plugins/networks.py
@@ -233,7 +233,8 @@ class NetworksWindowsRegistryPluginTest(test_lib.RegistryPluginTestCase):
         'DNS Suffix: localdomain')
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[3]
 
@@ -251,7 +252,8 @@ class NetworksWindowsRegistryPluginTest(test_lib.RegistryPluginTestCase):
         'Connection Type: Wireless')
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/officemru.py
+++ b/tests/parsers/winreg_plugins/officemru.py
@@ -113,7 +113,8 @@ class OfficeMRUPluginTest(test_lib.RegistryPluginTestCase):
             key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test OfficeMRUWindowsRegistryEvent.
     event = events[0]
@@ -135,7 +136,8 @@ class OfficeMRUPluginTest(test_lib.RegistryPluginTestCase):
         '[F00000000][T01CD0146EA1EADB0][O00000000]*'
         'C:\\Users\\nfury\\Documents\\StarFury\\S...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/outlook.py
+++ b/tests/parsers/winreg_plugins/outlook.py
@@ -96,7 +96,8 @@ class MSOutlook2013SearchMRUPluginTest(test_lib.RegistryPluginTestCase):
         'username@example.com.ost: 0x00372bcf').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 # TODO: The catalog for Office 2013 (15.0) contains binary values not

--- a/tests/parsers/winreg_plugins/programscache.py
+++ b/tests/parsers/winreg_plugins/programscache.py
@@ -75,7 +75,8 @@ class ExplorerProgramCacheWindowsRegistryPluginTest(
         'Origin: HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\'
         'CurrentVe...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # The ProgramsCache list event.
     event = events[75]
@@ -116,7 +117,8 @@ class ExplorerProgramCacheWindowsRegistryPluginTest(
         '19: Internet Explorer (No Add-ons).lnk]').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # The Windows Registry key event.
     event = events[76]
@@ -139,7 +141,8 @@ class ExplorerProgramCacheWindowsRegistryPluginTest(
         'StartMenu_Start_Time: [REG_BINARY] (8 bytes)').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testProcessStartPage2(self):
     """Tests the Process function on a StartPage2 key."""

--- a/tests/parsers/winreg_plugins/run.py
+++ b/tests/parsers/winreg_plugins/run.py
@@ -92,7 +92,8 @@ class AutoRunsPluginTest(test_lib.RegistryPluginTestCase):
         '/autoRun').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testProcessNtuserRunOnce(self):
     """Tests the Process function on a Run key."""
@@ -130,7 +131,8 @@ class AutoRunsPluginTest(test_lib.RegistryPluginTestCase):
             key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testProcessSoftwareRun(self):
     """Tests the Process function on a Run key."""
@@ -172,7 +174,8 @@ class AutoRunsPluginTest(test_lib.RegistryPluginTestCase):
         'VMwareUser.exe"').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testProcessSoftwareRunOnce(self):
     """Tests the Process function on a RunOnce key."""
@@ -210,7 +213,8 @@ class AutoRunsPluginTest(test_lib.RegistryPluginTestCase):
         '-k -rq').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/sam_users.py
+++ b/tests/parsers/winreg_plugins/sam_users.py
@@ -66,7 +66,8 @@ class SAMUsersWindowsRegistryPluginTest(test_lib.RegistryPluginTestCase):
         'RID: 500 '
         'Login count: 6')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     # Test SAMUsersWindowsRegistryEvent.
     event = events[1]
@@ -90,7 +91,8 @@ class SAMUsersWindowsRegistryPluginTest(test_lib.RegistryPluginTestCase):
         'RID: 500 '
         'Login count: 6')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/services.py
+++ b/tests/parsers/winreg_plugins/services.py
@@ -128,7 +128,8 @@ class ServicesRegistryPluginTest(test_lib.RegistryPluginTestCase):
         'Group: [REG_SZ] Pnp Filter').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testProcessFile(self):
     """Tests the Process function on a key in a file."""

--- a/tests/parsers/winreg_plugins/shutdown.py
+++ b/tests/parsers/winreg_plugins/shutdown.py
@@ -62,7 +62,8 @@ class ShutdownWindowsRegistryPluginTest(test_lib.RegistryPluginTestCase):
         'Description: ShutdownTime').format(key_path)
     expected_short_message = 'ShutdownTime'
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/task_scheduler.py
+++ b/tests/parsers/winreg_plugins/task_scheduler.py
@@ -67,7 +67,8 @@ class TaskCacheWindowsRegistryPluginTest(test_lib.RegistryPluginTestCase):
     expected_short_message = (
         'Task: SynchronizeTime')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[1]
 
@@ -85,7 +86,8 @@ class TaskCacheWindowsRegistryPluginTest(test_lib.RegistryPluginTestCase):
     expected_short_message = (
         'Task: SynchronizeTime')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/terminal_server.py
+++ b/tests/parsers/winreg_plugins/terminal_server.py
@@ -96,7 +96,8 @@ class ServersTerminalServerClientPluginTest(test_lib.RegistryPluginTestCase):
         'Username hint: DOMAIN\\username').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[1]
 
@@ -109,7 +110,8 @@ class ServersTerminalServerClientPluginTest(test_lib.RegistryPluginTestCase):
         '[{0:s}] '
         '(empty)').format(key_path)
 
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
 
 class DefaultTerminalServerClientMRUPluginTest(test_lib.RegistryPluginTestCase):
@@ -178,7 +180,8 @@ class DefaultTerminalServerClientMRUPluginTest(test_lib.RegistryPluginTestCase):
         'MRU1: computer.domain.com').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/timezone.py
+++ b/tests/parsers/winreg_plugins/timezone.py
@@ -151,7 +151,8 @@ class WinRegTimezonePluginTest(test_lib.RegistryPluginTestCase):
         'TimeZoneKeyName: W. Europe Standard Time').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testProcessFile(self):
     """Tests the Process function on registry file."""
@@ -191,7 +192,8 @@ class WinRegTimezonePluginTest(test_lib.RegistryPluginTestCase):
         'TimeZoneKeyName: Eastern Standard Time').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/typedurls.py
+++ b/tests/parsers/winreg_plugins/typedurls.py
@@ -79,7 +79,8 @@ class MsieTypedURLsPluginTest(test_lib.RegistryPluginTestCase):
         'url13: http://go.microsoft.com/fwlink/?LinkId=69157').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 class TypedPathsPluginTest(test_lib.RegistryPluginTestCase):
@@ -120,7 +121,8 @@ class TypedPathsPluginTest(test_lib.RegistryPluginTestCase):
         '[{0:s}] '
         'url1: \\\\controller').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/usb.py
+++ b/tests/parsers/winreg_plugins/usb.py
@@ -64,7 +64,8 @@ class USBPluginTest(test_lib.RegistryPluginTestCase):
         'Vendor: VID_0E0F').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/usbstor.py
+++ b/tests/parsers/winreg_plugins/usbstor.py
@@ -72,7 +72,8 @@ class USBStorPlugin(test_lib.RegistryPluginTestCase):
         'Vendor: Ven_HP').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/userassist.py
+++ b/tests/parsers/winreg_plugins/userassist.py
@@ -84,7 +84,8 @@ class UserAssistPluginTest(test_lib.RegistryPluginTestCase):
         'Count: 14').format(key_path, expected_value_name)
     expected_short_message = '{0:s} Count: 14'.format(expected_value_name)
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testProcessOnWin7(self):
     """Tests the Process function on a Windows 7 Registry file."""
@@ -134,7 +135,8 @@ class UserAssistPluginTest(test_lib.RegistryPluginTestCase):
             key_path, expected_value_name)
     expected_short_message = '{0:s} Count: 14'.format(expected_value_name)
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/windows_version.py
+++ b/tests/parsers/winreg_plugins/windows_version.py
@@ -131,7 +131,8 @@ class WindowsVersionPluginTest(test_lib.RegistryPluginTestCase):
         'RegisteredOwner: [REG_SZ] A Concerned Citizen').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[1]
 
@@ -156,7 +157,8 @@ class WindowsVersionPluginTest(test_lib.RegistryPluginTestCase):
         'MyTestOS 5.1 Service Pack 1 '
         'Origin: HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Win...')
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
   def testProcessFile(self):
     """Tests the Process function on a Windows Registry file."""
@@ -212,7 +214,8 @@ class WindowsVersionPluginTest(test_lib.RegistryPluginTestCase):
         'SystemRoot: [REG_SZ] C:\\Windows').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/winlogon.py
+++ b/tests/parsers/winreg_plugins/winlogon.py
@@ -309,7 +309,8 @@ class WinlogonPluginTest(test_lib.RegistryPluginTestCase):
         'Trigger: Logoff').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
     event = events[13]
 
@@ -326,7 +327,8 @@ class WinlogonPluginTest(test_lib.RegistryPluginTestCase):
         'Trigger: Logon').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winreg_plugins/winrar.py
+++ b/tests/parsers/winreg_plugins/winrar.py
@@ -89,7 +89,8 @@ class WinRARHistoryPluginTest(test_lib.RegistryPluginTestCase):
         '0: C:\\Downloads\\The Sleeping Dragon CD1.iso '
         '1: C:\\Downloads\\plaso-static.rar').format(key_path)
     expected_short_message = '{0:s}...'.format(expected_message[:77])
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/winrestore.py
+++ b/tests/parsers/winrestore.py
@@ -44,7 +44,8 @@ class RestorePointLogParserTest(test_lib.ParserTestCase):
         'Restore point type: UNKNOWN').format(expected_description)
     expected_short_message = expected_description
 
-    self._TestGetMessageStrings(event, expected_message, expected_short_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_short_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/xchatlog.py
+++ b/tests/parsers/xchatlog.py
@@ -30,46 +30,73 @@ class XChatLogUnitTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2011-12-31 20:11:55.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = 'XChat start logging'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[1]
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
     expected_message = '--> You are now talking on #gugle'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[2]
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
     expected_message = '--- Topic for #gugle is plaso, a difficult word'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[3]
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
     expected_message = 'Topic for #gugle set by Kristinn'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[4]
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
     expected_message = '--- Joachim gives voice to fpi'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[5]
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
     expected_message = '* XChat here'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[6]
+
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
     expected_message = '[nickname: fpi] ola plas-ing guys!'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[7]
 
     self.CheckTimestamp(event.timestamp, '2011-12-31 22:00:00.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = '[nickname: STRANGER] \u65e5\u672c'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[8]
 
     self.CheckTimestamp(event.timestamp, '2011-12-31 22:59:00.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = 'XChat end logging'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/xchatscrollback.py
+++ b/tests/parsers/xchatscrollback.py
@@ -29,60 +29,86 @@ class XChatScrollbackUnitTest(test_lib.ParserTestCase):
 
     self.CheckTimestamp(event.timestamp, '2009-01-16 02:56:19.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = '[] * Speaking now on ##plaso##'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[1]
 
     self.CheckTimestamp(event.timestamp, '2009-01-16 02:56:27.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = '[] * Joachim \xe8 uscito (Client exited)'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[2]
 
     self.CheckTimestamp(event.timestamp, '2009-01-18 21:58:36.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = '[] Tcl interface unloaded'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[3]
 
     self.CheckTimestamp(event.timestamp, '2009-01-18 21:58:36.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = '[] Python interface unloaded'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[5]
     self.assertEqual(event.timestamp, 0)
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = '[nickname: fpi] 0 is a good timestamp'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[6]
 
     self.CheckTimestamp(event.timestamp, '2009-01-26 08:50:56.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = '[] * Topic of #plasify \xe8: .'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[7]
 
     self.CheckTimestamp(event.timestamp, '2009-01-26 08:51:02.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     event = events[8]
 
     self.CheckTimestamp(event.timestamp, '2009-01-26 08:52:12.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = '[nickname: fpi] Hi Kristinn!'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
     event = events[9]
 
     self.CheckTimestamp(event.timestamp, '2009-01-26 08:53:13.000000')
 
+    event_data = self._GetEventDataOfEvent(storage_writer, event)
+
     expected_message = '[nickname: Kristinn] GO AND WRITE PARSERS!!! O_o'
-    self._TestGetMessageStrings(event, expected_message, expected_message)
+    self._TestGetMessageStrings(
+        event_data, expected_message, expected_message)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changed _TestGetMessageStrings tests to use event_data #2684

* Changed `_TestGetMessageStrings` function
* Changed call to `_TestGetMessageStrings` in tests
* Changes to winlnk formatter to handle event data attributes set to None, to determine linked path
* Changes for consistency across tests