### PR TITLE
Remove show_memory_usage from log2timeline doc

### DIFF
--- a/docs/sources/user/Using-log2timeline.md
+++ b/docs/sources/user/Using-log2timeline.md
@@ -229,7 +229,6 @@ Options:
 
 
 --single_process
---show_memory_usage
 
 --workers
 ```


### PR DESCRIPTION
As far as I can tell, this argument is not in the code, so removing it from the doc.


**Related issue (if applicable):** fixes #<plaso issue number here>

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/master/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
