### PR TITLE
Added Elastic Timesketch output module #3097

### DIFF
--- a/plaso/cli/helpers/__init__.py
+++ b/plaso/cli/helpers/__init__.py
@@ -8,6 +8,7 @@ from plaso.cli.helpers import data_location
 from plaso.cli.helpers import date_filters
 from plaso.cli.helpers import dynamic_output
 from plaso.cli.helpers import elastic_output
+from plaso.cli.helpers import elastic_ts_output
 from plaso.cli.helpers import event_filters
 from plaso.cli.helpers import extraction
 from plaso.cli.helpers import filter_file

--- a/plaso/cli/helpers/elastic_ts_output.py
+++ b/plaso/cli/helpers/elastic_ts_output.py
@@ -15,7 +15,7 @@ class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
   CATEGORY = 'output'
   DESCRIPTION = 'Argument helper for the Elastic Timesketch output modules.'
 
-  _DEFAULT_TIMELINE_ID = 0
+  _DEFAULT_TIMELINE_IDENTIFIER = 0
 
   @classmethod
   def AddArguments(cls, argument_group):
@@ -32,10 +32,11 @@ class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
         argument_group)
 
     argument_group.add_argument(
-        '--timeline_id', '--timeline-id', dest='timeline_id', type=int,
-        default=cls._DEFAULT_TIMELINE_ID, action='store',
-        metavar='TIMELINE_ID', help=(
-            'The ID of the Timesketch Timeline object this data is tied to'))
+        '--timeline_identifier', '--timeline-identifier',
+        dest='timeline_identifier', type=int,
+        default=cls._DEFAULT_TIMELINE_IDENTIFIER, action='store',
+        metavar='IDENTIFIER', help=(
+             'The identifier of the timeline in Timesketch.'))
 
   # pylint: disable=arguments-differ
   @classmethod
@@ -58,11 +59,12 @@ class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
     elastic_output.ElasticSearchOutputArgumentsHelper.ParseOptions(
         options, output_module)
 
-    timeline_id = cls._ParseNumericOption(
-        options, 'timeline_id', default_value=cls._DEFAULT_TIMELINE_ID)
+    timeline_identifier = cls._ParseNumericOption(
+        options, 'timeline_identifier',
+        default_value=cls._DEFAULT_TIMELINE_IDENTIFIER)
 
