### PR TITLE
Changed escaping of UsnJrnl path in Windows text-based filter file

### DIFF
--- a/data/filter_windows.txt
+++ b/data/filter_windows.txt
@@ -19,7 +19,7 @@
 # File system metadata files.
 /[$]MFT
 /[$]LogFile
-/[$]Extend/$UsnJrnl
+/[$]Extend/[$]UsnJrnl
 # Recycle Bin and Recycler.
 /[$]Recycle.Bin
 /[$]Recycle.Bin/.+


### PR DESCRIPTION
## One line description of pull request
Adding brackets to "$" in "$Usnjrnl" in filter_windows.txt


## Description:
The $Usnjrnl is not found unless the $ is bracketed.

**Related issue (if applicable):** fixes #<plaso issue number here>

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
