### PR TITLE
Updated MacOS Source release installation instructions

### DIFF
--- a/docs/sources/user/MacOS-Source-Release.md
+++ b/docs/sources/user/MacOS-Source-Release.md
@@ -44,6 +44,7 @@ source ~/plaso_env/bin/activate
 Install the plaso dependencies:
 ```
 cd /tmp/plaso-20190708/
+curl -Lo requirements.txt https://raw.githubusercontent.com/log2timeline/plaso/master/requirements.txt
 pip install -r requirements.txt
 ```
 
@@ -65,6 +66,7 @@ deactivate
 Install the plaso dependencies:
 ```
 cd /tmp/plaso-20190708/
+curl -Lo requirements.txt https://raw.githubusercontent.com/log2timeline/plaso/master/requirements.txt
 sudo pip3 install -r requirements.txt
 ```
 

--- a/docs/sources/user/MacOS-Source-Release.md
+++ b/docs/sources/user/MacOS-Source-Release.md
@@ -1,10 +1,10 @@
-# MacOS Source Release
+# MacOS Source release
 
 To install the "Source code" release of Plaso on MacOS you need to download the latest version from https://github.com/log2timeline/plaso/releases/latest
 
 For the purposes of this guide it will use 20200430 to represent the latest Plaso release in the examples below. However, you will need to adjust this based on the latest version available from the link above.
 
-Under the latest release you should see four links to different packages, you will need to download the "**Source code (tar.gz)**" package file e.g. https://github.com/log2timeline/plaso/archive/20200430.tar.gz
+Under the latest release you should see four links to different packages, you will need to download the "**Source code (tar.gz)**" package file, for example https://github.com/log2timeline/plaso/archive/20200430.tar.gz
 
 Extract the source code:
 

--- a/docs/sources/user/MacOS-Source-Release.md
+++ b/docs/sources/user/MacOS-Source-Release.md
@@ -1,77 +1,87 @@
 # MacOS Source Release
 
-To install the "Source code" release of plaso on MacOS you need to download the latest version from https://github.com/log2timeline/plaso/releases/latest
+To install the "Source code" release of Plaso on MacOS you need to download the latest version from https://github.com/log2timeline/plaso/releases/latest
 
-Under the latest release you should see four links to differnet packages, you will need to download the "**Source code (tar.gz)**" package file.
+For the purposes of this guide it will use 20200430 to represent the latest Plaso release in the examples below. However, you will need to adjust this based on the latest version available from the link above.
 
-For the purposes of this guide it will use "_plaso-20190708_" to represent the current version of Plaso in the following command line examples. However, you will need to adjust this based on the latest release version you have just downloaded from the link above.
-
+Under the latest release you should see four links to different packages, you will need to download the "**Source code (tar.gz)**" package file e.g. https://github.com/log2timeline/plaso/archive/20200430.tar.gz
 
 Extract the source code:
+
 ```
 cd /tmp
-tar zxf ~/Downloads/plaso-20190708.tar.gz
+tar zxf ~/Downloads/plaso-20200430.tar.gz
 ```
 
 In some cases, MacOS will automatically ungzip the downloaded file. In which case, untar with:
+
 ```
 cd /tmp
-tar xf ~/Downloads/plaso-20190708.tar
+tar xf ~/Downloads/plaso-20200430.tar
 ```
 
 XCode Command Line Tools is required. It can be installed with:
+
 ```
 xcode-select --install
 ```
 
 If python3 is not already installed, it can be downloaded from https://www.python.org/downloads/
 
-## Install plaso contained within a virtual environment
+## Install Plaso contained within a virtual environment
 
 Plaso can be installed within a virtual environment so that dependency packages are not installed system-wide.
 To do this, install Virtualenv:
+
 ```
 sudo pip3 install virtualenv
 ```
 
