### PR TITLE
Fix missing spaces in ssh Message strings

### DIFF
--- a/data/formatters/generic.yaml
+++ b/data/formatters/generic.yaml
@@ -635,10 +635,10 @@ short_message:
 type: 'conditional'
 data_type: 'syslog:ssh:failed_connection'
 message:
-- 'Unsuccessful connection of user: {username}'
+- 'Unsuccessful connection of user: {username} '
 - 'from {address}:'
-- '{port}'
-- 'using authentication method: {authentication_method}'
+- '{port} '
+- 'using authentication method: {authentication_method} '
 - 'ssh pid: {pid}'
 separator: ''
 short_message:
@@ -647,10 +647,10 @@ short_message:
 type: 'conditional'
 data_type: 'syslog:ssh:login'
 message:
-- 'Successful login of user: {username}'
+- 'Successful login of user: {username} '
 - 'from {address}:'
-- '{port}'
-- 'using authentication method: {authentication_method}'
+- '{port} '
+- 'using authentication method: {authentication_method} '
 - 'ssh pid: {pid}'
 separator: ''
 short_message:
@@ -660,7 +660,7 @@ type: 'conditional'
 data_type: 'syslog:ssh:opened_connection'
 message:
 - 'Connection opened {address}:'
-- '{port}'
+- '{port} '
 - 'ssh pid: {pid}'
 separator: ''
 short_message:


### PR DESCRIPTION
## Fix missing spaces in ssh Message strings
I noticed some message strings were missings spaces:

> Successful login of user: ryanfrom 10.1.1.1:53570using authentication method: passwordssh pid: 1234

Small PR to add those in.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