-    if timeline_id:
-      output_module.SetTimelineIdentifier(timeline_id)
+    if timeline_identifier:
+      output_module.SetTimelineIdentifier(timeline_identifier)
 
 
 manager.ArgumentHelperManager.RegisterHelper(

--- a/plaso/cli/helpers/elastic_ts_output.py
+++ b/plaso/cli/helpers/elastic_ts_output.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+"""The Elastic Timesketch output module CLI arguments helper."""
+
+import getpass
+import json
+import os
+
+from uuid import uuid4
+
+from plaso.cli.helpers import interface
+from plaso.cli.helpers import manager
+from plaso.cli.helpers import server_config
+from plaso.cli import logger
+from plaso.lib import errors
+from plaso.output import elastic
+from plaso.output import shared_elastic
+
+
+class ElasticTimesketchArgumentsHelper(server_config.ServerArgumentsHelper):
+  """Elastic Timesketch CLI arguments helper."""
+
+  _DEFAULT_SERVER = '127.0.0.1'
+  _DEFAULT_PORT = 9200
+
+
+class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
+  """Elastic Timesketch output module CLI arguments helper."""
+
+  NAME = 'elastic_ts'
+  CATEGORY = 'output'
+  DESCRIPTION = 'Argument helper for the Elastic Timesketch output modules.'
+
+  _DEFAULT_INDEX_NAME = uuid4().hex
+  _DEFAULT_FLUSH_INTERVAL = 1000
+  _DEFAULT_TIMELINE_ID = 0
+
+  @classmethod
+  def AddArguments(cls, argument_group):
+    """Adds command line arguments the helper supports to an argument group.
+
+    This function takes an argument parser or an argument group object and adds
+    to it all the command line arguments this helper supports.
+
+    Args:
+      argument_group (argparse._ArgumentGroup|argparse.ArgumentParser):
+          argparse group.
+    """
+    argument_group.add_argument(
+        '--index_name', '--index-name', dest='index_name', type=str,
+        action='store', default=cls._DEFAULT_INDEX_NAME, metavar='NAME',
+        help='Name of the index in ElasticSearch.')
+
+    argument_group.add_argument(
+        '--flush_interval', '--flush-interval', dest='flush_interval', type=int,
+        action='store', default=cls._DEFAULT_FLUSH_INTERVAL, metavar='INTERVAL',
+        help='Events to queue up before bulk insert to ElasticSearch.')
+
+    argument_group.add_argument(
+        '--elastic_mappings', '--elastic-mappings', dest='elastic_mappings',
+        action='store', default=None, metavar='PATH', help=(
+            'Username to use for Elasticsearch authentication.'))
+
+    argument_group.add_argument(
+        '--elastic_user', '--elastic-user', dest='elastic_user', action='store',
+        default=None, metavar='USERNAME', help=(
+            'Username to use for Elasticsearch authentication.'))
+
+    argument_group.add_argument(
+        '--elastic_password', '--elastic-password', dest='elastic_password',
+        action='store', default=None, metavar='PASSWORD', help=(
+            'Password to use for Elasticsearch authentication. WARNING: use '
+            'with caution since this can expose the password to other users '
+            'on the system. The password can also be set with the environment '
+            'variable PLASO_ELASTIC_PASSWORD. '))
+
+    argument_group.add_argument(
+        '--timeline_id', '--timeline-id', dest='timeline_id', type=int,
+        default=cls._DEFAULT_TIMELINE_ID, action='store',
+        metavar='TIMELINE_ID', help=(
+            'The ID of the Timesketch Timeline object this data is tied to'))
+
+    argument_group.add_argument(
+        '--use_ssl', '--use-ssl', dest='use_ssl', action='store_true',
+        help='Enforces use of SSL/TLS.')
+
+    argument_group.add_argument(
+        '--ca_certificates_file_path', '--ca-certificates-file-path',
+        dest='ca_certificates_file_path', action='store', type=str,
+        default=None, metavar='PATH', help=(
+            'Path to a file containing a list of root certificates to trust.'))
+
+    argument_group.add_argument(
+        '--elastic_url_prefix', '--elastic-url-prefix',
+        dest='elastic_url_prefix', type=str, action='store', default=None,
+        metavar='URL_PREFIX', help='URL prefix for elastic search.')
+
+    ElasticTimesketchArgumentsHelper.AddArguments(argument_group)
+
+  # pylint: disable=arguments-differ
+  @classmethod
+  def ParseOptions(cls, options, output_module):
+    """Parses and validates options.
+
+    Args:
+      options (argparse.Namespace): parser options.
+      output_module (OutputModule): output module to configure.
+
+    Raises:
+      BadConfigObject: when the output module object is of the wrong type.
+      BadConfigOption: when a configuration parameter fails validation.
+    """
+    if not isinstance(
+        output_module, shared_elastic.SharedElasticsearchOutputModule):
+      raise errors.BadConfigObject(
+          'Output module is not an instance of ElasticsearchOutputModule')
+
+    index_name = cls._ParseStringOption(
+        options, 'index_name', default_value=cls._DEFAULT_INDEX_NAME)
+    flush_interval = cls._ParseNumericOption(
+        options, 'flush_interval', default_value=cls._DEFAULT_FLUSH_INTERVAL)
+    mappings_file_path = cls._ParseStringOption(options, 'elastic_mappings')
+    elastic_user = cls._ParseStringOption(options, 'elastic_user')
+    elastic_password = cls._ParseStringOption(options, 'elastic_password')
+    use_ssl = getattr(options, 'use_ssl', False)
+    timeline_id = cls._ParseNumericOption(
+        options, 'timeline_id', default_value=cls._DEFAULT_TIMELINE_ID)
+
+    ca_certificates_path = cls._ParseStringOption(
+        options, 'ca_certificates_file_path')
+    elastic_url_prefix = cls._ParseStringOption(options, 'elastic_url_prefix')
+
+    if elastic_password is None:
+      elastic_password = os.getenv('PLASO_ELASTIC_PASSWORD', None)
+
+    if elastic_password is not None:
+      logger.warning(
+          'Note that specifying your Elasticsearch password via '
+          '--elastic_password or the environment PLASO_ELASTIC_PASSWORD can '
+          'expose the password to other users on the system.')
+
+    if elastic_user is not None and elastic_password is None:
+      elastic_password = getpass.getpass('Enter your Elasticsearch password: ')
+
+    ElasticTimesketchArgumentsHelper.ParseOptions(options, output_module)
+    output_module.SetIndexName(index_name)
+    output_module.SetFlushInterval(flush_interval)
+    output_module.SetUsername(elastic_user)
+    output_module.SetPassword(elastic_password)
+    output_module.SetUseSSL(use_ssl)
+    output_module.SetCACertificatesPath(ca_certificates_path)
+    output_module.SetURLPrefix(elastic_url_prefix)
+    if timeline_id:
+      output_module.SetTimelineID(timeline_id)
+
+    if not mappings_file_path or not os.path.isfile(mappings_file_path):
+      mappings_filename = output_module.MAPPINGS_FILENAME
+
+      data_location = getattr(options, '_data_location', None) or 'data'
+      mappings_file_path = os.path.join(data_location, mappings_filename)
+
+    if not mappings_file_path or not os.path.isfile(mappings_file_path):
+      raise errors.BadConfigOption(
+          'No such Elasticsearch mappings file: {0!s}.'.format(
+              mappings_file_path))
+
+    with open(mappings_file_path, 'r') as file_object:
+      mappings_json = json.load(file_object)
+
+    output_module.SetMappings(mappings_json)
+
+
+manager.ArgumentHelperManager.RegisterHelper(ElasticTimesketchOutputArgumentsHelper)

--- a/plaso/cli/helpers/elastic_ts_output.py
+++ b/plaso/cli/helpers/elastic_ts_output.py
@@ -43,6 +43,7 @@ class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
             'The ID of the Timesketch Timeline object this data is tied to'))
 
     ElasticTimesketchArgumentsHelper.AddArguments(argument_group)
+    elastic_output.ElasticSearchOutputArgumentsHelper.Add(argument_group)
 
   # pylint: disable=arguments-differ
   @classmethod
@@ -66,6 +67,8 @@ class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
         options, 'timeline_id', default_value=cls._DEFAULT_TIMELINE_ID)
 
     ElasticTimesketchArgumentsHelper.ParseOptions(options, output_module)
+    elastic_output.ElasticSearchOutputArgumentsHelper.ParseOptions(options, output_module)
+
     if timeline_id:
       output_module.SetTimelineID(timeline_id)
 

--- a/plaso/cli/helpers/elastic_ts_output.py
+++ b/plaso/cli/helpers/elastic_ts_output.py
@@ -1,16 +1,12 @@
 # -*- coding: utf-8 -*-
 """The Elastic Timesketch output module CLI arguments helper."""
 
