### PR TITLE
Add cli option to pass elasticsearch password #2976

### DIFF
--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -128,15 +128,15 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
     elastic_url_prefix = cls._ParseStringOption(
         options, 'elastic_url_prefix', default_value=cls._DEFAULT_URL_PREFIX)
 
-    if elastic_password is cls._DEFAULT_ELASTIC_PASSWORD:
+    if elastic_password is not cls._DEFAULT_ELASTIC_PASSWORD:
       logger.warning('Provide elastic password via cli is unsafe')
+    else:
       elastic_password = os.getenv(
           "PLASO_ELASTIC_PASSWORD",
           cls._DEFAULT_ELASTIC_PASSWORD)
 
     if elastic_user is not None and elastic_password is None:
-      elastic_password = getpass.getpass(
-          'Enter your Elasticsearch password: ')
+      elastic_password = getpass.getpass('Enter your Elasticsearch password: ')
 
     ElasticSearchServerArgumentsHelper.ParseOptions(options, output_module)
     output_module.SetIndexName(index_name)

--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -121,11 +121,12 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
 
     if elastic_password is None:
       elastic_password = os.getenv('PLASO_ELASTIC_PASSWORD', None)
-    else:
+
+    if elastic_password is not None:
       logger.warning(
           'Note that specifying your Elasticsearch password via '
-          '--elastic_password can expose the password to other users on the '
-          'system.')
+          '--elastic_password or the environment PLASO_ELASTIC_PASSWORD can '
+          'expose the password to other users on the system.')
 
     if elastic_user is not None and elastic_password is None:
       elastic_password = getpass.getpass('Enter your Elasticsearch password: ')

--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -71,10 +71,11 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
             'Username to use for Elasticsearch authentication.'))
     argument_group.add_argument(
         '--elastic_password', dest='elastic_password', action='store',
-        default=os.getenv("PLASO_ELASTIC_PASSWORD",
-        cls._DEFAULT_ELASTIC_PASSWORD), help=(
-        'Password to use for Elasticsearch authentication. Can also '+
-        'be set with the environment variable PLASO_ELASTIC_PASSWORD'))
+        default=os.getenv(
+            "PLASO_ELASTIC_PASSWORD",
+            cls._DEFAULT_ELASTIC_PASSWORD),
+        help=('Password to use for Elasticsearch authentication. Can '+\
+        'also be set with the environment variable PLASO_ELASTIC_PASSWORD'))
     argument_group.add_argument(
         '--use_ssl', dest='use_ssl', action='store_true',
         help='Enforces use of ssl.')
