### PR TITLE
Changed AppVeyor CI tests to use Python 3.8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,14 @@ environment:
   matrix:
   - TARGET: unittests
     MACHINE_TYPE: "x86"
-    PYTHON: "C:\\Python37"
-    PYTHON_VERSION: "3.7"
+    PYTHON: "C:\\Python38"
+    PYTHON_VERSION: "3.8"
+    L2TBINARIES_TRACK: "testing"
   - TARGET: unittests
     MACHINE_TYPE: "amd64"
-    PYTHON: "C:\\Python37-x64"
-    PYTHON_VERSION: "3.7"
+    PYTHON: "C:\\Python38-x64"
+    PYTHON_VERSION: "3.8"
+    L2TBINARIES_TRACK: "testing"
 
 install:
 - cmd: '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86 /release'
@@ -15,10 +17,10 @@ install:
 - cmd: "%PYTHON%\\python.exe -m pip install pywin32 WMI"
 - cmd: "%PYTHON%\\python.exe %PYTHON%\\Scripts\\pywin32_postinstall.py -install"
 - cmd: git clone https://github.com/log2timeline/l2tdevtools.git ..\l2tdevtools
-- cmd: if [%PYTHON_VERSION%]==[3.7] (
+- cmd: if [%PYTHON_VERSION%]==[3.8] (
     mkdir dependencies &&
     set PYTHONPATH=..\l2tdevtools &&
-    "%PYTHON%\\python.exe" ..\l2tdevtools\tools\update.py --download-directory dependencies --machine-type %MACHINE_TYPE% --msi-targetdir "%PYTHON%" --track dev PyYAML XlsxWriter artifacts bencode biplist certifi cffi chardet cryptography dateutil defusedxml dfdatetime dfvfs dfwinreg dtfabric elasticsearch-py fakeredis future idna libbde libesedb libevt libevtx libewf libfsapfs libfsntfs libfvde libfwnt libfwsi liblnk libluksde libmsiecf libolecf libqcow libregf libscca libsigscan libsmdev libsmraw libvhdi libvmdk libvshadow libvslvm lz4 mock pbr pefile psutil pyparsing pytsk3 pytz pyzmq redis requests six sortedcontainers urllib3 yara-python )
+    "%PYTHON%\\python.exe" ..\l2tdevtools\tools\update.py --download-directory dependencies --machine-type %MACHINE_TYPE% --msi-targetdir "%PYTHON%" --track "%L2TBINARIES_TRACK%" PyYAML XlsxWriter artifacts bencode biplist certifi cffi chardet cryptography dateutil defusedxml dfdatetime dfvfs dfwinreg dtfabric elasticsearch-py fakeredis future idna libbde libesedb libevt libevtx libewf libfsapfs libfsntfs libfvde libfwnt libfwsi liblnk libluksde libmsiecf libolecf libqcow libregf libscca libsigscan libsmdev libsmraw libvhdi libvmdk libvshadow libvslvm lz4 mock pbr pefile psutil pyparsing pytsk3 pytz pyzmq redis requests six sortedcontainers urllib3 yara-python )
 
 build: off
 

--- a/tests/cli/log2timeline_tool.py
+++ b/tests/cli/log2timeline_tool.py
@@ -564,8 +564,10 @@ optional arguments:
             '{0!s}.').format(exception))
 
       # There should be 3 filestat and 3 pe parser generated events.
+      # Typically there are 3 filestat events, but there can be 4 on platforms
+      # that support os.stat_result st_birthtime.
       events = list(storage_file.GetSortedEvents())
-      self.assertEqual(len(events), 6)
+      self.assertIn(len(events), [6, 7])
 
   def testShowInfo(self):
     """Tests the output of the tool in info mode."""

--- a/tests/engine/worker.py
+++ b/tests/engine/worker.py
@@ -151,7 +151,9 @@ class EventExtractionWorkerTest(shared_test_lib.BaseTestCase):
     self._TestProcessPathSpec(
         storage_writer, path_spec, knowledge_base_values=knowledge_base_values)
 
-    self.assertEqual(storage_writer.number_of_events, 19)
+    # Typically there are 3 filestat events, but there can be 4 on platforms
+    # that support os.stat_result st_birthtime.
+    self.assertIn(storage_writer.number_of_events, [19, 20])
 
   def testProcessPathSpecCompressedFileGZIP(self):
     """Tests the ProcessPathSpec function on a gzip compressed file."""
@@ -163,7 +165,9 @@ class EventExtractionWorkerTest(shared_test_lib.BaseTestCase):
     self._TestProcessPathSpec(
         storage_writer, path_spec, knowledge_base_values=knowledge_base_values)
 
-    self.assertEqual(storage_writer.number_of_events, 16)
+    # Typically there are 3 filestat events, but there can be 4 on platforms
+    # that support os.stat_result st_birthtime.
+    self.assertIn(storage_writer.number_of_events, [16, 17])
 
   def testProcessPathSpecCompressedFileBZIP2(self):
     """Tests the ProcessPathSpec function on a bzip2 compressed file."""
@@ -175,7 +179,9 @@ class EventExtractionWorkerTest(shared_test_lib.BaseTestCase):
     self._TestProcessPathSpec(
         storage_writer, path_spec, knowledge_base_values=knowledge_base_values)
 
-    self.assertEqual(storage_writer.number_of_events, 15)
+    # Typically there are 3 filestat events, but there can be 4 on platforms
+    # that support os.stat_result st_birthtime.
+    self.assertIn(storage_writer.number_of_events, [15, 16])
 
   def testProcessPathSpec(self):
     """Tests the ProcessPathSpec function on an archive file."""
@@ -203,7 +209,9 @@ class EventExtractionWorkerTest(shared_test_lib.BaseTestCase):
     self._TestProcessPathSpec(
         storage_writer, path_spec, knowledge_base_values=knowledge_base_values)
 
-    self.assertEqual(storage_writer.number_of_events, 3)
+    # Typically there are 3 filestat events, but there can be 4 on platforms
+    # that support os.stat_result st_birthtime.
+    self.assertIn(storage_writer.number_of_events, [3, 4])
 
     # Process an archive file with "process archive files" mode.
     path_spec = self._GetTestFilePathSpec(['syslog.tar'])
@@ -212,7 +220,9 @@ class EventExtractionWorkerTest(shared_test_lib.BaseTestCase):
         storage_writer, path_spec, knowledge_base_values=knowledge_base_values,
         process_archives=True)
 
-    self.assertEqual(storage_writer.number_of_events, 16)
+    # Typically there are 3 filestat events, but there can be 4 on platforms
+    # that support os.stat_result st_birthtime.
+    self.assertIn(storage_writer.number_of_events, [16, 17])
 
   def testProcessPathSpecCompressedArchive(self):
     """Tests the ProcessPathSpec function on a compressed archive file."""
@@ -243,7 +253,9 @@ class EventExtractionWorkerTest(shared_test_lib.BaseTestCase):
         storage_writer, path_spec, knowledge_base_values=knowledge_base_values,
         process_archives=True)
 
-    self.assertEqual(storage_writer.number_of_events, 17)
+    # Typically there are 3 filestat events, but there can be 4 on platforms
+    # that support os.stat_result st_birthtime.
+    self.assertIn(storage_writer.number_of_events, [17, 18])
 
   def testProcessPathSpecVMDK(self):
     """Tests the ProcessPathSpec function on a VMDK with symbolic links."""


### PR DESCRIPTION
Changed AppVeyor CI tests to use Python 3.8