-import getpass
-import json
-import os
 
 from uuid import uuid4
 
 from plaso.cli.helpers import interface
 from plaso.cli.helpers import manager
 from plaso.cli.helpers import server_config
-from plaso.cli import logger
 from plaso.lib import errors
 from plaso.output import shared_elastic
 
@@ -45,53 +41,10 @@ class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
           argparse group.
     """
     argument_group.add_argument(
-        '--index_name', '--index-name', dest='index_name', type=str,
-        action='store', default=cls._DEFAULT_INDEX_NAME, metavar='NAME',
-        help='Name of the index in ElasticSearch.')
-
-    argument_group.add_argument(
-        '--flush_interval', '--flush-interval', dest='flush_interval', type=int,
-        action='store', default=cls._DEFAULT_FLUSH_INTERVAL, metavar='INTERVAL',
-        help='Events to queue up before bulk insert to ElasticSearch.')
-
-    argument_group.add_argument(
-        '--elastic_mappings', '--elastic-mappings', dest='elastic_mappings',
-        action='store', default=None, metavar='PATH', help=(
-            'Username to use for Elasticsearch authentication.'))
-
-    argument_group.add_argument(
-        '--elastic_user', '--elastic-user', dest='elastic_user', action='store',
-        default=None, metavar='USERNAME', help=(
-            'Username to use for Elasticsearch authentication.'))
-
-    argument_group.add_argument(
-        '--elastic_password', '--elastic-password', dest='elastic_password',
-        action='store', default=None, metavar='PASSWORD', help=(
-            'Password to use for Elasticsearch authentication. WARNING: use '
-            'with caution since this can expose the password to other users '
-            'on the system. The password can also be set with the environment '
-            'variable PLASO_ELASTIC_PASSWORD. '))
-
-    argument_group.add_argument(
         '--timeline_id', '--timeline-id', dest='timeline_id', type=int,
         default=cls._DEFAULT_TIMELINE_ID, action='store',
         metavar='TIMELINE_ID', help=(
             'The ID of the Timesketch Timeline object this data is tied to'))
-
-    argument_group.add_argument(
-        '--use_ssl', '--use-ssl', dest='use_ssl', action='store_true',
-        help='Enforces use of SSL/TLS.')
-
-    argument_group.add_argument(
-        '--ca_certificates_file_path', '--ca-certificates-file-path',
-        dest='ca_certificates_file_path', action='store', type=str,
-        default=None, metavar='PATH', help=(
-            'Path to a file containing a list of root certificates to trust.'))
-
-    argument_group.add_argument(
-        '--elastic_url_prefix', '--elastic-url-prefix',
-        dest='elastic_url_prefix', type=str, action='store', default=None,
-        metavar='URL_PREFIX', help='URL prefix for elastic search.')
 
     ElasticTimesketchArgumentsHelper.AddArguments(argument_group)
 
@@ -113,59 +66,12 @@ class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
       raise errors.BadConfigObject(
           'Output module is not an instance of ElasticsearchOutputModule')
 
-    index_name = cls._ParseStringOption(
-        options, 'index_name', default_value=cls._DEFAULT_INDEX_NAME)
-    flush_interval = cls._ParseNumericOption(
-        options, 'flush_interval', default_value=cls._DEFAULT_FLUSH_INTERVAL)
-    mappings_file_path = cls._ParseStringOption(options, 'elastic_mappings')
-    elastic_user = cls._ParseStringOption(options, 'elastic_user')
-    elastic_password = cls._ParseStringOption(options, 'elastic_password')
-    use_ssl = getattr(options, 'use_ssl', False)
     timeline_id = cls._ParseNumericOption(
         options, 'timeline_id', default_value=cls._DEFAULT_TIMELINE_ID)
 
-    ca_certificates_path = cls._ParseStringOption(
-        options, 'ca_certificates_file_path')
-    elastic_url_prefix = cls._ParseStringOption(options, 'elastic_url_prefix')
-
-    if elastic_password is None:
-      elastic_password = os.getenv('PLASO_ELASTIC_PASSWORD', None)
-
-    if elastic_password is not None:
-      logger.warning(
-          'Note that specifying your Elasticsearch password via '
-          '--elastic_password or the environment PLASO_ELASTIC_PASSWORD can '
-          'expose the password to other users on the system.')
-
-    if elastic_user is not None and elastic_password is None:
-      elastic_password = getpass.getpass('Enter your Elasticsearch password: ')
-
     ElasticTimesketchArgumentsHelper.ParseOptions(options, output_module)
-    output_module.SetIndexName(index_name)
-    output_module.SetFlushInterval(flush_interval)
-    output_module.SetUsername(elastic_user)
-    output_module.SetPassword(elastic_password)
-    output_module.SetUseSSL(use_ssl)
-    output_module.SetCACertificatesPath(ca_certificates_path)
-    output_module.SetURLPrefix(elastic_url_prefix)
     if timeline_id:
       output_module.SetTimelineID(timeline_id)
-
-    if not mappings_file_path or not os.path.isfile(mappings_file_path):
-      mappings_filename = output_module.MAPPINGS_FILENAME
-
-      data_location = getattr(options, '_data_location', None) or 'data'
-      mappings_file_path = os.path.join(data_location, mappings_filename)
-
-    if not mappings_file_path or not os.path.isfile(mappings_file_path):
-      raise errors.BadConfigOption(
-          'No such Elasticsearch mappings file: {0!s}.'.format(
-              mappings_file_path))
-
-    with open(mappings_file_path, 'r') as file_object:
-      mappings_json = json.load(file_object)
-
-    output_module.SetMappings(mappings_json)
 
 
 manager.ArgumentHelperManager.RegisterHelper(

--- a/plaso/cli/helpers/elastic_ts_output.py
+++ b/plaso/cli/helpers/elastic_ts_output.py
@@ -8,14 +8,6 @@ from plaso.lib import errors
 from plaso.output import shared_elastic
 
 
-class ElasticTimesketchArgumentsHelper(
-    elastic_output.ElasticSearchServerArgumentsHelper):
-  """Elastic Timesketch CLI arguments helper."""
-
-  _DEFAULT_SERVER = '127.0.0.1'
-  _DEFAULT_PORT = 9200
-
-
 class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
   """Elastic Timesketch output module CLI arguments helper."""
 
@@ -36,14 +28,14 @@ class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
       argument_group (argparse._ArgumentGroup|argparse.ArgumentParser):
           argparse group.
     """
