### PR TITLE
Corrected invalid plugin names in preset and added test

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -10,9 +10,10 @@ parsers:
 - sqlite/android_sms
 - sqlite/android_webview
 - sqlite/android_webviewcache
-- sqlite/chrome_27_history
 - sqlite/chrome_8_history
-- sqlite/chrome_cookies
+- sqlite/chrome_17_cookies
+- sqlite/chrome_27_history
+- sqlite/chrome_66_cookies
 - sqlite/skype
 ---
 name: linux
@@ -91,10 +92,11 @@ parsers:
 - opera_global
 - opera_typed_history
 - plist/safari_history
-- sqlite/chrome_27_history
 - sqlite/chrome_8_history
+- sqlite/chrome_17_cookies
+- sqlite/chrome_27_history
+- sqlite/chrome_66_cookies
 - sqlite/chrome_autofill
-- sqlite/chrome_cookies
 - sqlite/chrome_extension_activity
 - sqlite/firefox_cookies
 - sqlite/firefox_downloads

--- a/tests/parsers/presets.py
+++ b/tests/parsers/presets.py
@@ -4,10 +4,13 @@
 
 from __future__ import unicode_literals
 
+import os
 import unittest
 
 from plaso.containers import artifacts
 from plaso.parsers import presets
+from plaso.parsers import manager as parsers_manager
+from plaso.filters import parser_filter
 
 from tests import test_lib as shared_test_lib
 
@@ -162,6 +165,22 @@ class ParserPresetsManagerTest(shared_test_lib.BaseTestCase):
 
   # TODO add tests for ReadFromFile
 
+class PresetsDataTest(shared_test_lib.BaseTestCase):
+  """Tests for the default preset files."""
+
+  def testParsersandPresets(self):
+    presets_file_path = os.path.join(self._DATA_PATH, 'presets.yaml')
+
+    preset_manager = presets.ParserPresetsManager()
+    preset_manager.ReadFromFile(presets_file_path)
+    filter_helper = parser_filter.ParserFilterExpressionHelper()
+
+    for name in preset_manager.GetNames():
+      expanded_preset = filter_helper.ExpandPresets(preset_manager, name)
+      _, invalid_parser_elements = (
+          parsers_manager.ParsersManager.CheckFilterExpression(expanded_preset))
+      self.assertFalse(
+          invalid_parser_elements, msg='Invalid parser/plugin name(s)')
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/parsers/presets.py
+++ b/tests/parsers/presets.py
@@ -168,7 +168,8 @@ class ParserPresetsManagerTest(shared_test_lib.BaseTestCase):
 class PresetsDataTest(shared_test_lib.BaseTestCase):
   """Tests for the default preset files."""
 
-  def testParsersandPresets(self):
+  def testParsersAndPresets(self):
+    """Tests that all parsers/plugins in the default presets are valid."""
     presets_file_path = os.path.join(self._DATA_PATH, 'presets.yaml')
 
     preset_manager = presets.ParserPresetsManager()


### PR DESCRIPTION
## Description:
Corrected plugin names in default presets, which changed in https://github.com/log2timeline/plaso/commit/98c474ee98b6a07c11798cec9989a7d2613fe70a 
Also added a test for the default presets, to catch this sort of error in future.

## Checklist:
  - [x] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [x] Reviewer assigned
