### PR TITLE
Removed Python 3.5 CI test due to dependency with type annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,15 +39,6 @@ jobs:
     python: 3.8
     services:
     - docker
-  - name: "Ubuntu Focal (20.04) (Docker) with Python 3.5 (tox)"
-    env:
-    - TOXENV="py35"
-    - UBUNTU_VERSION="20.04"
-    group: edge
-    language: python
-    python: 3.5
-    services:
-    - docker
   - name: "Ubuntu Focal (20.04) (Docker) with Python 3.6 (tox)"
     env:
     - TOXENV="py36"


### PR DESCRIPTION
Removed Python 3.5 CI test due to dependency with type annotations