### PR TITLE
Remove unused os and mount_path CLI options from log2timeline #3019

### DIFF
--- a/plaso/cli/extraction_tool.py
+++ b/plaso/cli/extraction_tool.py
@@ -56,8 +56,6 @@ class ExtractionTool(
         input_reader=input_reader, output_writer=output_writer)
     self._artifacts_registry = None
     self._buffer_size = 0
-    self._mount_path = None
-    self._operating_system = None
     self._parser_filter_expression = None
     self._preferred_year = None
     self._presets_file = None
@@ -148,7 +146,6 @@ class ExtractionTool(
         self._process_compressed_streams)
     configuration.extraction.yara_rules_string = self._yara_rules_string
     configuration.filter_file = self._filter_file
-    configuration.input_source.mount_path = self._mount_path
     configuration.log_filename = self._log_file
     configuration.parser_filter_expression = parser_filter_expression
     configuration.preferred_year = self._preferred_year

--- a/plaso/cli/log2timeline_tool.py
+++ b/plaso/cli/log2timeline_tool.py
@@ -342,12 +342,6 @@ class Log2TimelineTool(extraction_tool.ExtractionTool):
               serializer_format))
     self._storage_serializer_format = serializer_format
 
-    # TODO: where is this defined?
-    self._operating_system = getattr(options, 'os', None)
-
-    if self._operating_system:
-      self._mount_path = getattr(options, 'filename', None)
-
     helpers_manager.ArgumentHelperManager.ParseOptions(
         options, self, names=['status_view'])
 


### PR DESCRIPTION
Remove unused os and mount_path CLI options from log2timeline #3019
