### PR TITLE
Change isAlive to is_alive for Python 3.9 compatibility.

### DIFF
--- a/plaso/engine/zeromq_queue.py
+++ b/plaso/engine/zeromq_queue.py
@@ -657,7 +657,7 @@ class ZeroMQBufferedQueue(ZeroMQQueue):
       if self._zmq_thread:
         logger.debug('[{0:s}] Waiting for thread to exit.'.format(self.name))
         self._zmq_thread.join(timeout=self.timeout_seconds)
-        if self._zmq_thread.isAlive():
+        if self._zmq_thread.is_alive():
           logger.error((
               '{0:s} ZMQ responder thread did not exit within timeout').format(
                   self.name))

--- a/plaso/multi_processing/engine.py
+++ b/plaso/multi_processing/engine.py
@@ -393,7 +393,7 @@ class MultiProcessEngine(engine.BaseEngine):
   def _StopStatusUpdateThread(self):
     """Stops the status update thread."""
     self._status_update_active = False
-    if self._status_update_thread.isAlive():
+    if self._status_update_thread.is_alive():
       self._status_update_thread.join()
     self._status_update_thread = None
 

--- a/plaso/multi_processing/plaso_xmlrpc.py
+++ b/plaso/multi_processing/plaso_xmlrpc.py
@@ -147,7 +147,7 @@ class ThreadedXMLRPCServer(rpc.RPCServer):
     """Stops the process status RPC server."""
     self._Close()
 
-    if self._rpc_thread.isAlive():
+    if self._rpc_thread.is_alive():
       self._rpc_thread.join()
     self._rpc_thread = None
 


### PR DESCRIPTION
## One line description of pull request

* Change `isAlive` to `is_alive` for Python 3.9 compatibility.

## Description:

* `isAlive` was deprecated in Python 3.8 and removed in Python 3.9 . Replace `isAlive` with `is_alive` to fix `DeprecationWarning`.

**Related issue (if applicable):** fixes #2656 

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