@@ -120,8 +121,9 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
         options, 'elastic_user', default_value=cls._DEFAULT_ELASTIC_USER)
     elastic_password = cls._ParseStringOption(
         options, 'elastic_password',
-        default_value=os.getenv("PLASO_ELASTIC_PASSWORD",
-        cls._DEFAULT_ELASTIC_PASSWORD))
+        default_value=os.getenv(
+            "PLASO_ELASTIC_PASSWORD",
+            cls._DEFAULT_ELASTIC_PASSWORD))
     use_ssl = getattr(options, 'use_ssl', False)
 
     ca_certificates_path = cls._ParseStringOption(

--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -3,17 +3,18 @@
 
 from __future__ import unicode_literals
 
-import os
 import getpass
+import os
 
 from uuid import uuid4
 
-from plaso.lib import errors
 from plaso.cli.helpers import interface
 from plaso.cli.helpers import manager
 from plaso.cli.helpers import server_config
-from plaso.output import elastic
 from plaso.cli import logger
+from plaso.lib import errors
+from plaso.output import elastic
+
 
 class ElasticSearchServerArgumentsHelper(server_config.ServerArgumentsHelper):
   """Elastic Search server CLI arguments helper."""
@@ -33,10 +34,6 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
   _DEFAULT_DOCUMENT_TYPE = 'plaso_event'
   _DEFAULT_FLUSH_INTERVAL = 1000
   _DEFAULT_RAW_FIELDS = False
-  _DEFAULT_ELASTIC_USER = None
-  _DEFAULT_ELASTIC_PASSWORD = None
-  _DEFAULT_CA_CERTS = None
-  _DEFAULT_URL_PREFIX = None
 
   @classmethod
   def AddArguments(cls, argument_group):
@@ -67,24 +64,24 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
             'Export string fields that will not be analyzed by Lucene.'))
     argument_group.add_argument(
         '--elastic_user', dest='elastic_user', action='store',
-        default=cls._DEFAULT_ELASTIC_USER, help=(
-            'Username to use for Elasticsearch authentication.'))
+        default=None, help='Username to use for Elasticsearch authentication.')
     argument_group.add_argument(
         '--elastic_password', dest='elastic_password', action='store',
-        default=cls._DEFAULT_ELASTIC_PASSWORD,
-        help=('Password to use for Elasticsearch authentication. Can '+\
-        'also be set with the environment variable PLASO_ELASTIC_PASSWORD'))
+        default=None, help=(
+            'Password to use for Elasticsearch authentication. WARNING: use '
+            'with caution since this can expose the password to other users '
+            'on the system. The password can also be set with the environment '
+            'variable PLASO_ELASTIC_PASSWORD. '))
     argument_group.add_argument(
         '--use_ssl', dest='use_ssl', action='store_true',
         help='Enforces use of ssl.')
     argument_group.add_argument(
         '--ca_certificates_file_path', dest='ca_certificates_file_path',
-        action='store', type=str, default=cls._DEFAULT_CA_CERTS, help=(
+        action='store', type=str, default=None, help=(
             'Path to a file containing a list of root certificates to trust.'))
     argument_group.add_argument(
         '--elastic_url_prefix', dest='elastic_url_prefix', type=str,
-        action='store', default=cls._DEFAULT_URL_PREFIX, help=(
-            'URL prefix for elastic search.'))
+        action='store', default=None, help='URL prefix for elastic search.')
 
     ElasticSearchServerArgumentsHelper.AddArguments(argument_group)
 
@@ -113,27 +110,22 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
         options, 'document_type', default_value=cls._DEFAULT_DOCUMENT_TYPE)
     flush_interval = cls._ParseNumericOption(
         options, 'flush_interval', default_value=cls._DEFAULT_FLUSH_INTERVAL)
-    raw_fields = getattr(
-        options, 'raw_fields', cls._DEFAULT_RAW_FIELDS)
-    elastic_user = cls._ParseStringOption(
-        options, 'elastic_user', default_value=cls._DEFAULT_ELASTIC_USER)
-    elastic_password = cls._ParseStringOption(
-        options, 'elastic_password',
-        cls._DEFAULT_ELASTIC_PASSWORD)
+    raw_fields = getattr(options, 'raw_fields', cls._DEFAULT_RAW_FIELDS)
+    elastic_user = cls._ParseStringOption(options, 'elastic_user')
+    elastic_password = cls._ParseStringOption(options, 'elastic_password')
     use_ssl = getattr(options, 'use_ssl', False)
 
     ca_certificates_path = cls._ParseStringOption(
-        options, 'ca_certificates_file_path',
-        default_value=cls._DEFAULT_CA_CERTS)
-    elastic_url_prefix = cls._ParseStringOption(
-        options, 'elastic_url_prefix', default_value=cls._DEFAULT_URL_PREFIX)
+        options, 'ca_certificates_file_path')
+    elastic_url_prefix = cls._ParseStringOption(options, 'elastic_url_prefix')
 
-    if elastic_password is not cls._DEFAULT_ELASTIC_PASSWORD:
-      logger.warning('Provide elastic password via cli is unsafe')
+    if elastic_password is None:
+      elastic_password = os.getenv('PLASO_ELASTIC_PASSWORD', None)
     else:
-      elastic_password = os.getenv(
-          "PLASO_ELASTIC_PASSWORD",
-          cls._DEFAULT_ELASTIC_PASSWORD)
+      logger.warning(
+          'Note that specifying your Elasticsearch password via '
+          '--elastic_password can expose the password to other users on the '
+          'system.')
 
     if elastic_user is not None and elastic_password is None:
       elastic_password = getpass.getpass('Enter your Elasticsearch password: ')

--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -116,7 +116,8 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
         options, 'raw_fields', cls._DEFAULT_RAW_FIELDS)
     elastic_user = cls._ParseStringOption(
         options, 'elastic_user', default_value=cls._DEFAULT_ELASTIC_USER)
