### PR TITLE
Added parser as an event attribute #2889

### DIFF
--- a/plaso/containers/events.py
+++ b/plaso/containers/events.py
@@ -17,6 +17,7 @@ class EventData(interface.AttributeContainer):
     data_type (str): event data type indicator.
     offset (int): offset relative to the start of the data stream where
         the event data is stored.
+    parser (str): string identifying the parser that produced the event data.
     query (str): query that was used to obtain the event data.
   """
   CONTAINER_TYPE = 'event_data'
@@ -30,6 +31,7 @@ class EventData(interface.AttributeContainer):
     super(EventData, self).__init__()
     self.data_type = data_type
     self.offset = None
+    self.parser = None
     self.query = None
 
 
@@ -51,6 +53,7 @@ class EventObject(interface.AttributeContainer):
     event_data_stream_number (int): number of the serialized event data stream,
         this attribute is used by the GZIP storage files to uniquely identify
         the event data linked to the tag.
+    parser (str): string identifying the parser that produced the event.
     tag (EventTag): event tag.
     timestamp (int): timestamp, which contains the number of microseconds
         since January 1, 1970, 00:00:00 UTC.
@@ -65,6 +68,7 @@ class EventObject(interface.AttributeContainer):
     self.event_data_entry_index = None
     self.event_data_row_identifier = None
     self.event_data_stream_number = None
+    self.parser = None
     self.tag = None
     self.timestamp = None
     # TODO: rename timestamp_desc to timestamp_description

--- a/plaso/storage/file_interface.py
+++ b/plaso/storage/file_interface.py
@@ -532,9 +532,9 @@ class StorageFileWriter(interface.StorageWriter):
     self._session.parsers_counter['total'] += 1
 
     # Here we want the name of the parser or plugin not the parser chain.
-    parser_name = getattr(event, 'parser', '')
-    _, _, parser_name = parser_name.rpartition('/')
-    if not parser_name:
+    if event.parser:
+      _, _, parser_name = event.parser.rpartition('/')
+    else:
       parser_name = 'N/A'
     self._session.parsers_counter[parser_name] += 1
 

--- a/tests/containers/events.py
+++ b/tests/containers/events.py
@@ -21,7 +21,7 @@ class EventDataTest(shared_test_lib.BaseTestCase):
     expected_attribute_names = [
         'data_type',
         'offset',
-        'parser'
+        'parser',
         'query']
 
     attribute_names = sorted(attribute_container.GetAttributeNames())

--- a/tests/containers/events.py
+++ b/tests/containers/events.py
@@ -21,6 +21,7 @@ class EventDataTest(shared_test_lib.BaseTestCase):
     expected_attribute_names = [
         'data_type',
         'offset',
+        'parser'
         'query']
 
     attribute_names = sorted(attribute_container.GetAttributeNames())
@@ -39,6 +40,7 @@ class EventObjectTest(shared_test_lib.BaseTestCase):
         'event_data_entry_index',
         'event_data_row_identifier',
         'event_data_stream_number',
+        'parser',
         'tag',
         'timestamp',
         'timestamp_desc']

--- a/tests/containers/plist_event.py
+++ b/tests/containers/plist_event.py
@@ -19,7 +19,7 @@ class PlistTimeEventDataTest(shared_test_lib.BaseTestCase):
     attribute_container = plist_event.PlistTimeEventData()
 
     expected_attribute_names = [
-        'data_type', 'desc', 'hostname', 'key', 'offset', 'query',
+        'data_type', 'desc', 'hostname', 'key', 'offset', 'parser', 'query',
         'root', 'username']
 
     attribute_names = sorted(attribute_container.GetAttributeNames())

--- a/tests/containers/shell_item_events.py
+++ b/tests/containers/shell_item_events.py
@@ -20,7 +20,7 @@ class ShellItemFileEntryEventDataTest(shared_test_lib.BaseTestCase):
 
     expected_attribute_names = [
         'data_type', 'file_reference', 'localized_name', 'long_name',
-        'name', 'offset', 'origin', 'query', 'shell_item_path']
+        'name', 'offset', 'origin', 'parser', 'query', 'shell_item_path']
 
     attribute_names = sorted(attribute_container.GetAttributeNames())
 

--- a/tests/containers/time_events.py
+++ b/tests/containers/time_events.py
@@ -22,7 +22,8 @@ class TimestampEventTest(shared_test_lib.BaseTestCase):
 
     expected_attribute_names = [
         'event_data_entry_index', 'event_data_row_identifier',
-        'event_data_stream_number', 'tag', 'timestamp', 'timestamp_desc']
+        'event_data_stream_number', 'parser', 'tag', 'timestamp',
+        'timestamp_desc']
 
     attribute_names = sorted(attribute_container.GetAttributeNames())
 
@@ -39,7 +40,8 @@ class DateTimeValuesEventTest(shared_test_lib.BaseTestCase):
 
     expected_attribute_names = [
         'event_data_entry_index', 'event_data_row_identifier',
-        'event_data_stream_number', 'tag', 'timestamp', 'timestamp_desc']
+        'event_data_stream_number', 'parser', 'tag', 'timestamp',
+        'timestamp_desc']
 
     attribute_names = sorted(attribute_container.GetAttributeNames())
 

--- a/tests/containers/windows_events.py
+++ b/tests/containers/windows_events.py
@@ -22,7 +22,8 @@ class WindowsDistributedLinkTrackingEventDataTest(shared_test_lib.BaseTestCase):
         windows_events.WindowsDistributedLinkTrackingEventData(test_uuid, None))
 
     expected_attribute_names = [
-        'data_type', 'mac_address', 'offset', 'origin', 'query', 'uuid']
+        'data_type', 'mac_address', 'offset', 'origin', 'parser', 'query',
+        'uuid']
 
     attribute_names = sorted(attribute_container.GetAttributeNames())
 
@@ -37,7 +38,7 @@ class WindowsVolumeEventDataTest(shared_test_lib.BaseTestCase):
     attribute_container = windows_events.WindowsVolumeEventData()
 
     expected_attribute_names = [
-        'data_type', 'device_path', 'offset', 'origin', 'query',
+        'data_type', 'device_path', 'offset', 'origin', 'parser', 'query',
         'serial_number']
 
     attribute_names = sorted(attribute_container.GetAttributeNames())

--- a/tests/output/l2t_csv.py
+++ b/tests/output/l2t_csv.py
@@ -38,6 +38,7 @@ class L2TCSVTest(test_lib.OutputModuleTestCase):
        'filename': 'log/syslog.1',
        'hostname': 'ubuntu',
        'my_number': 123,
+       'parser': 'test_parser',
        'some_additional_foo': True,
        'a_binary_field': b'binary',
        'text': (
@@ -95,7 +96,7 @@ class L2TCSVTest(test_lib.OutputModuleTestCase):
         'log/syslog.1',
         '-',
         '-',
-        '-',
+        'test_parser',
         'a_binary_field: binary; my_number: 123; some_additional_foo: True']
 
     event, event_data = containers_test_lib.CreateEventFromValues(
@@ -134,8 +135,8 @@ class L2TCSVTest(test_lib.OutputModuleTestCase):
         'ubuntu,Reporter <CRON> PID: 8442 (pam_unix(cron:session): session '
         'closed for user root),Reporter <CRON> PID: 8442 '
         '(pam_unix(cron:session): session closed for user root),'
-        '2,log/syslog.1,-,Malware Printed,'
-        '-,a_binary_field: binary; my_number: 123; some_additional_foo: True\n')
+        '2,log/syslog.1,-,Malware Printed,test_parser,'
+        'a_binary_field: binary; my_number: 123; some_additional_foo: True\n')
 
     event_body = self._output_writer.ReadOutput()
     self.assertEqual(event_body, expected_event_body)

--- a/tests/parsers/mediator.py
+++ b/tests/parsers/mediator.py
@@ -190,13 +190,16 @@ class ParsersMediatorTest(test_lib.ParserTestCase):
     date_time = fake_time.FakeTime()
     event_with_timestamp = time_events.DateTimeValuesEvent(
         date_time, definitions.TIME_DESCRIPTION_WRITTEN)
+    event_with_timestamp.parser = 'test_parser'
     event_data = events.EventData()
+    event_data.parser = 'test_parser'
 
     parsers_mediator.ProduceEventWithEventData(event_with_timestamp, event_data)
     self.assertEqual(storage_writer.number_of_warnings, 0)
     self.assertEqual(storage_writer.number_of_events, 1)
 
     event_without_timestamp = events.EventObject()
+    event_without_timestamp.parser = 'test_parser'
     with self.assertRaises(errors.InvalidEvent):
       parsers_mediator.ProduceEventWithEventData(
           event_without_timestamp, event_data)

--- a/tests/parsers/winreg_plugins/windows_version.py
+++ b/tests/parsers/winreg_plugins/windows_version.py
@@ -25,7 +25,7 @@ class WindowsRegistryInstallationEventDataTest(shared_test_lib.BaseTestCase):
     attribute_container = windows_version.WindowsRegistryInstallationEventData()
 
     expected_attribute_names = [
-        'build_number', 'data_type', 'key_path', 'offset', 'owner',
+        'build_number', 'data_type', 'key_path', 'offset', 'owner', 'parser',
         'product_name', 'query', 'service_pack', 'version']
 
     attribute_names = sorted(attribute_container.GetAttributeNames())

--- a/tests/serializer/json_serializer.py
+++ b/tests/serializer/json_serializer.py
@@ -142,6 +142,7 @@ class JSONAttributeContainerSerializerTest(JSONSerializerTestCase):
 
     expected_event = events.EventData()
     expected_event.data_type = 'test:event2'
+    expected_event.parser = 'test_parser'
     expected_event.pathspec = path_spec
 
     expected_event.empty_string = ''
@@ -174,6 +175,7 @@ class JSONAttributeContainerSerializerTest(JSONSerializerTestCase):
         'integer': 34,
         'float': -122.082203542683,
         'my_list': ['asf', 4234, 2, 54, 'asf'],
+        'parser': 'test_parser',
         'pathspec': path_spec.comparable,
         'string': 'Normal string',
         'unicode_string': 'And I am a unicorn.',
@@ -189,6 +191,7 @@ class JSONAttributeContainerSerializerTest(JSONSerializerTestCase):
   def testReadAndWriteSerializedEventObject(self):
     """Test ReadSerialized and WriteSerialized of EventObject."""
     expected_event = events.EventObject()
+    expected_event.parser = 'test_parser'
     expected_event.timestamp = 1234124
     expected_event.timestamp_desc = 'Written'
 
@@ -205,6 +208,7 @@ class JSONAttributeContainerSerializerTest(JSONSerializerTestCase):
     self.assertIsInstance(event, events.EventObject)
 
     expected_event_dict = {
+        'parser': 'test_parser',
         'timestamp': 1234124,
         'timestamp_desc': 'Written'}
 


### PR DESCRIPTION
Per https://github.com/log2timeline/plaso/issues/1687#issuecomment-360735449 I think we want to track the origin of both events and event_datas, so kept the attribute on both.

Also added some extra tests to hopefully catch similar issues in the future.

https://github.com/log2timeline/plaso/issues/1691 is possibly related to this, but I think we'll still want to track what created the event objects themselves.