### PR TITLE
Added additional fields support to elastic output module #3172

### DIFF
--- a/plaso/cli/helpers/dynamic_output.py
+++ b/plaso/cli/helpers/dynamic_output.py
@@ -37,10 +37,10 @@ class DynamicOutputArgumentsHelper(interface.ArgumentsHelper):
 
     default_fields = ', '.join(cls._DEFAULT_FIELDS)
     argument_group.add_argument(
-        '--additional_fields', dest='additional_fields', type=str,
-        action='store', default='', help=(
-            'Defines extra fields to be included in the output, in addition to'
-            ' the default fields, which are {0:s}.'.format(default_fields)))
+        '--additional_fields', '--additional-fields', dest='additional_fields',
+        type=str, action='store', default='', help=(
+            'Defines extra fields to be included in the output, in addition to '
+            'the default fields, which are {0:s}.'.format(default_fields)))
 
   @classmethod
   def ParseOptions(cls, options, output_module):  # pylint: disable=arguments-differ
@@ -62,11 +62,9 @@ class DynamicOutputArgumentsHelper(interface.ArgumentsHelper):
     fields = cls._ParseStringOption(
         options, 'fields', default_value=default_fields)
 
-    additional_fields = cls._ParseStringOption(
-        options, 'additional_fields')
-
+    additional_fields = cls._ParseStringOption(options, 'additional_fields')
     if additional_fields:
-      fields = '{0:s},{1:s}'.format(fields, additional_fields)
+      fields = ','.join([fields, additional_fields])
 
     output_module.SetFields([
         field_name.strip() for field_name in fields.split(',')])

--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -61,7 +61,7 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
             'Export string fields that will not be analyzed by Lucene.'))
 
     argument_group.add_argument(
-        '--additional', '--additional-fields', dest='additional_fields',
+        '--additional_fields', '--additional-fields', dest='additional_fields',
         action='store', default='', help=(
             'JSON string with a dict of fields and values to add to each '
             'event that will be indexed by Elastic.'))
@@ -130,21 +130,21 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
     additional_fields_string = cls._ParseStringOption(
         options, 'additional_fields')
 
+    additional_fields = {}
     if additional_fields_string:
       try:
         additional_fields = json.loads(additional_fields_string)
-      except (json.JSONDecodeError, ValueError) as exc:
+      except (json.JSONDecodeError, ValueError) as exception:
         additional_fields = {}
         logger.warning(
-            'Unable to parse the extra fields, with error: {0!s}'.format(exc))
+            'Unable to parse the extra fields, with error: {0!s}'.format(
+                exception))
 
       if not isinstance(additional_fields, dict):
         logger.warning(
-            'Extra fields needs to be a dictionary, not [{0!s}]'.format(
+            'Extra fields needs to be a dictionary, not "{0!s}"'.format(
                 type(additional_fields)))
         additional_fields = {}
-    else:
-      additional_fields = {}
 
     ca_certificates_path = cls._ParseStringOption(
         options, 'ca_certificates_file_path')

--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -61,6 +61,12 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
             'Export string fields that will not be analyzed by Lucene.'))
 
     argument_group.add_argument(
+        '--extra_fields', '--extra-fields', dest='extra_fields',
+        action='store', default='', help=(
+            'JSON string with a dict of fields and values to add to each '
+            'event that will be indexed by Elastic.'))
+
+    argument_group.add_argument(
         '--elastic_mappings', '--elastic-mappings', dest='elastic_mappings',
         action='store', default=None, metavar='PATH', help=(
             'Username to use for Elasticsearch authentication.'))
@@ -121,6 +127,23 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
     elastic_user = cls._ParseStringOption(options, 'elastic_user')
     elastic_password = cls._ParseStringOption(options, 'elastic_password')
     use_ssl = getattr(options, 'use_ssl', False)
