### PR TITLE
Changed processing time to indicate number of days

### DIFF
--- a/plaso/cli/status_view.py
+++ b/plaso/cli/status_view.py
@@ -339,23 +339,24 @@ class StatusView(object):
     Args:
       processing_status (ProcessingStatus): processing status.
     """
-    if not processing_status:
-      processing_time = 0
-    else:
+    processing_time = 0
+    if processing_status:
       processing_time = time.time() - processing_status.start_time
-    days, remainder = divmod(int(processing_time), 24 * 60 * 60)
-    hours, remainder = divmod(remainder, 60 * 60)
-    minutes, seconds = divmod(remainder, 60)
+
+    processing_time, seconds = divmod(int(processing_time), 60)
+    processing_time, minutes = divmod(processing_time, 60)
+    days, hours = divmod(processing_time, 24)
+
     if days == 0:
-      days = ''
+      days_string = ''
     elif days == 1:
-      days = '1 day, '
+      days_string = '1 day, '
     else:
-      days = '{0:d} days, '.format(days)
+      days_string = '{0:d} days, '.format(days)
 
     self._output_writer.Write(
         'Processing time\t\t: {0:s}{1:02d}:{2:02d}:{3:02d}\n'.format(
-            days, hours, minutes, seconds))
+            days_string, hours, minutes, seconds))
 
   def _PrintTasksStatus(self, processing_status):
     """Prints the status of the tasks.

--- a/plaso/cli/status_view.py
+++ b/plaso/cli/status_view.py
@@ -340,14 +340,22 @@ class StatusView(object):
       processing_status (ProcessingStatus): processing status.
     """
     if not processing_status:
-      processing_time = '00:00:00'
+      processing_time = 0
     else:
       processing_time = time.time() - processing_status.start_time
-      time_struct = time.gmtime(processing_time)
-      processing_time = time.strftime('%H:%M:%S', time_struct)
+    days, remainder = divmod(int(processing_time), 24 * 60 * 60)
+    hours, remainder = divmod(remainder, 60 * 60)
+    minutes, seconds = divmod(remainder, 60)
+    if days == 0:
+      days = ''
+    elif days == 1:
+      days = '1 day, '
+    else:
+      days = '{0:d} days, '.format(days)
 
     self._output_writer.Write(
-        'Processing time\t\t: {0:s}\n'.format(processing_time))
+        'Processing time\t\t: {0:s}{1:02d}:{2:02d}:{3:02d}\n'.format(
+            days, hours, minutes, seconds))
 
   def _PrintTasksStatus(self, processing_status):
     """Prints the status of the tasks.


### PR DESCRIPTION
## Display correct duration if analysis takes more than 24 hours


## Description:
If a scan takes more than 24 hours the use of `time.strftime` hides the number of days.
This PR fixes this problem.
Also added tests to verify the output of `_PrintProcessingTime`.


## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