-
+    elastic_password = cls._ParseStringOption(
+        options, 'elastic_password', default_value=os.getenv("PLASO_ELASTIC_USERNAME", cls._DEFAULT_ELASTIC_PASSWORD))
     use_ssl = getattr(options, 'use_ssl', False)
 
     ca_certificates_path = cls._ParseStringOption(

--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -73,8 +73,8 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
         '--elastic_password', dest='elastic_password', action='store',
         default=os.getenv("PLASO_ELASTIC_PASSWORD",
         cls._DEFAULT_ELASTIC_PASSWORD), help=(
-        'Password to use for Elasticsearch authentication.\\
-        Can also be set with the environment variable PLASO_ELASTIC_PASSWORD'))    
+        'Password to use for Elasticsearch authentication. Can also '+
+        'be set with the environment variable PLASO_ELASTIC_PASSWORD'))
     argument_group.add_argument(
         '--use_ssl', dest='use_ssl', action='store_true',
         help='Enforces use of ssl.')
@@ -119,7 +119,7 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
     elastic_user = cls._ParseStringOption(
         options, 'elastic_user', default_value=cls._DEFAULT_ELASTIC_USER)
     elastic_password = cls._ParseStringOption(
-        options, 'elastic_password', 
+        options, 'elastic_password',
         default_value=os.getenv("PLASO_ELASTIC_PASSWORD",
         cls._DEFAULT_ELASTIC_PASSWORD))
     use_ssl = getattr(options, 'use_ssl', False)