+    extra_fields_string = cls._ParseStringOption(options, 'extra_fields')
+
+    if extra_fields_string:
+      try:
+        extra_fields = json.loads(extra_fields_string)
+      except (json.JSONDecodeError, ValueError) as exc:
+        extra_fields = {}
+        logger.warning(
+            'Unable to parse the extra fields, with error: {0!s}'.format(exc))
+
+      if not isinstance(extra_fields, dict):
+        logger.warning(
+            'Extra fields needs to be a dictionary, not [{0!s}]'.format(
+                type(extra_fields)))
+        extra_fields = {}
+    else:
+      extra_fields = {}
 
     ca_certificates_path = cls._ParseStringOption(
         options, 'ca_certificates_file_path')
@@ -146,6 +169,7 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
     output_module.SetUseSSL(use_ssl)
     output_module.SetCACertificatesPath(ca_certificates_path)
     output_module.SetURLPrefix(elastic_url_prefix)
+    output_module.SetExtraFields(extra_fields)
 
     # TODO: remove --raw-field option.
     raw_fields = getattr(options, 'raw_fields', cls._DEFAULT_RAW_FIELDS)

--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -61,7 +61,7 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
             'Export string fields that will not be analyzed by Lucene.'))
 
     argument_group.add_argument(
-        '--extra_fields', '--extra-fields', dest='extra_fields',
+        '--additional', '--additional-fields', dest='additional_fields',
         action='store', default='', help=(
             'JSON string with a dict of fields and values to add to each '
             'event that will be indexed by Elastic.'))
@@ -127,23 +127,24 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
     elastic_user = cls._ParseStringOption(options, 'elastic_user')
     elastic_password = cls._ParseStringOption(options, 'elastic_password')
     use_ssl = getattr(options, 'use_ssl', False)
-    extra_fields_string = cls._ParseStringOption(options, 'extra_fields')
+    additional_fields_string = cls._ParseStringOption(
+        options, 'additional_fields')
 
-    if extra_fields_string:
+    if additional_fields_string:
       try:
-        extra_fields = json.loads(extra_fields_string)
+        additional_fields = json.loads(additional_fields_string)
       except (json.JSONDecodeError, ValueError) as exc:
-        extra_fields = {}
+        additional_fields = {}
         logger.warning(
             'Unable to parse the extra fields, with error: {0!s}'.format(exc))
 
-      if not isinstance(extra_fields, dict):
+      if not isinstance(additional_fields, dict):
         logger.warning(
             'Extra fields needs to be a dictionary, not [{0!s}]'.format(
-                type(extra_fields)))
-        extra_fields = {}
+                type(additional_fields)))
+        additional_fields = {}
     else:
-      extra_fields = {}
+      additional_fields = {}
 
     ca_certificates_path = cls._ParseStringOption(
         options, 'ca_certificates_file_path')
@@ -169,7 +170,7 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
     output_module.SetUseSSL(use_ssl)
     output_module.SetCACertificatesPath(ca_certificates_path)
     output_module.SetURLPrefix(elastic_url_prefix)
-    output_module.SetExtraFields(extra_fields)
+    output_module.SetAdditionalFields(additional_fields)
 
     # TODO: remove --raw-field option.
     raw_fields = getattr(options, 'raw_fields', cls._DEFAULT_RAW_FIELDS)

--- a/plaso/output/shared_elastic.py
+++ b/plaso/output/shared_elastic.py
@@ -367,10 +367,22 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
   def SetAdditionalFields(self, additional_fields):
     """Sets the additional field.
 
+    This function allows for you to add a key/value pair to each document
+    that is indexed by Elastic. That is for each document or event that is
+    indexed into Elastic all key/value pairs in the additional_fields dict
+    will be added to the document.
+
+    Only keys that start with '__' will be allowed to be added in order to
+    prevent overwriting already existing keys in the event.
+
     Args:
       additional_fields (dict[str, Any]): Additional fields and values that
           will be added to each indexed event.
     """
