### PR TITLE
Made test paths independent of working directory.

### DIFF
--- a/tests/analysis/chrome_extension.py
+++ b/tests/analysis/chrome_extension.py
@@ -20,8 +20,6 @@ class MockChromeExtensionPlugin(chrome_extension.ChromeExtensionPlugin):
 
   NAME = 'chrome_extension_test'
 
-  _TEST_DATA_PATH = os.path.join(os.getcwd(), 'test_data')
-
   def _GetChromeWebStorePage(self, extension_identifier):
     """Retrieves the page for the extension from the Chrome store website.
 
@@ -40,19 +38,6 @@ class MockChromeExtensionPlugin(chrome_extension.ChromeExtensionPlugin):
       page_content = file_object.read()
 
     return page_content.decode('utf-8')
-
-  def _GetTestFilePath(self, path_segments):
-    """Retrieves the path of a test file in the test data directory.
-
-    Args:
-    path_segments (list[str]): path segments inside the test data directory.
-
-    Returns:
-      str: path of the test file.
-    """
-    # Note that we need to pass the individual path segments to os.path.join
-    # and not a list.
-    return os.path.join(self._TEST_DATA_PATH, *path_segments)
 
 
 class ChromeExtensionTest(test_lib.AnalysisPluginTestCase):

--- a/tests/analysis/init_imports.py
+++ b/tests/analysis/init_imports.py
@@ -4,7 +4,6 @@
 
 from __future__ import unicode_literals
 
-import os
 import unittest
 
 from tests import test_lib
@@ -13,14 +12,14 @@ from tests import test_lib
 class AnalysisImportTest(test_lib.ImportCheckTestCase):
   """Tests that analysis plugin classes are imported correctly."""
 
-  _ANALYSIS_PATH = os.path.join(test_lib.PROJECT_PATH, 'plaso', 'analysis')
   _IGNORABLE_FILES = frozenset([
       'logger.py', 'manager.py', 'definitions.py', 'mediator.py',
       'interface.py'])
 
   def testAnalysisPluginsImported(self):
     """Tests that all parsers are imported."""
-    self._AssertFilesImportedInInit(self._ANALYSIS_PATH, self._IGNORABLE_FILES)
+    self._AssertFilesImportedInInit(
+        test_lib.ANALYSIS_PATH, self._IGNORABLE_FILES)
 
 
 if __name__ == '__main__':

--- a/tests/analysis/init_imports.py
+++ b/tests/analysis/init_imports.py
@@ -13,7 +13,7 @@ from tests import test_lib
 class AnalysisImportTest(test_lib.ImportCheckTestCase):
   """Tests that analysis plugin classes are imported correctly."""
 
-  _ANALYSIS_PATH = os.path.join(os.getcwd(), 'plaso', 'analysis')
+  _ANALYSIS_PATH = os.path.join(test_lib.PROJECT_PATH, 'plaso', 'analysis')
   _IGNORABLE_FILES = frozenset([
       'logger.py', 'manager.py', 'definitions.py', 'mediator.py',
       'interface.py'])

--- a/tests/analyzers/init_imports.py
+++ b/tests/analyzers/init_imports.py
@@ -14,7 +14,7 @@ from tests import test_lib
 class AnalyzersImportTest(test_lib.ImportCheckTestCase):
   """Tests that analyzer and hasher classes are imported correctly."""
 
-  _ANALYZERS_PATH = os.path.join(os.getcwd(), 'plaso', 'analyzers')
+  _ANALYZERS_PATH = os.path.join(test_lib.PROJECT_PATH, 'plaso', 'analyzers')
   _IGNORABLE_FILES = frozenset(['logger.py', 'manager.py', 'interface.py'])
 
   def testAnalyzersImported(self):

--- a/tests/analyzers/init_imports.py
+++ b/tests/analyzers/init_imports.py
@@ -14,20 +14,20 @@ from tests import test_lib
 class AnalyzersImportTest(test_lib.ImportCheckTestCase):
   """Tests that analyzer and hasher classes are imported correctly."""
 
-  _ANALYZERS_PATH = os.path.join(test_lib.PROJECT_PATH, 'plaso', 'analyzers')
   _IGNORABLE_FILES = frozenset(['logger.py', 'manager.py', 'interface.py'])
 
   def testAnalyzersImported(self):
     """Tests that all parsers are imported."""
-    self._AssertFilesImportedInInit(self._ANALYZERS_PATH, self._IGNORABLE_FILES)
+    self._AssertFilesImportedInInit(
+        test_lib.ANALYZERS_PATH, self._IGNORABLE_FILES)
 
   def testHashersImported(self):
     """Tests that all plugins are imported."""
-    parsers_glob = '{0:s}/*_hashers/'.format(self._ANALYZERS_PATH)
+    parsers_glob = '{0:s}/*_hashers/'.format(test_lib.ANALYZERS_PATH)
     plugin_directories = glob.glob(parsers_glob)
     for plugin_directory in plugin_directories:
       plugin_directory_path = os.path.join(
-          self._ANALYZERS_PATH, plugin_directory)
+          test_lib.ANALYZERS_PATH, plugin_directory)
       self._AssertFilesImportedInInit(
           plugin_directory_path, self._IGNORABLE_FILES)
 

--- a/tests/cli/helpers/init_imports.py
+++ b/tests/cli/helpers/init_imports.py
@@ -4,7 +4,6 @@
 
 from __future__ import unicode_literals
 
-import os
 import unittest
 
 from tests import test_lib
@@ -13,14 +12,12 @@ from tests import test_lib
 class CLIHelperImportTest(test_lib.ImportCheckTestCase):
   """Tests that CLI helper classes are imported correctly."""
 
-  _CLI_HELPERS_PATH = os.path.join(
-      test_lib.PROJECT_PATH, 'plaso', 'cli', 'helpers')
   _IGNORABLE_FILES = frozenset(['manager.py', 'interface.py'])
 
   def testCLIHelpersImported(self):
     """Tests that all parsers are imported."""
     self._AssertFilesImportedInInit(
-        self._CLI_HELPERS_PATH, self._IGNORABLE_FILES)
+        test_lib.CLI_HELPERS_PATH, self._IGNORABLE_FILES)
 
 
 if __name__ == '__main__':

--- a/tests/cli/helpers/init_imports.py
+++ b/tests/cli/helpers/init_imports.py
@@ -13,7 +13,8 @@ from tests import test_lib
 class CLIHelperImportTest(test_lib.ImportCheckTestCase):
   """Tests that CLI helper classes are imported correctly."""
 
-  _CLI_HELPERS_PATH = os.path.join(os.getcwd(), 'plaso', 'cli', 'helpers')
+  _CLI_HELPERS_PATH = os.path.join(
+      test_lib.PROJECT_PATH, 'plaso', 'cli', 'helpers')
   _IGNORABLE_FILES = frozenset(['manager.py', 'interface.py'])
 
   def testCLIHelpersImported(self):

--- a/tests/cli/image_export_tool.py
+++ b/tests/cli/image_export_tool.py
@@ -158,7 +158,7 @@ class ImageExportToolTest(test_lib.CLIToolTestCase):
     """Tests the _ParseSignatureIdentifiers function."""
     test_tool = image_export_tool.ImageExportTool()
 
-    test_tool._ParseSignatureIdentifiers(self._DATA_PATH, 'gzip')
+    test_tool._ParseSignatureIdentifiers(shared_test_lib.DATA_PATH, 'gzip')
 
     with self.assertRaises(ValueError):
       test_tool._ParseSignatureIdentifiers(None, 'gzip')
@@ -195,7 +195,7 @@ class ImageExportToolTest(test_lib.CLIToolTestCase):
     output_writer = test_lib.TestOutputWriter(encoding='utf-8')
     test_tool = image_export_tool.ImageExportTool(output_writer=output_writer)
 
-    test_tool._data_location = self._TEST_DATA_PATH
+    test_tool._data_location = shared_test_lib.TEST_DATA_PATH
 
     test_tool.ListSignatureIdentifiers()
 

--- a/tests/containers/init_imports.py
+++ b/tests/containers/init_imports.py
@@ -4,7 +4,6 @@
 
 from __future__ import unicode_literals
 
-import os
 import unittest
 
 from tests import test_lib
@@ -13,13 +12,12 @@ from tests import test_lib
 class ContainersImportTest(test_lib.ImportCheckTestCase):
   """Tests that container classes are imported correctly."""
 
-  _CONTAINERS_PATH = os.path.join(test_lib.PROJECT_PATH, 'plaso', 'containers')
   _IGNORABLE_FILES = frozenset(['manager.py', 'interface.py'])
 
   def testContainersImported(self):
     """Tests that all parsers are imported."""
     self._AssertFilesImportedInInit(
-        self._CONTAINERS_PATH, self._IGNORABLE_FILES)
+        test_lib.CONTAINERS_PATH, self._IGNORABLE_FILES)
 
 
 if __name__ == '__main__':

--- a/tests/containers/init_imports.py
+++ b/tests/containers/init_imports.py
@@ -13,7 +13,7 @@ from tests import test_lib
 class ContainersImportTest(test_lib.ImportCheckTestCase):
   """Tests that container classes are imported correctly."""
 
-  _CONTAINERS_PATH = os.path.join(os.getcwd(), 'plaso', 'containers')
+  _CONTAINERS_PATH = os.path.join(test_lib.PROJECT_PATH, 'plaso', 'containers')
   _IGNORABLE_FILES = frozenset(['manager.py', 'interface.py'])
 
   def testContainersImported(self):

--- a/tests/formatters/init_imports.py
+++ b/tests/formatters/init_imports.py
@@ -13,7 +13,6 @@ from tests import test_lib
 class FormattersImportTest(test_lib.ImportCheckTestCase):
   """Tests that CLI helper classes are imported correctly."""
 
-  _CLI_HELPERS_PATH = os.path.join(test_lib.PROJECT_PATH, 'plaso', 'formatters')
   _IGNORABLE_FILES = frozenset([
       'default.py', 'interface.py', 'logger.py', 'manager.py', 'mediator.py',
       'winevt_rc.py', 'yaml_formatters_file.py'])
@@ -21,7 +20,7 @@ class FormattersImportTest(test_lib.ImportCheckTestCase):
   def testFormattersImported(self):
     """Tests that all parsers are imported."""
     self._AssertFilesImportedInInit(
-        self._CLI_HELPERS_PATH, self._IGNORABLE_FILES)
+        test_lib.CLI_HELPERS_PATH, self._IGNORABLE_FILES)
 
 
 if __name__ == '__main__':

--- a/tests/formatters/init_imports.py
+++ b/tests/formatters/init_imports.py
@@ -4,7 +4,6 @@
 
 from __future__ import unicode_literals
 
-import os
 import unittest
 
 from tests import test_lib

--- a/tests/formatters/init_imports.py
+++ b/tests/formatters/init_imports.py
@@ -13,7 +13,7 @@ from tests import test_lib
 class FormattersImportTest(test_lib.ImportCheckTestCase):
   """Tests that CLI helper classes are imported correctly."""
 
-  _CLI_HELPERS_PATH = os.path.join(os.getcwd(), 'plaso', 'formatters')
+  _CLI_HELPERS_PATH = os.path.join(test_lib.PROJECT_PATH, 'plaso', 'formatters')
   _IGNORABLE_FILES = frozenset([
       'default.py', 'interface.py', 'logger.py', 'manager.py', 'mediator.py',
       'winevt_rc.py', 'yaml_formatters_file.py'])

--- a/tests/output/init_imports.py
+++ b/tests/output/init_imports.py
@@ -4,7 +4,6 @@
 
 from __future__ import unicode_literals
 
-import os
 import unittest
 
 from tests import test_lib
@@ -13,14 +12,13 @@ from tests import test_lib
 class OutputImportTest(test_lib.ImportCheckTestCase):
   """Tests that analysis plugin classes are imported correctly."""
 
-  _OUTPUT_PATH = os.path.join(test_lib.PROJECT_PATH, 'plaso', 'output')
   _IGNORABLE_FILES = frozenset([
       'logger.py', 'manager.py', 'mediator.py', 'interface.py',
       'shared_elastic.py', 'shared_json.py'])
 
   def testOutputModulesImported(self):
     """Tests that all output modules are imported."""
-    self._AssertFilesImportedInInit(self._OUTPUT_PATH, self._IGNORABLE_FILES)
+    self._AssertFilesImportedInInit(test_lib.OUTPUT_PATH, self._IGNORABLE_FILES)
 
 
 if __name__ == '__main__':

--- a/tests/output/init_imports.py
+++ b/tests/output/init_imports.py
@@ -13,7 +13,7 @@ from tests import test_lib
 class OutputImportTest(test_lib.ImportCheckTestCase):
   """Tests that analysis plugin classes are imported correctly."""
 
-  _OUTPUT_PATH = os.path.join(os.getcwd(), 'plaso', 'output')
+  _OUTPUT_PATH = os.path.join(test_lib.PROJECT_PATH, 'plaso', 'output')
   _IGNORABLE_FILES = frozenset([
       'logger.py', 'manager.py', 'mediator.py', 'interface.py',
       'shared_elastic.py', 'shared_json.py'])

--- a/tests/parsers/filestat.py
+++ b/tests/parsers/filestat.py
@@ -15,6 +15,7 @@ from plaso.lib import definitions
 from plaso.parsers import filestat
 
 from tests.parsers import test_lib
+from tests import test_lib as shared_test_lib
 
 
 class FileStatTest(test_lib.ParserTestCase):
@@ -124,7 +125,7 @@ class FileStatTest(test_lib.ParserTestCase):
     self.assertEqual(event_data.file_size, 1247)
     self.assertIsNone(event_data.inode)
 
-    test_path = os.path.join(self._TEST_DATA_PATH, 'syslog.gz')
+    test_path = os.path.join(shared_test_lib.TEST_DATA_PATH, 'syslog.gz')
     expected_message = (
         'GZIP:{0:s} '
         'Type: file').format(test_path)
@@ -233,7 +234,7 @@ class FileStatTest(test_lib.ParserTestCase):
     self.assertEqual(event_data.file_size, 10240)
     self.assertIsNone(event_data.inode)
 
-    test_path = os.path.join(self._TEST_DATA_PATH, 'syslog.tgz')
+    test_path = os.path.join(shared_test_lib.TEST_DATA_PATH, 'syslog.tgz')
     expected_message = (
         'GZIP:{0:s} '
         'Type: file').format(test_path)

--- a/tests/parsers/filestat.py
+++ b/tests/parsers/filestat.py
@@ -124,7 +124,7 @@ class FileStatTest(test_lib.ParserTestCase):
     self.assertEqual(event_data.file_size, 1247)
     self.assertIsNone(event_data.inode)
 
-    test_path = os.path.join(os.getcwd(), 'test_data', 'syslog.gz')
+    test_path = os.path.join(self._TEST_DATA_PATH, 'syslog.gz')
     expected_message = (
         'GZIP:{0:s} '
         'Type: file').format(test_path)
@@ -233,7 +233,7 @@ class FileStatTest(test_lib.ParserTestCase):
     self.assertEqual(event_data.file_size, 10240)
     self.assertIsNone(event_data.inode)
 
-    test_path = os.path.join(os.getcwd(), 'test_data', 'syslog.tgz')
+    test_path = os.path.join(self._TEST_DATA_PATH, 'syslog.tgz')
     expected_message = (
         'GZIP:{0:s} '
         'Type: file').format(test_path)

--- a/tests/parsers/init_imports.py
+++ b/tests/parsers/init_imports.py
@@ -14,7 +14,7 @@ from tests import test_lib
 class ParserImportTest(test_lib.ImportCheckTestCase):
   """Tests that parser classes are imported correctly."""
 
-  _PARSERS_PATH = os.path.join(os.getcwd(), 'plaso', 'parsers')
+  _PARSERS_PATH = os.path.join(test_lib.PROJECT_PATH, 'plaso', 'parsers')
   _IGNORABLE_FILES = frozenset([
       'dtfabric_parser.py', 'dtfabric_plugin.py', 'logger.py', 'manager.py',
       'presets.py', 'mediator.py', 'interface.py', 'plugins.py'])

--- a/tests/parsers/init_imports.py
+++ b/tests/parsers/init_imports.py
@@ -14,22 +14,22 @@ from tests import test_lib
 class ParserImportTest(test_lib.ImportCheckTestCase):
   """Tests that parser classes are imported correctly."""
 
-  _PARSERS_PATH = os.path.join(test_lib.PROJECT_PATH, 'plaso', 'parsers')
   _IGNORABLE_FILES = frozenset([
       'dtfabric_parser.py', 'dtfabric_plugin.py', 'logger.py', 'manager.py',
       'presets.py', 'mediator.py', 'interface.py', 'plugins.py'])
 
   def testParsersImported(self):
     """Tests that all parsers are imported."""
-    self._AssertFilesImportedInInit(self._PARSERS_PATH, self._IGNORABLE_FILES)
+    self._AssertFilesImportedInInit(
+        test_lib.PARSERS_PATH, self._IGNORABLE_FILES)
 
   def testPluginsImported(self):
     """Tests that all plugins are imported."""
-    parsers_glob = '{0:s}/*_plugins/'.format(self._PARSERS_PATH)
+    parsers_glob = '{0:s}/*_plugins/'.format(test_lib.PARSERS_PATH)
     plugin_directories = glob.glob(parsers_glob)
     for plugin_directory in plugin_directories:
       plugin_directory_path = os.path.join(
-          self._PARSERS_PATH, plugin_directory)
+          test_lib.PARSERS_PATH, plugin_directory)
       self._AssertFilesImportedInInit(
           plugin_directory_path, self._IGNORABLE_FILES)
 

--- a/tests/parsers/test_lib.py
+++ b/tests/parsers/test_lib.py
@@ -208,7 +208,7 @@ class ParserTestCase(shared_test_lib.BaseTestCase):
         formatters_directory_path)
 
     formatter_mediator = formatters_mediator.FormatterMediator(
-        data_location=self._DATA_PATH)
+        data_location=shared_test_lib.DATA_PATH)
     message, message_short = (
         formatters_manager.FormattersManager.GetMessageStrings(
             formatter_mediator, event_data))

--- a/tests/preprocessors/init_imports.py
+++ b/tests/preprocessors/init_imports.py
@@ -4,7 +4,6 @@
 
 from __future__ import unicode_literals
 
-import os
 import unittest
 
 from tests import test_lib
@@ -13,15 +12,13 @@ from tests import test_lib
 class PreprocessorsImportTest(test_lib.ImportCheckTestCase):
   """Tests that preprocessor classes are imported correctly."""
 
-  _PREPROCESSORS_PATH = os.path.join(
-      test_lib.PROJECT_PATH, 'plaso', 'preprocessors')
   _IGNORABLE_FILES = frozenset([
       'logger.py', 'manager.py', 'mediator.py', 'interface.py'])
 
   def testAnalysisPluginsImported(self):
     """Tests that all preprocessors are imported."""
     self._AssertFilesImportedInInit(
-        self._PREPROCESSORS_PATH, self._IGNORABLE_FILES)
+        test_lib.PREPROCESSORS_PATH, self._IGNORABLE_FILES)
 
 
 if __name__ == '__main__':

--- a/tests/preprocessors/init_imports.py
+++ b/tests/preprocessors/init_imports.py
@@ -13,7 +13,8 @@ from tests import test_lib
 class PreprocessorsImportTest(test_lib.ImportCheckTestCase):
   """Tests that preprocessor classes are imported correctly."""
 
-  _PREPROCESSORS_PATH = os.path.join(os.getcwd(), 'plaso', 'preprocessors')
+  _PREPROCESSORS_PATH = os.path.join(
+      test_lib.PROJECT_PATH, 'plaso', 'preprocessors')
   _IGNORABLE_FILES = frozenset([
       'logger.py', 'manager.py', 'mediator.py', 'interface.py'])
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -14,7 +14,7 @@ from dfvfs.lib import definitions as dfvfs_definitions
 from dfvfs.path import factory as path_spec_factory
 from dfvfs.resolver import resolver as path_spec_resolver
 
-PROJECT_PATH = os.path.normpath(
+PROJECT_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '..'))
 
 def GetTestFilePath(path_segments):
@@ -35,8 +35,8 @@ class BaseTestCase(unittest.TestCase):
   """The base test case."""
 
   _PROJECT_PATH = PROJECT_PATH
-  _DATA_PATH = os.path.join(_PROJECT_PATH, 'data')
-  _TEST_DATA_PATH = os.path.join(_PROJECT_PATH, 'test_data')
+  _DATA_PATH = os.path.abspath(os.path.join(_PROJECT_PATH, 'data'))
+  _TEST_DATA_PATH = os.path.abspath(os.path.join(_PROJECT_PATH, 'test_data'))
 
   # Show full diff results, part of TestCase so does not follow our naming
   # conventions.

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -14,6 +14,8 @@ from dfvfs.lib import definitions as dfvfs_definitions
 from dfvfs.path import factory as path_spec_factory
 from dfvfs.resolver import resolver as path_spec_resolver
 
+PROJECT_PATH = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), '..'))
 
 def GetTestFilePath(path_segments):
   """Retrieves the path of a test file in the test data directory.
