### PR TITLE
tag_linux.txt

### DIFF
--- a/data/tag_linux.txt
+++ b/data/tag_linux.txt
@@ -14,6 +14,7 @@ login_failed
   reporter is 'sshd' AND body contains 'uthentication failure'
   data_type is 'selinux:line' AND audit_type is 'USER_LOGIN' AND body contains 'res=failed'
   data_type is 'selinux:line' AND audit_type is 'ANOM_LOGIN_FAILURES'
+  reporter is 'xscreensaver' AND body contains 'FAILED LOGIN'
 
 logout
   reporter is 'login' AND body contains 'session closed'

--- a/data/tag_linux.txt
+++ b/data/tag_linux.txt
@@ -5,7 +5,9 @@ application_execution
 
 login
   reporter is 'login' AND (body contains 'session opened' OR body contains 'logged in' OR body contains 'ROOT LOGIN')
+  reporter is 'sshd' AND (body contains 'Starting session' OR body contains 'session opened')
   data_type is 'selinux:line' AND audit_type is 'LOGIN'
+  data_type is 'linux:utmp:event' AND type == 7
 
 login_failed
   data_type is 'syslog:line' AND body contains 'pam_tally2'
@@ -15,10 +17,25 @@ login_failed
 
 logout
   reporter is 'login' AND body contains 'session closed'
+  reporter is 'sshd' AND (body contains 'session closed' OR body contains 'Close session')
   reporter is 'systemd-logind' AND body contains 'logged out'
+  # This will also flag dead gettys that init kills during shutdown/reboot (at least with SysV init)
+  data_type is 'linux:utmp:event' AND type == 8 AND terminal != '' AND pid != 0
+
+session_start
+  reporter is 'systemd-logind' and body contains 'New session'
+
+session_stop
+  reporter is 'systemd-logind' and body contains 'Removed session'
 
 boot
-  data_type is 'linux:utmp:event' AND terminal is 'system boot'
+  data_type is 'linux:utmp:event' AND terminal is 'system boot' AND username is 'reboot' AND type == 2
+
+shutdown
+  data_type is 'linux:utmp:event' AND (terminal is '~~' OR terminal is 'system boot') and type == 1 and username is 'shutdown'
+
+runlevel
+  data_type is 'linux:utmp:event' AND type == 1 AND username is 'runlevel'
 
 device_connection
   reporter is 'kernel' AND body contains 'New USB device found'

--- a/data/tag_linux.txt
+++ b/data/tag_linux.txt
@@ -1,0 +1,44 @@
+application_execution
+  reporter is 'sudo' AND body contains 'COMMAND='
+  data_type is 'selinux:line' AND audit_type is 'EXECVE'
+  data_type is 'syslog:cron:task_run' OR data_type is 'bash:history:command' OR data_type is 'shell:zsh:history' OR data_type is 'docker:json:layer'
+
+login
+  reporter is 'login' AND (body contains 'session opened' OR body contains 'logged in' OR body contains 'ROOT LOGIN')
+  data_type is 'selinux:line' AND audit_type is 'LOGIN'
+
+login_failed
+  data_type is 'syslog:line' AND body contains 'pam_tally2'
+  reporter is 'sshd' AND body contains 'uthentication failure'
+  data_type is 'selinux:line' AND audit_type is 'USER_LOGIN' AND body contains 'res=failed'
+  data_type is 'selinux:line' AND audit_type is 'ANOM_LOGIN_FAILURES'
+
+logout
+  reporter is 'login' AND body contains 'session closed'
+  reporter is 'systemd-logind' AND body contains 'logged out'
+
+boot
+  data_type is 'linux:utmp:event' AND terminal is 'system boot'
+
+device_connection
+  reporter is 'kernel' AND body contains 'New USB device found'
+
+device_disconnection
+  reporter is 'kernel' AND body contains 'USB disconnect'
+
+application_install
+  data_type is 'dpkg:line' AND body contains 'status installed'
+
+service_start
+  data_type is 'selinux:line' AND audit_type is 'SERVICE_START'
+
+service_stop
+  data_type is 'selinux:line' AND audit_type is 'SERVICE_STOP'
+
+promiscuous
+  data_type is 'selinux:line' AND audit_type is 'ANOM_PROMISCUOUS'
+  reporter is 'kernel' AND body contains 'promiscuous mode'
+
+crash
+  data_type is 'selinux:line' AND audit_type is 'ANOM_ABEND'
+  reporter is 'kernel' AND body contains 'segfault'


### PR DESCRIPTION
## Linux tags for the tagging analysis plugin

## Description:

Wanted to open this up for discussion. So I made (initial) `tag_linux.txt` as it was completely missing from Plaso. I threw together some tags that I would see myself needing, but this is not yet complete and I want to improve this before possible merging.

Notes:

* `data_type is 'syslog:line'` shouldn't be used as it could also be `systemd:journal`. In these cases I think `reporter` is better.
* Same information can be available from different components and I think we should tag all of them and not rely on single component logging some event (e.g. login event that can be logged via PAM, audit or systemd-login)
* Should we separate login vs. authentication events?
    * Or logins & sessions?
* I tried this with Plaso's `test_data/` and also some data of my own
* What else needs to be tagged? Some ideas:
    * Kernel module loads/unloads
    * User account modifications
    * Application installs in different distros
    * Mounts/unmounts
    * Ptrace events
    * Syslog resets or HUPs
    * OOM kills, kernel panics & core dumps
    * `at`
    * AppArmor stuff

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