-Create a virtual environment to install plaso into (in this instance, it's named "plaso_env" created under the home directory):
+Create a virtual environment to install Plaso into (in this instance, it's named "plaso_env" created under the home directory):
+
 ```
 virtualenv -p python3 ~/plaso_env
 ```
 
 Activate the virtual environment:
+
 ```
 source ~/plaso_env/bin/activate
 ```
 
-Install the plaso dependencies:
+Install the Plaso dependencies:
+
 ```
-cd /tmp/plaso-20190708/
+cd /tmp/plaso-20200430/
 pip install -r requirements.txt
 ```
 
-Install plaso:
+Install Plaso:
+
 ```
 python setup.py build
 python setup.py install
 ```
 
 To deactivate the virtual environment:
+
 ```
 deactivate
 ```
 
-*In order to run plaso, the virtual environment needs to be activated.*
+*In order to run Plaso, the virtual environment needs to be activated.*
 
-## Install plaso system-wide
+## Install Plaso system-wide
 
-Install the plaso dependencies:
+Install the Plaso dependencies:
+
 ```
-cd /tmp/plaso-20190708/
+cd /tmp/plaso-20200430/
 sudo pip3 install -r requirements.txt
 ```
 
-Install plaso:
+Install Plaso:
+
 ```
 python3 setup.py build
 sudo python3 setup.py install
@@ -93,7 +103,6 @@ Some Python dependencies fail to compile with the error:
 It is likely that the Python interpreter was built using a specific MacOS SDK.
 Make sure that version of the MacOS SDK is installed on your system, in the
 example above this is MacOS SDK 10.14.
-
 
 Pycrypto fails to build with the error:
 
@@ -119,7 +128,6 @@ export CFLAGS="-I/usr/local/include ${CFLAGS}";
 export LDFLAGS="-L/usr/local/lib ${LDFLAGS}";
 ```
 
-
 Yara-python fails to build with the error:
 
 ```
@@ -144,4 +152,3 @@ And your build environment knows where to find its development files:
 export CFLAGS="-I/usr/local/opt/openssl@1.1/include ${CFLAGS}";
 export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib ${LDFLAGS}";
 ```
-

--- a/docs/sources/user/MacOS-Source-Release.md
+++ b/docs/sources/user/MacOS-Source-Release.md
@@ -1,8 +1,11 @@
 # MacOS Source Release
 
-To install the source release of plaso on MacOS you need to download the latest version from https://github.com/log2timeline/plaso/releases
+To install the "Source code" release of plaso on MacOS you need to download the latest version from https://github.com/log2timeline/plaso/releases/latest
 
-Attached to the most recent release (as of this time version 20190708) is a "Source code (tar.gz)" file.
+Under the latest release you should see four links to differnet packages, you will need to download the "**Source code (tar.gz)**" package file.
+
+For the purposes of this guide it will use "_plaso-20190708_" to represent the current version of Plaso in the following command line examples. However, you will need to adjust this based on the latest release version you have just downloaded from the link above.
+
 
 Extract the source code:
 ```
@@ -44,7 +47,6 @@ source ~/plaso_env/bin/activate
 Install the plaso dependencies:
 ```
 cd /tmp/plaso-20190708/
-curl -Lo requirements.txt https://raw.githubusercontent.com/log2timeline/plaso/master/requirements.txt
 pip install -r requirements.txt
 ```
 
@@ -66,7 +68,6 @@ deactivate
 Install the plaso dependencies:
 ```
 cd /tmp/plaso-20190708/
-curl -Lo requirements.txt https://raw.githubusercontent.com/log2timeline/plaso/master/requirements.txt
 sudo pip3 install -r requirements.txt
 ```
 


### PR DESCRIPTION
## One line description of pull request

The requirements.txt is missing from the [Release download package](https://github.com/log2timeline/plaso/releases/tag/20200430), so added a specific curl to pull the requirements.txt file.

## Description:

The doc page for a MacOS install is missing the requirements.txt file. I've updated the docs page to include a command to pull down the correct file so the rest of the documentation will work

**Related issue (if applicable):** 
N/A

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [X] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [x] Reviewer assigned