@@ -26,14 +28,15 @@ def GetTestFilePath(path_segments):
   """
   # Note that we need to pass the individual path segments to os.path.join
   # and not a list.
-  return os.path.join(os.getcwd(), 'test_data', *path_segments)
+  return os.path.join(PROJECT_PATH, 'test_data', *path_segments)
 
 
 class BaseTestCase(unittest.TestCase):
   """The base test case."""
 
-  _DATA_PATH = os.path.join(os.getcwd(), 'data')
-  _TEST_DATA_PATH = os.path.join(os.getcwd(), 'test_data')
+  _PROJECT_PATH = PROJECT_PATH
+  _DATA_PATH = os.path.join(_PROJECT_PATH, 'data')
+  _TEST_DATA_PATH = os.path.join(_PROJECT_PATH, 'test_data')
 
   # Show full diff results, part of TestCase so does not follow our naming
   # conventions.
@@ -125,9 +128,7 @@ class ImportCheckTestCase(BaseTestCase):
         module_name, _, _ = filename.partition('.')
         import_expression = re.compile(r' import {0:s}\b'.format(module_name))
 
-        # pylint: disable=deprecated-method
-        # TODO: replace by assertRegex once Python 2 support is removed.
-        self.assertRegexpMatches(
+        self.assertRegex(
             init_content, import_expression,
             '{0:s} not imported in {1:s}'.format(module_name, init_path))
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -14,8 +14,20 @@ from dfvfs.lib import definitions as dfvfs_definitions
 from dfvfs.path import factory as path_spec_factory
 from dfvfs.resolver import resolver as path_spec_resolver
 
-PROJECT_PATH = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), '..'))
+# The path to top of the Plaso source tree.
+PROJECT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+# The paths below are all derived from the project path directory.
+# They are enumerated explicitly here so that they can be overwritten for
+# compatibility with different build systems.
+ANALYSIS_PATH = os.path.join(PROJECT_PATH, 'plaso', 'analysis')
+ANALYZERS_PATH = os.path.join(PROJECT_PATH, 'plaso', 'analyzers')
+CLI_HELPERS_PATH = os.path.join(PROJECT_PATH, 'plaso', 'cli', 'helpers')
+CONTAINERS_PATH = os.path.join(PROJECT_PATH, 'plaso', 'containers')
+DATA_PATH = os.path.join(PROJECT_PATH, 'data')
+OUTPUT_PATH = os.path.join(PROJECT_PATH, 'plaso', 'output')
+PARSERS_PATH = os.path.join(PROJECT_PATH, 'plaso', 'parsers')
+PREPROCESSORS_PATH = os.path.join(PROJECT_PATH, 'plaso', 'preprocessors')
+TEST_DATA_PATH = os.path.join(PROJECT_PATH, 'test_data')
 
 def GetTestFilePath(path_segments):
   """Retrieves the path of a test file in the test data directory.
