### PR TITLE
fix(timesketch_out): set SearchIndex status to ready when done

### DIFF
--- a/plaso/output/timesketch_out.py
+++ b/plaso/output/timesketch_out.py
@@ -50,9 +50,7 @@ class TimesketchOutputModule(shared_elastic.SharedElasticsearchOutputModule):
     with self._timesketch.app_context():
       search_index = timesketch_sketch.SearchIndex.query.filter_by(
           index_name=self._index_name).first()
-      search_index.status.remove(search_index.status[0])
-      timesketch_db_session.add(search_index)
-      timesketch_db_session.commit()
+      search_index.set_status('ready')
 
   def GetMissingArguments(self):
     """Retrieves a list of arguments that are missing from the input.


### PR DESCRIPTION
## One line description of pull request

Timesketch Output: set status to ready when done processing events.

## Description:

Set the correct status on the SearchIndex when done processing so that the index appears in the Timesketch UI (which only displays indices in the "ready" state).

This should fix https://github.com/google/timesketch/issues/571

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [x] Reviewer assigned
