### PR TITLE
Update presets.yaml with chrome_cookies split

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -10,9 +10,10 @@ parsers:
 - sqlite/android_sms
 - sqlite/android_webview
 - sqlite/android_webviewcache
+- sqlite/chrome_17_cookies
 - sqlite/chrome_27_history
+- sqlite/chrome_66_cookies
 - sqlite/chrome_8_history
-- sqlite/chrome_cookies
 - sqlite/skype
 ---
 name: linux
@@ -91,10 +92,11 @@ parsers:
 - opera_global
 - opera_typed_history
 - plist/safari_history
+- sqlite/chrome_17_cookies
 - sqlite/chrome_27_history
+- sqlite/chrome_66_cookies
 - sqlite/chrome_8_history
 - sqlite/chrome_autofill
-- sqlite/chrome_cookies
 - sqlite/chrome_extension_activity
 - sqlite/firefox_cookies
 - sqlite/firefox_downloads


### PR DESCRIPTION
chrome_cookies was split into chrome_17_cookies and chrome_66_cookies; update presets to reflect that.

**Related issue (if applicable):** fixes #2832 

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