+    additional_keys = list(additional_fields.keys())
+    for key in additional_keys:
+      if not key.startswith('__'):
+        _ = additional_fields.pop(key)
     self._additional_fields = additional_fields
     logger.debug(
         'Additional fields set, adding fields: {0:s} to each event'.format(

--- a/plaso/output/shared_elastic.py
+++ b/plaso/output/shared_elastic.py
@@ -365,10 +365,10 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     self._client = None
 
   def SetAdditionalFields(self, additional_fields):
-    """Set the additional field.
+    """Sets the additional field.
 
     Args:
-      additional_fields (dict): A dict with additional fields and values that
+      additional_fields (dict[str, Any]): Additional fields and values that
           will be added to each indexed event.
     """
     self._additional_fields = additional_fields
@@ -377,7 +377,7 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
             ','.join(additional_fields.keys())))
 
   def SetFlushInterval(self, flush_interval):
-    """Set the flush interval.
+    """Sets the flush interval.
 
     Args:
       flush_interval (int): number of events to buffer before doing a bulk
@@ -387,7 +387,7 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     logger.debug('Elasticsearch flush interval: {0:d}'.format(flush_interval))
 
   def SetIndexName(self, index_name):
-    """Set the index name.
+    """Sets the index name.
 
     Args:
       index_name (str): name of the index.
@@ -404,7 +404,7 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     self._mappings = mappings
 
   def SetPassword(self, password):
-    """Set the password.
+    """Sets the password.
 
     Args:
       password (str): password to authenticate with.
@@ -413,7 +413,7 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     logger.debug('Elastic password: ********')
 
   def SetServerInformation(self, server, port):
-    """Set the server information.
+    """Sets the server information.
 
     Args:
       server (str): IP address or hostname of the server.

--- a/plaso/output/shared_elastic.py
+++ b/plaso/output/shared_elastic.py
@@ -163,6 +163,7 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     super(SharedElasticsearchOutputModule, self).__init__(output_mediator)
     self._client = None
     self._event_documents = []
+    self._extra_fields = None
     self._flush_interval = self._DEFAULT_FLUSH_INTERVAL
     self._field_formatting_helper = SharedElasticsearchFieldFormattingHelper(
         output_mediator)
@@ -323,6 +324,9 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     event_values = self._GetSanitizedEventValues(
         event, event_data, event_data_stream, event_tag)
 
+    if self._extra_fields:
+      event_values.update(self._extra_fields)
+
     self._event_documents.append(event_document)
     self._event_documents.append(event_values)
     self._number_of_buffered_events += 1
@@ -359,6 +363,18 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     self._FlushEvents()
 
     self._client = None
+
+  def SetExtraFields(self, extra_fields):
+    """Set the extra field.
+
+    Args:
+      extra_fields (dict): A dict with extra fields and values that
+          will be added to each indexed event.
+    """
+    self._extra_fields = extra_fields
+    logger.debug(
+        'Extra fields set, adding fields: {0:s} to each event'.format(
+            ','.join(extra_fields.keys())))
 
   def SetFlushInterval(self, flush_interval):
     """Set the flush interval.

--- a/plaso/output/shared_elastic.py
+++ b/plaso/output/shared_elastic.py
@@ -161,9 +161,9 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
           modules and other components, such as storage and dfvfs.
     """
     super(SharedElasticsearchOutputModule, self).__init__(output_mediator)
+    self._additional_fields = None
     self._client = None
     self._event_documents = []
-    self._extra_fields = None
     self._flush_interval = self._DEFAULT_FLUSH_INTERVAL
     self._field_formatting_helper = SharedElasticsearchFieldFormattingHelper(
         output_mediator)
@@ -324,8 +324,8 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
     event_values = self._GetSanitizedEventValues(
         event, event_data, event_data_stream, event_tag)
 
-    if self._extra_fields:
-      event_values.update(self._extra_fields)
+    if self._additional_fields:
+      event_values.update(self._additional_fields)
 
     self._event_documents.append(event_document)
     self._event_documents.append(event_values)
@@ -364,17 +364,17 @@ class SharedElasticsearchOutputModule(interface.OutputModule):
 
     self._client = None
 
-  def SetExtraFields(self, extra_fields):
-    """Set the extra field.
+  def SetAdditionalFields(self, additional_fields):
+    """Set the additional field.
 
     Args:
-      extra_fields (dict): A dict with extra fields and values that
+      additional_fields (dict): A dict with additional fields and values that
           will be added to each indexed event.
     """
-    self._extra_fields = extra_fields
+    self._additional_fields = additional_fields
     logger.debug(
-        'Extra fields set, adding fields: {0:s} to each event'.format(
-            ','.join(extra_fields.keys())))
+        'Additional fields set, adding fields: {0:s} to each event'.format(
+            ','.join(additional_fields.keys())))
 
   def SetFlushInterval(self, flush_interval):
     """Set the flush interval.

--- a/tests/cli/helpers/dynamic_output.py
+++ b/tests/cli/helpers/dynamic_output.py
@@ -25,7 +25,7 @@ usage: cli_helper.py [--fields FIELDS] [--additional_fields ADDITIONAL_FIELDS]
 Test argument parser.
 
 optional arguments:
-  --additional_fields ADDITIONAL_FIELDS
+  --additional_fields ADDITIONAL_FIELDS, --additional-fields ADDITIONAL_FIELDS
                         Defines extra fields to be included in the output, in
                         addition to the default fields, which are datetime,
                         timestamp_desc, source, source_long, message, parser,

--- a/tests/cli/helpers/elastic_output.py
+++ b/tests/cli/helpers/elastic_output.py
@@ -32,8 +32,10 @@ Test argument parser.
 
 optional arguments:
   --additional_fields ADDITIONAL_FIELDS, --additional-fields ADDITIONAL_FIELDS
-                        JSON string with a dict of fields and values to add to
-                        each event that will be indexed by Elastic.
+                        Defines extra fields to be included in the output, in
+                        addition to the default fields, which are datetime,
+                        display_name, message, source_long, source_short, tag,
+                        timestamp, timestamp_desc.
   --ca_certificates_file_path PATH, --ca-certificates-file-path PATH
                         Path to a file containing a list of root certificates
                         to trust.

--- a/tests/cli/helpers/elastic_output.py
+++ b/tests/cli/helpers/elastic_output.py
@@ -21,15 +21,19 @@ class ElasticSearchOutputArgumentsHelperTest(
 
   _EXPECTED_OUTPUT = """\
 usage: cli_helper.py [--index_name NAME] [--flush_interval INTERVAL]
-                     [--raw_fields] [--elastic_mappings PATH]
-                     [--elastic_user USERNAME] [--elastic_password PASSWORD]
-                     [--use_ssl] [--ca_certificates_file_path PATH]
+                     [--raw_fields] [--additional_fields ADDITIONAL_FIELDS]
+                     [--elastic_mappings PATH] [--elastic_user USERNAME]
+                     [--elastic_password PASSWORD] [--use_ssl]
+                     [--ca_certificates_file_path PATH]
                      [--elastic_url_prefix URL_PREFIX] [--server HOSTNAME]
                      [--port PORT]
 
 Test argument parser.
 
 optional arguments:
+  --additional_fields ADDITIONAL_FIELDS, --additional-fields ADDITIONAL_FIELDS
+                        JSON string with a dict of fields and values to add to
+                        each event that will be indexed by Elastic.
   --ca_certificates_file_path PATH, --ca-certificates-file-path PATH
                         Path to a file containing a list of root certificates
                         to trust.

--- a/tests/cli/helpers/output_modules.py
+++ b/tests/cli/helpers/output_modules.py
@@ -24,7 +24,7 @@ usage: cli_helper.py [-o FORMAT] [-w OUTPUT_FILE] [--fields FIELDS]
 Test argument parser.
 
 optional arguments:
-  --additional_fields ADDITIONAL_FIELDS
+  --additional_fields ADDITIONAL_FIELDS, --additional-fields ADDITIONAL_FIELDS
                         Defines extra fields to be included in the output, in
                         addition to the default fields, which are datetime,
                         timestamp_desc, source, source_long, message, parser,


### PR DESCRIPTION
## One line description of pull request

Changing the shared_elastic output module to allow you to define extra fields to add to each event as it gets indexed into Elastic.

## Description:

The reason is a move for Timesketch to stop using the Timesketch output module in favor of the Elastic one. This would mean that the TS specific things that are done in the output module are going to be moved to TS itself, and all that psort does is to ingest data into ES.

However in order for Timesketch to be able to identify each event as belonging to a particular timeline new events need to be added to each document that is indexed. This PR provides the option to do so.

## Checklist:
  - [x] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [x] Reviewer assigned
