### PR TITLE
Changed Docker entry point script to use unattended mode #2617

### DIFF
--- a/config/docker/plaso-switch.sh
+++ b/config/docker/plaso-switch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Since docker run can only have one "entry point" this script enables calling
+# Since Docker run can only have one "entry point" this script enables calling
 # either log2timeline or other utility scripts e.g.
 # docker run <container_id> image_export
 # docker run <container_id> log2timeline
@@ -10,23 +10,23 @@
 #
 # or to run it on actual data:
 # mkdir -p /data/sources    # put the files to parse here
-# mkdir -p /data/results    # plaso storage file will appear hear
+# mkdir -p /data/results    # a Plaso storage file will appear here
 # docker run -v /data/:/data <container_id> log2timeline \
 #     /data/results/result.plaso /data/sources
 
 case "$1" in
   image_export|image_export.py)
-    /usr/bin/image_export.py "${@:2}" ;;
+    /usr/bin/image_export.py --unattended "${@:2}" ;;
   log2timeline|log2timeline.py)
-    /usr/bin/log2timeline.py "${@:2}" ;;
+    /usr/bin/log2timeline.py --unattended "${@:2}" ;;
   pinfo|pinfo.py)
-    /usr/bin/pinfo.py "${@:2}" ;;
+    /usr/bin/pinfo.py --unattended "${@:2}" ;;
   psort|psort.py)
-    /usr/bin/psort.py "${@:2}" ;;
+    /usr/bin/psort.py --unattended "${@:2}" ;;
   psteal|psteal.py)
-    /usr/bin/psteal.py "${@:2}" ;;
+    /usr/bin/psteal.py --unattended "${@:2}" ;;
   "")
-    /usr/bin/log2timeline.py "${@:2}" ;;
+    /usr/bin/log2timeline.py --unattended "${@:2}" ;;
   *)
     echo "Unsupported command: $1"
 esac

--- a/config/travis/runtests.sh
+++ b/config/travis/runtests.sh
@@ -65,7 +65,8 @@ then
 
 	docker build --build-arg PPA_TRACK="dev" -f Dockerfile -t ${CONTAINER_NAME} .
 
-	docker run -v ${SOURCE_PATH}:/data ${CONTAINER_NAME} log2timeline --status_view linear /data/test.plaso /data/test_data;
+	# The Docker CI test seems to be timing out when run on /data/test_data
+	docker run -v ${SOURCE_PATH}:/data ${CONTAINER_NAME} log2timeline --status_view linear /data/test.plaso /data/test_data/image.qcow2;
 
 	docker run -v ${SOURCE_PATH}:/data ${CONTAINER_NAME} psort --status_view linear -w /data/timeline.log /data/test.plaso;
 


### PR DESCRIPTION
Split https://github.com/log2timeline/plaso/pull/3094 into 2 PRs to ensure CI tests pass changes have been reviews by @rgayon 