--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -71,8 +71,10 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
             'Username to use for Elasticsearch authentication.'))
     argument_group.add_argument(
         '--elastic_password', dest='elastic_password', action='store',
-        default=os.getenv("PLASO_ELASTIC_PASSWORD", cls._DEFAULT_ELASTIC_PASSWORD), help=(
-            'Password to use for Elasticsearch authentication. Can also be set with the environment variable PLASO_ELASTIC_PASSWORD'))    
+        default=os.getenv("PLASO_ELASTIC_PASSWORD",
+        cls._DEFAULT_ELASTIC_PASSWORD), help=(
+        'Password to use for Elasticsearch authentication.\\
+        Can also be set with the environment variable PLASO_ELASTIC_PASSWORD'))    
     argument_group.add_argument(
         '--use_ssl', dest='use_ssl', action='store_true',
         help='Enforces use of ssl.')
@@ -117,7 +119,9 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
     elastic_user = cls._ParseStringOption(
         options, 'elastic_user', default_value=cls._DEFAULT_ELASTIC_USER)
     elastic_password = cls._ParseStringOption(
-        options, 'elastic_password', default_value=os.getenv("PLASO_ELASTIC_PASSWORD", cls._DEFAULT_ELASTIC_PASSWORD))
+        options, 'elastic_password', 
+        default_value=os.getenv("PLASO_ELASTIC_PASSWORD",
+        cls._DEFAULT_ELASTIC_PASSWORD))
     use_ssl = getattr(options, 'use_ssl', False)
 
     ca_certificates_path = cls._ParseStringOption(

--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -71,7 +71,7 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
             'Username to use for Elasticsearch authentication.'))
     argument_group.add_argument(
         '--elastic_password', dest='elastic_password', action='store',
-        default=os.getenv("PLASO_ELASTIC_USERNAME", cls._DEFAULT_ELASTIC_PASSWORD), help=(
+        default=os.getenv("PLASO_ELASTIC_PASSWORD", cls._DEFAULT_ELASTIC_PASSWORD), help=(
             'Password to use for Elasticsearch authentication. Can also be set with the environment variable PLASO_ELASTIC_PASSWORD'))    
     argument_group.add_argument(
         '--use_ssl', dest='use_ssl', action='store_true',
@@ -117,7 +117,7 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
     elastic_user = cls._ParseStringOption(
         options, 'elastic_user', default_value=cls._DEFAULT_ELASTIC_USER)
     elastic_password = cls._ParseStringOption(
-        options, 'elastic_password', default_value=os.getenv("PLASO_ELASTIC_USERNAME", cls._DEFAULT_ELASTIC_PASSWORD))
+        options, 'elastic_password', default_value=os.getenv("PLASO_ELASTIC_PASSWORD", cls._DEFAULT_ELASTIC_PASSWORD))
     use_ssl = getattr(options, 'use_ssl', False)
 
     ca_certificates_path = cls._ParseStringOption(

--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -3,6 +3,7 @@
 
 from __future__ import unicode_literals
 
+import os
 import getpass
 
 from uuid import uuid4
@@ -33,6 +34,7 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
   _DEFAULT_FLUSH_INTERVAL = 1000
   _DEFAULT_RAW_FIELDS = False
   _DEFAULT_ELASTIC_USER = None
+  _DEFAULT_ELASTIC_PASSWORD = None
   _DEFAULT_CA_CERTS = None
   _DEFAULT_URL_PREFIX = None
 
@@ -67,6 +69,10 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
         '--elastic_user', dest='elastic_user', action='store',
         default=cls._DEFAULT_ELASTIC_USER, help=(
             'Username to use for Elasticsearch authentication.'))
+    argument_group.add_argument(
+        '--elastic_password', dest='elastic_password', action='store',
+        default=os.getenv("PLASO_ELASTIC_USERNAME", cls._DEFAULT_ELASTIC_PASSWORD), help=(
+            'Password to use for Elasticsearch authentication. Can also be set with the environment variable PLASO_ELASTIC_PASSWORD'))    
     argument_group.add_argument(
         '--use_ssl', dest='use_ssl', action='store_true',
         help='Enforces use of ssl.')
@@ -119,7 +125,7 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
     elastic_url_prefix = cls._ParseStringOption(
         options, 'elastic_url_prefix', default_value=cls._DEFAULT_URL_PREFIX)
 
-    if elastic_user is not None:
+    if elastic_user is not None and elastic_password is None:
       elastic_password = getpass.getpass(
           'Enter your Elasticsearch password: ')
     else:

--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -128,7 +128,7 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
     if elastic_user is not None and elastic_password is None:
       elastic_password = getpass.getpass(
           'Enter your Elasticsearch password: ')
-    else:
+    elif elastic_user is None:
       elastic_password = None
 
     ElasticSearchServerArgumentsHelper.ParseOptions(options, output_module)

--- a/tests/cli/helpers/elastic_output.py
+++ b/tests/cli/helpers/elastic_output.py
@@ -42,7 +42,7 @@ optional arguments:
   --elastic_password ELASTIC_PASSWORD
                         Password to use for Elasticsearch authentication. Can
                         also be set with the environment variable
-                        PLASO_ELASTIC_PASSWORD                        
+                        PLASO_ELASTIC_PASSWORD
   --elastic_url_prefix ELASTIC_URL_PREFIX
                         URL prefix for elastic search.
   --elastic_user ELASTIC_USER

--- a/tests/cli/helpers/elastic_output.py
+++ b/tests/cli/helpers/elastic_output.py
@@ -40,9 +40,11 @@ optional arguments:
                         Name of the document type that will be used in
                         ElasticSearch.
   --elastic_password ELASTIC_PASSWORD
-                        Password to use for Elasticsearch authentication. Can
-                        also be set with the environment variable
-                        PLASO_ELASTIC_PASSWORD
+                        Password to use for Elasticsearch authentication.
+                        WARNING: use with caution since this can expose the
+                        password to other users on the system. The password
+                        can also be set with the environment variable
+                        PLASO_ELASTIC_PASSWORD.
   --elastic_url_prefix ELASTIC_URL_PREFIX
                         URL prefix for elastic search.
   --elastic_user ELASTIC_USER

--- a/tests/cli/helpers/elastic_output.py
+++ b/tests/cli/helpers/elastic_output.py
@@ -15,12 +15,13 @@ from tests.cli import test_lib as cli_test_lib
 from tests.cli.helpers import test_lib
 
 
-class ElasticSearchOutputArgumentsHelperTest(test_lib.OutputModuleArgumentsHelperTest):
-    """Tests the Elastic Search output module CLI arguments helper."""
+class ElasticSearchOutputArgumentsHelperTest(
+    test_lib.OutputModuleArgumentsHelperTest):
+  """Tests the Elastic Search output module CLI arguments helper."""
 
-    # pylint: disable=no-member,protected-access
+  # pylint: disable=no-member,protected-access
 
-    _EXPECTED_OUTPUT = """\
+  _EXPECTED_OUTPUT = """\
 usage: cli_helper.py [--index_name INDEX_NAME] [--doc_type DOCUMENT_TYPE]
                      [--flush_interval FLUSH_INTERVAL] [--raw_fields]
                      [--elastic_user ELASTIC_USER]
@@ -41,7 +42,7 @@ optional arguments:
   --elastic_password ELASTIC_PASSWORD
                         Password to use for Elasticsearch authentication. Can
                         also be set with the environment variable
-                        PLASO_ELASTIC_PASSWORD
+                        PLASO_ELASTIC_PASSWORD                        
   --elastic_url_prefix ELASTIC_URL_PREFIX
                         URL prefix for elastic search.
   --elastic_user ELASTIC_USER
@@ -58,35 +59,32 @@ optional arguments:
   --use_ssl             Enforces use of ssl.
 """
 
-    def testAddArguments(self):
-        """Tests the AddArguments function."""
-        argument_parser = argparse.ArgumentParser(
-            prog="cli_helper.py",
-            description="Test argument parser.",
-            add_help=False,
-            formatter_class=cli_test_lib.SortedArgumentsHelpFormatter,
-        )
+  def testAddArguments(self):
+    """Tests the AddArguments function."""
+    argument_parser = argparse.ArgumentParser(
+        prog='cli_helper.py',
+        description='Test argument parser.', add_help=False,
+        formatter_class=cli_test_lib.SortedArgumentsHelpFormatter)
 
-        elastic_output.ElasticSearchOutputArgumentsHelper.AddArguments(argument_parser)
+    elastic_output.ElasticSearchOutputArgumentsHelper.AddArguments(
+        argument_parser)
 
-        output = self._RunArgparseFormatHelp(argument_parser)
-        self.assertEqual(output, self._EXPECTED_OUTPUT)
+    output = self._RunArgparseFormatHelp(argument_parser)
+    self.assertEqual(output, self._EXPECTED_OUTPUT)
 
-    def testParseOptions(self):
-        """Tests the ParseOptions function."""
-        options = cli_test_lib.TestOptions()
+  def testParseOptions(self):
+    """Tests the ParseOptions function."""
+    options = cli_test_lib.TestOptions()
 
-        output_mediator = self._CreateOutputMediator()
-        output_module = elastic.ElasticsearchOutputModule(output_mediator)
-        elastic_output.ElasticSearchOutputArgumentsHelper.ParseOptions(
-            options, output_module
-        )
+    output_mediator = self._CreateOutputMediator()
+    output_module = elastic.ElasticsearchOutputModule(output_mediator)
+    elastic_output.ElasticSearchOutputArgumentsHelper.ParseOptions(
+        options, output_module)
 
-        with self.assertRaises(errors.BadConfigObject):
-            elastic_output.ElasticSearchOutputArgumentsHelper.ParseOptions(
-                options, None
-            )
+    with self.assertRaises(errors.BadConfigObject):
+      elastic_output.ElasticSearchOutputArgumentsHelper.ParseOptions(
+          options, None)
 
 
-if __name__ == "__main__":
-    unittest.main()
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/cli/helpers/elastic_output.py
+++ b/tests/cli/helpers/elastic_output.py
@@ -15,16 +15,16 @@ from tests.cli import test_lib as cli_test_lib
 from tests.cli.helpers import test_lib
 
 
-class ElasticSearchOutputArgumentsHelperTest(
-    test_lib.OutputModuleArgumentsHelperTest):
-  """Tests the Elastic Search output module CLI arguments helper."""
+class ElasticSearchOutputArgumentsHelperTest(test_lib.OutputModuleArgumentsHelperTest):
+    """Tests the Elastic Search output module CLI arguments helper."""
 
-  # pylint: disable=no-member,protected-access
+    # pylint: disable=no-member,protected-access
 
-  _EXPECTED_OUTPUT = """\
+    _EXPECTED_OUTPUT = """\
 usage: cli_helper.py [--index_name INDEX_NAME] [--doc_type DOCUMENT_TYPE]
                      [--flush_interval FLUSH_INTERVAL] [--raw_fields]
-                     [--elastic_user ELASTIC_USER] [--use_ssl]
+                     [--elastic_user ELASTIC_USER]
+                     [--elastic_password ELASTIC_PASSWORD] [--use_ssl]
                      [--ca_certificates_file_path CA_CERTIFICATES_FILE_PATH]
                      [--elastic_url_prefix ELASTIC_URL_PREFIX]
                      [--server HOSTNAME] [--port PORT]
@@ -38,6 +38,10 @@ optional arguments:
   --doc_type DOCUMENT_TYPE
                         Name of the document type that will be used in
                         ElasticSearch.
+  --elastic_password ELASTIC_PASSWORD
+                        Password to use for Elasticsearch authentication. Can
+                        also be set with the environment variable
+                        PLASO_ELASTIC_PASSWORD                        
   --elastic_url_prefix ELASTIC_URL_PREFIX
                         URL prefix for elastic search.
   --elastic_user ELASTIC_USER
@@ -54,32 +58,35 @@ optional arguments:
   --use_ssl             Enforces use of ssl.
 """
 
-  def testAddArguments(self):
-    """Tests the AddArguments function."""
-    argument_parser = argparse.ArgumentParser(
-        prog='cli_helper.py',
-        description='Test argument parser.', add_help=False,
-        formatter_class=cli_test_lib.SortedArgumentsHelpFormatter)
+    def testAddArguments(self):
+        """Tests the AddArguments function."""
+        argument_parser = argparse.ArgumentParser(
+            prog="cli_helper.py",
+            description="Test argument parser.",
+            add_help=False,
+            formatter_class=cli_test_lib.SortedArgumentsHelpFormatter,
+        )
 
-    elastic_output.ElasticSearchOutputArgumentsHelper.AddArguments(
-        argument_parser)
+        elastic_output.ElasticSearchOutputArgumentsHelper.AddArguments(argument_parser)
 
-    output = self._RunArgparseFormatHelp(argument_parser)
-    self.assertEqual(output, self._EXPECTED_OUTPUT)
+        output = self._RunArgparseFormatHelp(argument_parser)
+        self.assertEqual(output, self._EXPECTED_OUTPUT)
 
-  def testParseOptions(self):
-    """Tests the ParseOptions function."""
-    options = cli_test_lib.TestOptions()
+    def testParseOptions(self):
+        """Tests the ParseOptions function."""
+        options = cli_test_lib.TestOptions()
 
-    output_mediator = self._CreateOutputMediator()
-    output_module = elastic.ElasticsearchOutputModule(output_mediator)
-    elastic_output.ElasticSearchOutputArgumentsHelper.ParseOptions(
-        options, output_module)
+        output_mediator = self._CreateOutputMediator()
+        output_module = elastic.ElasticsearchOutputModule(output_mediator)
+        elastic_output.ElasticSearchOutputArgumentsHelper.ParseOptions(
+            options, output_module
+        )
 
-    with self.assertRaises(errors.BadConfigObject):
-      elastic_output.ElasticSearchOutputArgumentsHelper.ParseOptions(
-          options, None)
+        with self.assertRaises(errors.BadConfigObject):
+            elastic_output.ElasticSearchOutputArgumentsHelper.ParseOptions(
+                options, None
+            )
 
 
-if __name__ == '__main__':
-  unittest.main()
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cli/helpers/elastic_output.py
+++ b/tests/cli/helpers/elastic_output.py
@@ -41,7 +41,7 @@ optional arguments:
   --elastic_password ELASTIC_PASSWORD
                         Password to use for Elasticsearch authentication. Can
                         also be set with the environment variable
-                        PLASO_ELASTIC_PASSWORD                        
+                        PLASO_ELASTIC_PASSWORD
   --elastic_url_prefix ELASTIC_URL_PREFIX
                         URL prefix for elastic search.
   --elastic_user ELASTIC_USER


### PR DESCRIPTION
## One line description of pull request

Add the possibility to run psort.py with elasticsearch output in a non interactive way

## Description:
add possibilities to pass elastic password : 
- as a cli option --elastic_password -> raise a warning in log
- via environment variable PLASO_ELASTIC_PASSWORD

**Related issue (if applicable):** fixes #<plaso issue number here>

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [x] Automated checks (Travis, Codecov, Codefactor ) Travis pass before rebase on most recent branch (that currently fail)
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