+    elastic_output.ElasticSearchOutputArgumentsHelper.AddArguments(
+        argument_group)
+
     argument_group.add_argument(
         '--timeline_id', '--timeline-id', dest='timeline_id', type=int,
         default=cls._DEFAULT_TIMELINE_ID, action='store',
         metavar='TIMELINE_ID', help=(
             'The ID of the Timesketch Timeline object this data is tied to'))
-
-    ElasticTimesketchArgumentsHelper.AddArguments(argument_group)
-    elastic_output.ElasticSearchOutputArgumentsHelper.Add(argument_group)
 
   # pylint: disable=arguments-differ
   @classmethod
@@ -63,11 +55,11 @@ class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
       raise errors.BadConfigObject(
           'Output module is not an instance of ElasticsearchOutputModule')
 
+    elastic_output.ElasticSearchOutputArgumentsHelper.ParseOptions(
+        options, output_module)
+
     timeline_id = cls._ParseNumericOption(
         options, 'timeline_id', default_value=cls._DEFAULT_TIMELINE_ID)
-
-    ElasticTimesketchArgumentsHelper.ParseOptions(options, output_module)
-    elastic_output.ElasticSearchOutputArgumentsHelper.ParseOptions(options, output_module)
 
     if timeline_id:
       output_module.SetTimelineID(timeline_id)

--- a/plaso/cli/helpers/elastic_ts_output.py
+++ b/plaso/cli/helpers/elastic_ts_output.py
@@ -1,17 +1,15 @@
 # -*- coding: utf-8 -*-
 """The Elastic Timesketch output module CLI arguments helper."""
 
-
-from uuid import uuid4
-
+from plaso.cli.helpers import elastic_output
 from plaso.cli.helpers import interface
 from plaso.cli.helpers import manager
-from plaso.cli.helpers import server_config
 from plaso.lib import errors
 from plaso.output import shared_elastic
 
 
-class ElasticTimesketchArgumentsHelper(server_config.ServerArgumentsHelper):
+class ElasticTimesketchArgumentsHelper(
+    elastic_output.ElasticSearchServerArgumentsHelper):
   """Elastic Timesketch CLI arguments helper."""
 
   _DEFAULT_SERVER = '127.0.0.1'
@@ -25,8 +23,6 @@ class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
   CATEGORY = 'output'
   DESCRIPTION = 'Argument helper for the Elastic Timesketch output modules.'
 
-  _DEFAULT_INDEX_NAME = uuid4().hex
-  _DEFAULT_FLUSH_INTERVAL = 1000
   _DEFAULT_TIMELINE_ID = 0
 
   @classmethod

--- a/plaso/cli/helpers/elastic_ts_output.py
+++ b/plaso/cli/helpers/elastic_ts_output.py
@@ -13,7 +13,7 @@ class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
 
   NAME = 'elastic_ts'
   CATEGORY = 'output'
-  DESCRIPTION = 'Argument helper for the Elastic Timesketch output modules.'
+  DESCRIPTION = 'Argument helper for the Elastic Timesketch output module.'
 
   _DEFAULT_TIMELINE_IDENTIFIER = 0
 

--- a/plaso/cli/helpers/elastic_ts_output.py
+++ b/plaso/cli/helpers/elastic_ts_output.py
@@ -5,7 +5,7 @@ from plaso.cli.helpers import elastic_output
 from plaso.cli.helpers import interface
 from plaso.cli.helpers import manager
 from plaso.lib import errors
-from plaso.output import shared_elastic
+from plaso.output import elastic_ts
 
 
 class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
