### PR TITLE
change filter for config.json for possibility to view config.v2.json

### DIFF
--- a/plaso/parsers/docker.py
+++ b/plaso/parsers/docker.py
@@ -293,9 +293,9 @@ class DockerJSONParser(interface.FileObjectParser):
     split_path = file_system.SplitPath(json_file_path)
     try:
       if 'containers' in split_path:
-        #if 'config.json' in split_path:
-        #Change because the name can be config.v2.json ...
-        if split_path and split_path[-1].startswith('config') and split_path[-1].endswith('.json'):
+        # For our intent, both version of the config file can be parsed
+        # the same way
+        if split_path[-1] in ['config.json', 'config.v2.json']:
           self._ParseContainerConfigJSON(parser_mediator, file_object)
         if json_file_path.endswith('-json.log'):
           self._ParseContainerLogJSON(parser_mediator, file_object)

--- a/plaso/parsers/docker.py
+++ b/plaso/parsers/docker.py
@@ -293,7 +293,9 @@ class DockerJSONParser(interface.FileObjectParser):
     split_path = file_system.SplitPath(json_file_path)
     try:
       if 'containers' in split_path:
-        if 'config.json' in split_path:
+        #if 'config.json' in split_path:
+        #Change because the name can be config.v2.json ...
+        if split_path and split_path[-1].startswith('config') and split_path[-1].endswith('.json'):
           self._ParseContainerConfigJSON(parser_mediator, file_object)
         if json_file_path.endswith('-json.log'):
           self._ParseContainerLogJSON(parser_mediator, file_object)


### PR DESCRIPTION
## One line description of pull request

The docker parser don't detect config.v2.json because the name must be 'config.json'.
Change verification for detect 'config*.json' file.

## Description:

-if 'config.json' in split_path:
+if split_path and split_path[-1].startswith('config') and split_path[-1].endswith('.json'):

## Notes:

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