@@ -28,15 +40,11 @@ def GetTestFilePath(path_segments):
   """
   # Note that we need to pass the individual path segments to os.path.join
   # and not a list.
-  return os.path.join(PROJECT_PATH, 'test_data', *path_segments)
+  return os.path.join(TEST_DATA_PATH, *path_segments)
 
 
 class BaseTestCase(unittest.TestCase):
   """The base test case."""
-
-  _PROJECT_PATH = PROJECT_PATH
-  _DATA_PATH = os.path.abspath(os.path.join(_PROJECT_PATH, 'data'))
-  _TEST_DATA_PATH = os.path.abspath(os.path.join(_PROJECT_PATH, 'test_data'))
 
   # Show full diff results, part of TestCase so does not follow our naming
   # conventions.
@@ -86,7 +94,7 @@ class BaseTestCase(unittest.TestCase):
     """
     # Note that we need to pass the individual path segments to os.path.join
     # and not a list.
-    return os.path.join(self._TEST_DATA_PATH, *path_segments)
+    return os.path.join(TEST_DATA_PATH, *path_segments)
 
   def _SkipIfPathNotExists(self, path):
     """Skips the test if the path does not exist.

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -81,7 +81,7 @@ class BaseTestCase(unittest.TestCase):
     """
     # Note that we need to pass the individual path segments to os.path.join
     # and not a list.
