### PR TITLE
Fix executable path in Winprefetch.py

### DIFF
--- a/plaso/parsers/winprefetch.py
+++ b/plaso/parsers/winprefetch.py
@@ -122,6 +122,7 @@ class WinPrefetchParser(interface.FileObjectParser):
         if (filename.startswith(volume_device_path) and
             filename.endswith(executable_filename)):
           _, _, path = filename.partition(volume_device_path)
+          break
 
     mapped_files = []
     for entry_index, file_metrics in enumerate(scca_file.file_metrics_entries):


### PR DESCRIPTION
Fix executable path in Winprefetch.py

## One line description of pull request
First occurence of executable path in the files reference list is more likely to be correct.


## Description:
First occurence of executable path in the files reference list is more likely to be correct.

E.g., 64-bit version of Internet Explorer 11 can start x86 version of itself which results in the following situation:

The .pf file of 64-bit version of IE has two records ending with 'iexplore.exe': 
- path to 64-bit version (with smaller index in the files reference list);
- path to x86 version (with higher index, the one which is now wrongly shown by log2timeline as executable path).


## Checklist:
  - [x] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [x] Reviewer assigned
