### PR TITLE
fix: parse `--artifact_filters_file` into correct option variable

### DIFF
--- a/plaso/cli/helpers/artifact_filters.py
+++ b/plaso/cli/helpers/artifact_filters.py
@@ -42,7 +42,7 @@ class ArtifactFiltersArgumentsHelper(interface.ArgumentsHelper):
 
     argument_group.add_argument(
         '--artifact_filters_file', '--artifact-filters_file',
-        dest='artifact_filters_file_path', type=str, default=None,
+        dest='artifact_filters_file', type=str, default=None,
         metavar='PATH', action='store', help=(
             'Names of forensic artifact definitions, provided in a file with '
             'one artifact name per line. Forensic artifacts are stored in '


### PR DESCRIPTION
## One line description of pull request

parse `--artifact_filters_file` into correct option variable

## Description:

parse `--artifact_filters_file` into correct option variable