@@ -51,7 +51,7 @@ class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
       BadConfigOption: when a configuration parameter fails validation.
     """
     if not isinstance(
-        output_module, shared_elastic.SharedElasticsearchOutputModule):
+        output_module, elastic_ts.ElasticTimesketchOutputModule):
       raise errors.BadConfigObject(
           'Output module is not an instance of ElasticsearchOutputModule')
 

--- a/plaso/cli/helpers/elastic_ts_output.py
+++ b/plaso/cli/helpers/elastic_ts_output.py
@@ -62,7 +62,7 @@ class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
         options, 'timeline_id', default_value=cls._DEFAULT_TIMELINE_ID)
 
     if timeline_id:
-      output_module.SetTimelineID(timeline_id)
+      output_module.SetTimelineIdentifier(timeline_id)
 
 
 manager.ArgumentHelperManager.RegisterHelper(

--- a/plaso/cli/helpers/elastic_ts_output.py
+++ b/plaso/cli/helpers/elastic_ts_output.py
@@ -12,7 +12,6 @@ from plaso.cli.helpers import manager
 from plaso.cli.helpers import server_config
 from plaso.cli import logger
 from plaso.lib import errors
-from plaso.output import elastic
 from plaso.output import shared_elastic
 
 
@@ -169,4 +168,5 @@ class ElasticTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
     output_module.SetMappings(mappings_json)
 
 
-manager.ArgumentHelperManager.RegisterHelper(ElasticTimesketchOutputArgumentsHelper)
+manager.ArgumentHelperManager.RegisterHelper(
+    ElasticTimesketchOutputArgumentsHelper)

--- a/plaso/output/__init__.py
+++ b/plaso/output/__init__.py
@@ -3,6 +3,7 @@
 
 from plaso.output import dynamic
 from plaso.output import elastic
+from plaso.output import elastic_ts
 from plaso.output import json_line
 from plaso.output import json_out
 from plaso.output import kml

--- a/plaso/output/elastic_ts.py
+++ b/plaso/output/elastic_ts.py
@@ -49,9 +49,10 @@ class ElasticTimesketchOutputModule(
       NoFormatterFound: if no event formatter can be found to match the data
           type in the event data.
     """
-    event_values = super()._GetSanitizedEventValues(
-        event=event, event_data=event_data,
-        event_data_stream=event_data_stream, event_tag=event_tag)
+    event_values = (
+        super(ElasticTimesketchOutputModule, self)._GetSanitizedEventValues(
+            event=event, event_data=event_data,
+            event_data_stream=event_data_stream, event_tag=event_tag))
 
     if self._timeline_id:
       event_values['__ts_timeline_id'] = self._timeline_id

--- a/plaso/output/elastic_ts.py
+++ b/plaso/output/elastic_ts.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""An output module that saves events to Elasticsearch TS index."""
+
+from plaso.output import logger
+from plaso.output import manager
+from plaso.output import shared_elastic
+
+
+class ElasticTimesketchOutputModule(shared_elastic.SharedElasticsearchOutputModule):
+  """Output module for Timesketch Elasticsearch."""
+
+  NAME = 'elastic_ts'
+  DESCRIPTION = (
+      'Saves the events into an Elasticsearch database for use '
+      'with Timesketch.')
+
+  MAPPINGS_FILENAME = 'timesketch.mappings'
+
+  def __init__(self, output_mediator):
+    """Initializes a Timesketch output module.
+
+    Args:
+      output_mediator (OutputMediator): mediates interactions between output
+          modules and other components, such as storage and dfvfs.
+    """
+    super().__init__(output_mediator)
+    self._timeline_id = None
+
+  def _GetSanitizedEventValues(
+      self, event, event_data, event_data_stream, event_tag):
+    """Sanitizes the event for use in Elasticsearch.
+
+    The event values need to be sanitized to prevent certain values from
+    causing problems when indexing with Elasticsearch. For example the path
+    specification is a nested dictionary which will cause problems for
+    Elasticsearch automatic indexing.
+
+    Args:
+      event (EventObject): event.
+      event_data (EventData): event data.
+      event_data_stream (EventDataStream): event data stream.
+      event_tag (EventTag): event tag.
+
+    Returns:
+      dict[str, object]: sanitized event values.
+
+    Raises:
+      NoFormatterFound: if no event formatter can be found to match the data
+          type in the event data.
+    """
+    event_values = super()._GetSanitizedEventValues(
+        event=event, event_data=event_data,
+        event_data_stream=event_data_stream, event_tag=event_tag)
+
+    if self._timeline_id:
+      event_values['__ts_timeline_id'] = self._timeline_id
+
+    return event_values
+
+  def GetMissingArguments(self):
+    """Retrieves a list of arguments that are missing from the input.
+
+    Returns:
+      list[str]: names of arguments that are required by the module and have
+          not been specified.
+    """
+    if not self._timeline_id:
+      return ['timeline_id']
+    return []
+
+  def SetTimelineID(self, timeline_id):
+    """Sets the timeline ID.
+
+    Args:
+      timeline_id (int): timeline ID.
+    """
+    self._timeline_id = timeline_id
+    logger.info('Timeline ID: {0:d}'.format(self._timeline_id))
+
+  def WriteHeader(self):
+    """Connects to the Elasticsearch server and creates the index."""
+    self._Connect()
+
+    self._CreateIndexIfNotExists(self._index_name, self._mappings)
+
+
+manager.OutputManager.RegisterOutput(
+    ElasticTimesketchOutputModule, disabled=shared_elastic.elasticsearch is None)

--- a/plaso/output/elastic_ts.py
+++ b/plaso/output/elastic_ts.py
@@ -25,7 +25,7 @@ class ElasticTimesketchOutputModule(
           modules and other components, such as storage and dfvfs.
     """
     super(ElasticTimesketchOutputModule, self).__init__(output_mediator)
-    self._timeline_id = None
+    self._timeline_identifier = None
 
   def _GetSanitizedEventValues(
       self, event, event_data, event_data_stream, event_tag):
@@ -54,8 +54,7 @@ class ElasticTimesketchOutputModule(
             event=event, event_data=event_data,
             event_data_stream=event_data_stream, event_tag=event_tag))
 
-    if self._timeline_id:
-      event_values['__ts_timeline_id'] = self._timeline_id
+    event_values['__ts_timeline_id'] = self._timeline_identifier
 
     return event_values
 
