### PR TITLE
Changed the elastic output helper text for elastic mappings.

### DIFF
--- a/plaso/cli/helpers/elastic_output.py
+++ b/plaso/cli/helpers/elastic_output.py
@@ -74,7 +74,7 @@ class ElasticSearchOutputArgumentsHelper(interface.ArgumentsHelper):
     argument_group.add_argument(
         '--elastic_mappings', '--elastic-mappings', dest='elastic_mappings',
         action='store', default=None, metavar='PATH', help=(
-            'Username to use for Elasticsearch authentication.'))
+            'Path to a file containing mappings for Elasticsearch indexing.'))
 
     argument_group.add_argument(
         '--elastic_user', '--elastic-user', dest='elastic_user', action='store',

--- a/tests/cli/helpers/elastic_output.py
+++ b/tests/cli/helpers/elastic_output.py
@@ -40,7 +40,8 @@ optional arguments:
                         Path to a file containing a list of root certificates
                         to trust.
   --elastic_mappings PATH, --elastic-mappings PATH
-                        Username to use for Elasticsearch authentication.
+                        Path to a file containing mappings for Elasticsearch
+                        indexing.
   --elastic_password PASSWORD, --elastic-password PASSWORD
                         Password to use for Elasticsearch authentication.
                         WARNING: use with caution since this can expose the

--- a/tests/cli/helpers/elastic_ts_output.py
+++ b/tests/cli/helpers/elastic_ts_output.py
@@ -40,7 +40,8 @@ optional arguments:
                         Path to a file containing a list of root certificates
                         to trust.
   --elastic_mappings PATH, --elastic-mappings PATH
-                        Username to use for Elasticsearch authentication.
+                        Path to a file containing mappings for Elasticsearch
+                        indexing.
   --elastic_password PASSWORD, --elastic-password PASSWORD
                         Password to use for Elasticsearch authentication.
                         WARNING: use with caution since this can expose the


### PR DESCRIPTION
## One line description of pull request

The CLI helper for elastic output contained a wrong helper text for the `elastic_mapping`

## Checklist:
  - [x] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [x] Reviewer assigned
