### PR TITLE
Enforce SQLite plugins to have required tables and columns

### DIFF
--- a/plaso/parsers/sqlite_plugins/interface.py
+++ b/plaso/parsers/sqlite_plugins/interface.py
@@ -140,10 +140,14 @@ class SQLitePlugin(plugins.BasePlugin):
       database (SQLiteDatabase): the database who's structure is being checked.
 
     Returns:
-      bool: True if the database has the minimum tables and columns defined by
-          the plugin, or False if it does not. The database can have more tables
-          and/or columns than specified by the plugin and still return True.
+      bool: True if the database has the required tables and columns defined by
+          the plugin, or False if it does not or if the plugin does not define
+          required tables and columns. The database can have more tables and/or
+          columns than specified by the plugin and still return True.
     """
+    if not self.REQUIRED_STRUCTURE:
+      return False
+
     has_required_structure = True
     for required_table, required_columns in self.REQUIRED_STRUCTURE.items():
       if required_table not in database.tables:

--- a/tests/parsers/sqlite_plugins/interface.py
+++ b/tests/parsers/sqlite_plugins/interface.py
@@ -19,7 +19,8 @@ class TestSQLitePlugin(interface.SQLitePlugin):
   QUERIES = [(
       'SELECT Field1, Field2, Field3 FROM MyTable', 'ParseMyTableRow')]
 
-  REQUIRED_TABLES = frozenset(['MyTable'])
+  REQUIRED_STRUCTURE = {
+      'MyTable': frozenset(['Field1'])}
 
   SCHEMAS = [
       {'MyTable': (


### PR DESCRIPTION
Enforce SQLite plugins to have required tables and columns