@@ -66,18 +65,18 @@ class ElasticTimesketchOutputModule(
       list[str]: names of arguments that are required by the module and have
           not been specified.
     """
-    if not self._timeline_id:
+    if not self._timeline_identifier:
       return ['timeline_id']
     return []
 
-  def SetTimelineIdentifier(self, timeline_id):
+  def SetTimelineIdentifier(self, timeline_identifier):
     """Sets the timeline identifier.
 
     Args:
       timeline_id (int): timeline ID.
     """
-    self._timeline_id = timeline_id
-    logger.info('Timeline ID: {0:d}'.format(self._timeline_id))
+    self._timeline_identifier = timeline_identifier
+    logger.info('Timeline identifier: {0:d}'.format(self._timeline_identifier))
 
   def WriteHeader(self):
     """Connects to the Elasticsearch server and creates the index."""

--- a/plaso/output/elastic_ts.py
+++ b/plaso/output/elastic_ts.py
@@ -6,7 +6,8 @@ from plaso.output import manager
 from plaso.output import shared_elastic
 
 
-class ElasticTimesketchOutputModule(shared_elastic.SharedElasticsearchOutputModule):
+class ElasticTimesketchOutputModule(
+    shared_elastic.SharedElasticsearchOutputModule):
   """Output module for Timesketch Elasticsearch."""
 
   NAME = 'elastic_ts'
@@ -85,4 +86,5 @@ class ElasticTimesketchOutputModule(shared_elastic.SharedElasticsearchOutputModu
 
 
 manager.OutputManager.RegisterOutput(
-    ElasticTimesketchOutputModule, disabled=shared_elastic.elasticsearch is None)
+    ElasticTimesketchOutputModule,
+    disabled=shared_elastic.elasticsearch is None)

--- a/plaso/output/elastic_ts.py
+++ b/plaso/output/elastic_ts.py
@@ -73,7 +73,7 @@ class ElasticTimesketchOutputModule(
     """Sets the timeline identifier.
 
     Args:
-      timeline_id (int): timeline ID.
+      timeline_identifier (int): timeline identifier.
     """
     self._timeline_identifier = timeline_identifier
     logger.info('Timeline identifier: {0:d}'.format(self._timeline_identifier))

--- a/plaso/output/elastic_ts.py
+++ b/plaso/output/elastic_ts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""An output module that saves events to Elasticsearch TS index."""
+"""An output module that saves events to Elasticsearch for Timesketch."""
 
 from plaso.output import logger
 from plaso.output import manager
@@ -18,7 +18,7 @@ class ElasticTimesketchOutputModule(
   MAPPINGS_FILENAME = 'timesketch.mappings'
 
   def __init__(self, output_mediator):
-    """Initializes a Timesketch output module.
+    """Initializes a Timesketch Elasticsearch output module.
 
     Args:
       output_mediator (OutputMediator): mediates interactions between output

--- a/plaso/output/elastic_ts.py
+++ b/plaso/output/elastic_ts.py
@@ -24,7 +24,7 @@ class ElasticTimesketchOutputModule(
       output_mediator (OutputMediator): mediates interactions between output
           modules and other components, such as storage and dfvfs.
     """
-    super().__init__(output_mediator)
+    super(ElasticTimesketchOutputModule, self).__init__(output_mediator)
     self._timeline_id = None
 
   def _GetSanitizedEventValues(

--- a/plaso/output/elastic_ts.py
+++ b/plaso/output/elastic_ts.py
@@ -69,8 +69,8 @@ class ElasticTimesketchOutputModule(
       return ['timeline_id']
     return []
 
-  def SetTimelineID(self, timeline_id):
-    """Sets the timeline ID.
+  def SetTimelineIdentifier(self, timeline_id):
+    """Sets the timeline identifier.
 
     Args:
       timeline_id (int): timeline ID.

--- a/tests/cli/helpers/elastic_ts_output.py
+++ b/tests/cli/helpers/elastic_ts_output.py
@@ -20,17 +20,45 @@ class ElasticTimesketchOutputArgumentsHelperTest(
   # pylint: disable=no-member,protected-access
 
   _EXPECTED_OUTPUT = """\
-usage: cli_helper.py [--timeline_id TIMELINE_ID] [--server HOSTNAME]
-                     [--port PORT]
+usage: cli_helper.py [--index_name NAME] [--flush_interval INTERVAL]
+                     [--raw_fields] [--elastic_mappings PATH]
+                     [--elastic_user USERNAME] [--elastic_password PASSWORD]
+                     [--use_ssl] [--ca_certificates_file_path PATH]
+                     [--elastic_url_prefix URL_PREFIX] [--server HOSTNAME]
+                     [--port PORT] [--timeline_id TIMELINE_ID]
 
 Test argument parser.
 
 optional arguments:
+  --ca_certificates_file_path PATH, --ca-certificates-file-path PATH
+                        Path to a file containing a list of root certificates
+                        to trust.
+  --elastic_mappings PATH, --elastic-mappings PATH
+                        Username to use for Elasticsearch authentication.
+  --elastic_password PASSWORD, --elastic-password PASSWORD
+                        Password to use for Elasticsearch authentication.
+                        WARNING: use with caution since this can expose the
+                        password to other users on the system. The password
+                        can also be set with the environment variable
+                        PLASO_ELASTIC_PASSWORD.
+  --elastic_url_prefix URL_PREFIX, --elastic-url-prefix URL_PREFIX
+                        URL prefix for elastic search.
+  --elastic_user USERNAME, --elastic-user USERNAME
+                        Username to use for Elasticsearch authentication.
+  --flush_interval INTERVAL, --flush-interval INTERVAL
+                        Events to queue up before bulk insert to
+                        ElasticSearch.
+  --index_name NAME, --index-name NAME
+                        Name of the index in ElasticSearch.
   --port PORT           The port number of the server.
+  --raw_fields, --raw-fields
+                        Export string fields that will not be analyzed by
+                        Lucene.
   --server HOSTNAME     The hostname or server IP address of the server.
   --timeline_id TIMELINE_ID, --timeline-id TIMELINE_ID
                         The ID of the Timesketch Timeline object this data is
                         tied to
+  --use_ssl, --use-ssl  Enforces use of SSL/TLS.
 """
 
   def testAddArguments(self):

--- a/tests/cli/helpers/elastic_ts_output.py
+++ b/tests/cli/helpers/elastic_ts_output.py
@@ -21,15 +21,21 @@ class ElasticTimesketchOutputArgumentsHelperTest(
 
   _EXPECTED_OUTPUT = """\
 usage: cli_helper.py [--index_name NAME] [--flush_interval INTERVAL]
-                     [--raw_fields] [--elastic_mappings PATH]
-                     [--elastic_user USERNAME] [--elastic_password PASSWORD]
-                     [--use_ssl] [--ca_certificates_file_path PATH]
+                     [--raw_fields] [--additional_fields ADDITIONAL_FIELDS]
+                     [--elastic_mappings PATH] [--elastic_user USERNAME]
+                     [--elastic_password PASSWORD] [--use_ssl]
+                     [--ca_certificates_file_path PATH]
                      [--elastic_url_prefix URL_PREFIX] [--server HOSTNAME]
                      [--port PORT] [--timeline_id TIMELINE_ID]
 
 Test argument parser.
 
 optional arguments:
+  --additional_fields ADDITIONAL_FIELDS, --additional-fields ADDITIONAL_FIELDS
+                        Defines extra fields to be included in the output, in
+                        addition to the default fields, which are datetime,
+                        display_name, message, source_long, source_short, tag,
+                        timestamp, timestamp_desc.
   --ca_certificates_file_path PATH, --ca-certificates-file-path PATH
                         Path to a file containing a list of root certificates
                         to trust.

--- a/tests/cli/helpers/elastic_ts_output.py
+++ b/tests/cli/helpers/elastic_ts_output.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the Elastic Timesketch output module CLI arguments helper."""
+
+import argparse
+import unittest
+
+from plaso.cli.helpers import elastic_ts_output
+from plaso.lib import errors
+from plaso.output import elastic_ts
+
+from tests.cli import test_lib as cli_test_lib
+from tests.cli.helpers import test_lib
+
+
+class ElasticTimesketchOutputArgumentsHelperTest(
+    test_lib.OutputModuleArgumentsHelperTest):
+  """Tests the Elastic Timesketch output module CLI arguments helper."""
+
+  # pylint: disable=no-member,protected-access
+
+  _EXPECTED_OUTPUT = """\
+usage: cli_helper.py [--index_name NAME] [--flush_interval INTERVAL]
+                     [--elastic_mappings PATH] [--elastic_user USERNAME]
+                     [--elastic_password PASSWORD] [--timeline_id TIMELINE_ID]
+                     [--use_ssl] [--ca_certificates_file_path PATH]
+                     [--elastic_url_prefix URL_PREFIX] [--server HOSTNAME]
+                     [--port PORT]
+
+Test argument parser.
+
+optional arguments:
+  --ca_certificates_file_path PATH, --ca-certificates-file-path PATH
+                        Path to a file containing a list of root certificates
+                        to trust.
+  --elastic_mappings PATH, --elastic-mappings PATH
+                        Username to use for Elasticsearch authentication.
+  --elastic_password PASSWORD, --elastic-password PASSWORD
+                        Password to use for Elasticsearch authentication.
+                        WARNING: use with caution since this can expose the
+                        password to other users on the system. The password
+                        can also be set with the environment variable
+                        PLASO_ELASTIC_PASSWORD.
+  --elastic_url_prefix URL_PREFIX, --elastic-url-prefix URL_PREFIX
+                        URL prefix for elastic search.
+  --elastic_user USERNAME, --elastic-user USERNAME
+                        Username to use for Elasticsearch authentication.
+  --flush_interval INTERVAL, --flush-interval INTERVAL
+                        Events to queue up before bulk insert to
+                        ElasticSearch.
+  --index_name NAME, --index-name NAME
+                        Name of the index in ElasticSearch.
+  --port PORT           The port number of the server.
+  --server HOSTNAME     The hostname or server IP address of the server.
+  --timeline_id TIMELINE_ID, --timeline-id TIMELINE_ID
+                        The ID of the Timesketch Timeline object this data is
+                        tied to
+  --use_ssl, --use-ssl  Enforces use of SSL/TLS.
+"""
+
+  def testAddArguments(self):
+    """Tests the AddArguments function."""
+    argument_parser = argparse.ArgumentParser(
+        prog='cli_helper.py',
+        description='Test argument parser.', add_help=False,
+        formatter_class=cli_test_lib.SortedArgumentsHelpFormatter)
+
+    elastic_ts_output.ElasticTimesketchOutputArgumentsHelper.AddArguments(
+        argument_parser)
+
+    output = self._RunArgparseFormatHelp(argument_parser)
+    self.assertEqual(output, self._EXPECTED_OUTPUT)
+
+  def testParseOptions(self):
+    """Tests the ParseOptions function."""
+    options = cli_test_lib.TestOptions()
+    options._data_location = 'data'
+
+    output_mediator = self._CreateOutputMediator()
+    output_module = elastic_ts.ElasticTimesketchOutputModule(output_mediator)
+    elastic_ts_output.ElasticTimesketchOutputArgumentsHelper.ParseOptions(
+        options, output_module)
+
+    with self.assertRaises(errors.BadConfigObject):
+      elastic_ts_output.ElasticTimesketchOutputArgumentsHelper.ParseOptions(
+          options, None)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/cli/helpers/elastic_ts_output.py
+++ b/tests/cli/helpers/elastic_ts_output.py
@@ -20,42 +20,17 @@ class ElasticTimesketchOutputArgumentsHelperTest(
   # pylint: disable=no-member,protected-access
 
   _EXPECTED_OUTPUT = """\
-usage: cli_helper.py [--index_name NAME] [--flush_interval INTERVAL]
-                     [--elastic_mappings PATH] [--elastic_user USERNAME]
-                     [--elastic_password PASSWORD] [--timeline_id TIMELINE_ID]
-                     [--use_ssl] [--ca_certificates_file_path PATH]
-                     [--elastic_url_prefix URL_PREFIX] [--server HOSTNAME]
+usage: cli_helper.py [--timeline_id TIMELINE_ID] [--server HOSTNAME]
                      [--port PORT]
 
 Test argument parser.
 
 optional arguments:
-  --ca_certificates_file_path PATH, --ca-certificates-file-path PATH
-                        Path to a file containing a list of root certificates
-                        to trust.
-  --elastic_mappings PATH, --elastic-mappings PATH
-                        Username to use for Elasticsearch authentication.
-  --elastic_password PASSWORD, --elastic-password PASSWORD
-                        Password to use for Elasticsearch authentication.
-                        WARNING: use with caution since this can expose the
-                        password to other users on the system. The password
-                        can also be set with the environment variable
-                        PLASO_ELASTIC_PASSWORD.
-  --elastic_url_prefix URL_PREFIX, --elastic-url-prefix URL_PREFIX
-                        URL prefix for elastic search.
-  --elastic_user USERNAME, --elastic-user USERNAME
-                        Username to use for Elasticsearch authentication.
-  --flush_interval INTERVAL, --flush-interval INTERVAL
-                        Events to queue up before bulk insert to
-                        ElasticSearch.
-  --index_name NAME, --index-name NAME
-                        Name of the index in ElasticSearch.
   --port PORT           The port number of the server.
   --server HOSTNAME     The hostname or server IP address of the server.
   --timeline_id TIMELINE_ID, --timeline-id TIMELINE_ID
                         The ID of the Timesketch Timeline object this data is
                         tied to
-  --use_ssl, --use-ssl  Enforces use of SSL/TLS.
 """
 
   def testAddArguments(self):

--- a/tests/cli/helpers/elastic_ts_output.py
+++ b/tests/cli/helpers/elastic_ts_output.py
@@ -26,7 +26,7 @@ usage: cli_helper.py [--index_name NAME] [--flush_interval INTERVAL]
                      [--elastic_password PASSWORD] [--use_ssl]
                      [--ca_certificates_file_path PATH]
                      [--elastic_url_prefix URL_PREFIX] [--server HOSTNAME]
-                     [--port PORT] [--timeline_id TIMELINE_ID]
+                     [--port PORT] [--timeline_identifier IDENTIFIER]
 
 Test argument parser.
 
@@ -61,9 +61,8 @@ optional arguments:
                         Export string fields that will not be analyzed by
                         Lucene.
   --server HOSTNAME     The hostname or server IP address of the server.
-  --timeline_id TIMELINE_ID, --timeline-id TIMELINE_ID
-                        The ID of the Timesketch Timeline object this data is
-                        tied to
+  --timeline_identifier IDENTIFIER, --timeline-identifier IDENTIFIER
+                        The identifier of the timeline in Timesketch.
   --use_ssl, --use-ssl  Enforces use of SSL/TLS.
 """
 

--- a/tests/output/elastic_ts.py
+++ b/tests/output/elastic_ts.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the ElasticTimesketch output module."""
+
+import unittest
+
+try:
+  from mock import MagicMock
+except ImportError:
+  from unittest.mock import MagicMock
+
+from plaso.output import elastic_ts
+from plaso.output import shared_elastic
+
+from tests.output import test_lib
+
+
+class TestElasticTimesketchOutputModule(
+    elastic_ts.ElasticTimesketchOutputModule):
+  """Elasticsearch output module for testing."""
+
+  def _Connect(self):
+    """Connects to an Elastic server."""
+    self._client = MagicMock()
+
+
+@unittest.skipIf(shared_elastic.elasticsearch is None, 'missing elasticsearch')
+class ElasticTimesketchOutputModuleTest(test_lib.OutputModuleTestCase):
+  """Tests for the ElasticTimesketch output module."""
+
+  # pylint: disable=protected-access
+
+  def testWriteHeader(self):
+    """Tests the WriteHeader function."""
+    output_mediator = self._CreateOutputMediator()
+    output_module = TestElasticTimesketchOutputModule(output_mediator)
+
+    self.assertIsNone(output_module._client)
+
+    output_module.WriteHeader()
+
+    self.assertIsNotNone(output_module._client)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
## One line description of pull request

This PR adds a new output module, based on the shared Elastic one, but that works with Timesketch.

## Description:

The purpose of this module is to replace the `timesketch_out` module. It is based on the `shared_elastic` and only really adds a single parameter to read in the timeline ID that the uploaded data belongs to. That is then added to each indexed document to make Timesketch work.

**Related issue (if applicable):** https://github.com/google/timesketch/issues/1567

## Checklist:
  - [x] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [x] Reviewer assigned
