### PR TITLE
Support Elasticsearch 7.x

### DIFF
--- a/plaso/output/shared_elastic.py
+++ b/plaso/output/shared_elastic.py
@@ -107,15 +107,12 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     """Inserts the buffered event documents into Elasticsearch."""
     try:
       # pylint: disable=unexpected-keyword-arg
-      # pylint does not recognizes request_timeout as a valid kwarg. According
-      # to http://elasticsearch-py.readthedocs.io/en/master/api.html#timeout
-      # it should be supported.
-      bulk_args = dict(
-        body=self._event_documents, index=self._index_name,
-        request_timeout=self._DEFAULT_REQUEST_TIMEOUT)
+      bulk_args = {
+          'body': self._event_documents, 'index': self._index_name,
+          'request_timeout': self._DEFAULT_REQUEST_TIMEOUT}
 
       # TODO: Remove once Elasticsearch v6.x is deprecated.
-      if self.GetClientMajorVersion() < 7:
+      if self._GetClientMajorVersion() < 7:
         bulk_args['doc_type'] = self._document_type
 
       self._client.bulk(**bulk_args)
@@ -237,7 +234,7 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     event_document = {'index': {'_index': self._index_name}}
 
     # TODO: Remove once Elasticsearch v6.x is deprecated.
-    if self.GetClientMajorVersion() < 7:
+    if self._GetClientMajorVersion() < 7:
       event_document['index']['_type'] = self._document_type
 
     event_values = self._GetSanitizedEventValues(event, event_data, event_tag)
@@ -258,12 +255,11 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
 
     self._client = None
 
-  def GetClientMajorVersion(self):
+  def _GetClientMajorVersion(self):
     """Get the major version of the Elasticsearch client library.
 
     Returns:
       int: Major version number.
-
     """
     return elasticsearch.__version__[0]
 

--- a/plaso/output/shared_elastic.py
+++ b/plaso/output/shared_elastic.py
@@ -107,15 +107,16 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     """Inserts the buffered event documents into Elasticsearch."""
     try:
       # pylint: disable=unexpected-keyword-arg
-      bulk_args = {
-          'body': self._event_documents, 'index': self._index_name,
+      bulk_arguments = {
+          'body': self._event_documents,
+          'index': self._index_name,
           'request_timeout': self._DEFAULT_REQUEST_TIMEOUT}
 
       # TODO: Remove once Elasticsearch v6.x is deprecated.
       if self._GetClientMajorVersion() < 7:
-        bulk_args['doc_type'] = self._document_type
+        bulk_arguments['doc_type'] = self._document_type
 
-      self._client.bulk(**bulk_args)
+      self._client.bulk(**bulk_arguments)
 
     except (
         ValueError,

--- a/plaso/output/timesketch_out.py
+++ b/plaso/output/timesketch_out.py
@@ -90,14 +90,19 @@ class TimesketchOutputModule(shared_elastic.SharedElasticsearchOutputModule):
     # This cannot be static because we use the value of self._document_type
     # from arguments.
     mappings = {
-        self._document_type: {
-            'properties': {
-                'timesketch_label': {
-                    'type': 'nested'
-                }
-            }
+      'properties': {
+        'timesketch_label': {
+          'type': 'nested'
+        },
+        'datetime': {
+          'type': 'date'
         }
+      }
     }
+
+    # TODO: Remove once Elasticsearch v6.x is deprecated.
+    if self.GetClientMajorVersion() < 7:
+      mappings = {self._document_type: mappings}
 
     # Get Elasticsearch host and port from Timesketch configuration.
     with self._timesketch.app_context():

--- a/plaso/output/timesketch_out.py
+++ b/plaso/output/timesketch_out.py
@@ -90,14 +90,14 @@ class TimesketchOutputModule(shared_elastic.SharedElasticsearchOutputModule):
     # This cannot be static because we use the value of self._document_type
     # from arguments.
     mappings = {
-      'properties': {
-        'timesketch_label': {
-          'type': 'nested'
-        },
-        'datetime': {
-          'type': 'date'
+        'properties': {
+            'timesketch_label': {
+              'type': 'nested'
+            },
+            'datetime': {
+              'type': 'date'
+            }
         }
-      }
     }
 
     # TODO: Remove once Elasticsearch v6.x is deprecated.

--- a/plaso/output/timesketch_out.py
+++ b/plaso/output/timesketch_out.py
@@ -92,10 +92,10 @@ class TimesketchOutputModule(shared_elastic.SharedElasticsearchOutputModule):
     mappings = {
         'properties': {
             'timesketch_label': {
-              'type': 'nested'
+                'type': 'nested'
             },
             'datetime': {
-              'type': 'date'
+                'type': 'date'
             }
         }
     }

--- a/plaso/output/timesketch_out.py
+++ b/plaso/output/timesketch_out.py
@@ -101,7 +101,7 @@ class TimesketchOutputModule(shared_elastic.SharedElasticsearchOutputModule):
     }
 
     # TODO: Remove once Elasticsearch v6.x is deprecated.
-    if self.GetClientMajorVersion() < 7:
+    if self._GetClientMajorVersion() < 7:
       mappings = {self._document_type: mappings}
 
     # Get Elasticsearch host and port from Timesketch configuration.


### PR DESCRIPTION
## One line description of pull request
Support Elasticsearch 7.x

## Description:
Support Elasticsearch 7.x but stay backwards compatible with versions prior to 7.
Tested with ES 7 and 6 server versions

**Related issue (if applicable):** fixes #<plaso issue number here>
#2465

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