-    return os.path.join(self._DATA_PATH, *path_segments)
+    return os.path.join(DATA_PATH, *path_segments)
 
   def _GetTestFilePath(self, path_segments):
     """Retrieves the path of a test file in the test data directory.

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -14,6 +14,7 @@ from dfvfs.lib import definitions as dfvfs_definitions
 from dfvfs.path import factory as path_spec_factory
 from dfvfs.resolver import resolver as path_spec_resolver
 
+
 # The path to top of the Plaso source tree.
 PROJECT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 # The paths below are all derived from the project path directory.
@@ -28,6 +29,7 @@ OUTPUT_PATH = os.path.join(PROJECT_PATH, 'plaso', 'output')
 PARSERS_PATH = os.path.join(PROJECT_PATH, 'plaso', 'parsers')
 PREPROCESSORS_PATH = os.path.join(PROJECT_PATH, 'plaso', 'preprocessors')
 TEST_DATA_PATH = os.path.join(PROJECT_PATH, 'test_data')
+
 
 def GetTestFilePath(path_segments):
   """Retrieves the path of a test file in the test data directory.


### PR DESCRIPTION
## Description:
Currently, tests rely on the working directory being the project root. This PR makes the relevant functions locate test files (test_data directory etc.) without relying on the current value of the working directory.

## Checklist:
  - [x] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [x] Reviewer assigned
