### PR TITLE
Added few Windows Firewall events to tag_windows.txt

### DIFF
--- a/data/tag_windows.txt
+++ b/data/tag_windows.txt
@@ -99,3 +99,6 @@ file_download
 # Tags OLE compound document print events.
 document_print
   data_type is 'olecf:summary_info' AND timestamp_desc contains 'Printed'
+
+firewall_change
+  data_type is 'windows:evtx:record' AND source_name is 'Microsoft-Windows-Windows Firewall With Advanced Security' AND (event_identifier is 2003 OR event_identifier is 2004 OR event_identifier is 2005 OR event_identifier is 2006)

--- a/data/tag_windows.txt
+++ b/data/tag_windows.txt
@@ -100,5 +100,6 @@ file_download
 document_print
   data_type is 'olecf:summary_info' AND timestamp_desc contains 'Printed'
 
+# Tags Windows Firewall With Advanced Security change events
 firewall_change
   data_type is 'windows:evtx:record' AND source_name is 'Microsoft-Windows-Windows Firewall With Advanced Security' AND (event_identifier is 2003 OR event_identifier is 2004 OR event_identifier is 2005 OR event_identifier is 2006)

--- a/tests/data/tag_windows.py
+++ b/tests/data/tag_windows.py
@@ -826,5 +826,6 @@ class WindowsTaggingFileTest(test_lib.TaggingFileTestCase):
         winevtx.WinEvtxRecordEventData, attribute_values_per_name,
         ['firewall_change'])
 
+    
 if __name__ == '__main__':
   unittest.main()

--- a/tests/data/tag_windows.py
+++ b/tests/data/tag_windows.py
@@ -812,6 +812,15 @@ class WindowsTaggingFileTest(test_lib.TaggingFileTestCase):
   # TODO: add tests for file_download tagging rule
   # TODO: add tests for document_print tagging rule
 
+  def testFirewallChange(self):
+    """Tests the firewall_change tagging rule."""
+    # Test: data_type is 'windows:evtx:record' AND source_name is 'Microsoft-Windows-Windows Firewall With Advanced Security' AND (event_identifier is 2003 OR event_identifier is 2004 OR event_identifier is 2005 OR event_identifier is 2006)
+    attribute_values_per_name = {
+        'source_name': ['Microsoft-Windows-Windows Firewall With Advanced Security'],
+        'event_identifier': [2003, 2004, 2005, 2006]}
+    self._CheckTaggingRule(
+        winevtx.WinEvtxRecordEventData, attribute_values_per_name,
+        ['firewall_change'])
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/data/tag_windows.py
+++ b/tests/data/tag_windows.py
@@ -820,12 +820,13 @@ class WindowsTaggingFileTest(test_lib.TaggingFileTestCase):
     #       (event_identifier is 2003 OR event_identifier is 2004 OR
     #        event_identifier is 2005 OR event_identifier is 2006)
     attribute_values_per_name = {
-        'source_name': ['Microsoft-Windows-Windows Firewall With Advanced Security'],
+        'source_name': [
+            'Microsoft-Windows-Windows Firewall With Advanced Security'],
         'event_identifier': [2003, 2004, 2005, 2006]}
     self._CheckTaggingRule(
         winevtx.WinEvtxRecordEventData, attribute_values_per_name,
         ['firewall_change'])
 
-    
+
 if __name__ == '__main__':
   unittest.main()

--- a/tests/data/tag_windows.py
+++ b/tests/data/tag_windows.py
@@ -814,7 +814,11 @@ class WindowsTaggingFileTest(test_lib.TaggingFileTestCase):
 
   def testFirewallChange(self):
     """Tests the firewall_change tagging rule."""
-    # Test: data_type is 'windows:evtx:record' AND source_name is 'Microsoft-Windows-Windows Firewall With Advanced Security' AND (event_identifier is 2003 OR event_identifier is 2004 OR event_identifier is 2005 OR event_identifier is 2006)
+    # Test: data_type is 'windows:evtx:record' AND
+    #       source_name is 'Microsoft-Windows-Windows Firewall With Advanced
+    #           Security' AND
+    #       (event_identifier is 2003 OR event_identifier is 2004 OR
+    #        event_identifier is 2005 OR event_identifier is 2006)
     attribute_values_per_name = {
         'source_name': ['Microsoft-Windows-Windows Firewall With Advanced Security'],
         'event_identifier': [2003, 2004, 2005, 2006]}


### PR DESCRIPTION
## Description:

* 2003 = A Windows Defender Firewall setting has changed.
* 2004 = A rule has been added to the Windows Defender Firewall exception list.
* 2005 = A rule has been modified in the Windows Defender Firewall exception list.
* 2006 = A rule has been deleted in the Windows Defender Firewall exception list.

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
