### PR TITLE
Updated Timesketch output module to work with upcoming version of Timesketch

### DIFF
--- a/plaso/output/timesketch_out.py
+++ b/plaso/output/timesketch_out.py
@@ -37,7 +37,13 @@ class TimesketchOutputModule(shared_elastic.SharedElasticsearchOutputModule):
     super(TimesketchOutputModule, self).__init__(output_mediator)
     self._timeline_name = hostname
     self._timeline_owner = None
-    self._timesketch = timesketch.create_app()
+    try:
+      self._timesketch = timesketch.create_app()
+    except AttributeError:
+      # TODO: Due to a change in Timesketch codebase, remove once Timesketch
+      # gets upgraded.
+      from timesketch import app
+      self._timesketch = app.create_app()
 
   def Close(self):
     """Closes the connection to TimeSketch Elasticsearch database.

--- a/plaso/output/timesketch_out.py
+++ b/plaso/output/timesketch_out.py
@@ -5,7 +5,11 @@ from __future__ import unicode_literals
 
 try:
   from flask import current_app
-  import timesketch
+  # For backwards compatibility with Timesketch installations.
+  try:
+    import timesketch.app as timesketch
+  except ImportError
+    import timesketch
   from timesketch.models import db_session as timesketch_db_session
   from timesketch.models import sketch as timesketch_sketch
   from timesketch.models import user as timesketch_user
@@ -37,13 +41,7 @@ class TimesketchOutputModule(shared_elastic.SharedElasticsearchOutputModule):
     super(TimesketchOutputModule, self).__init__(output_mediator)
     self._timeline_name = hostname
     self._timeline_owner = None
-    try:
-      self._timesketch = timesketch.create_app()
-    except AttributeError:
-      # TODO: Due to a change in Timesketch codebase, remove once Timesketch
-      # gets upgraded.
-      from timesketch import app
-      self._timesketch = app.create_app()
+    self._timesketch = timesketch.create_app()
 
   def Close(self):
     """Closes the connection to TimeSketch Elasticsearch database.

--- a/plaso/output/timesketch_out.py
+++ b/plaso/output/timesketch_out.py
@@ -5,7 +5,8 @@ from __future__ import unicode_literals
 
 try:
   from flask import current_app
-  # For backwards compatibility with Timesketch installations.
+  # TODO: Added for backwards compatibility with Timesketch installations.
+  # Remove once no longer needed.
   try:
     import timesketch.app as timesketch
   except ImportError

--- a/plaso/output/timesketch_out.py
+++ b/plaso/output/timesketch_out.py
@@ -9,7 +9,7 @@ try:
   # Remove once no longer needed.
   try:
     import timesketch.app as timesketch
-  except ImportError
+  except ImportError:
     import timesketch
   from timesketch.models import db_session as timesketch_db_session
   from timesketch.models import sketch as timesketch_sketch


### PR DESCRIPTION
## One line description of pull request

After https://github.com/google/timesketch/pull/1248 in Timesketch the `create_app` no longer resides in `timesketch` module, but rather inside the `timesketch.app` module.

This PR fixes that.

## Description:


**Related issue (if applicable):** fixes https://github.com/google/timesketch/issues/1254

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [x] Reviewer assigned
