### PR TITLE
Lowered psort event heap limit

### DIFF
--- a/plaso/multi_processing/psort.py
+++ b/plaso/multi_processing/psort.py
@@ -206,7 +206,7 @@ class PsortMultiProcessEngine(multi_process_engine.MultiProcessEngine):
 
   _QUEUE_TIMEOUT = 10 * 60
 
-  _HEAP_MAXIMUM_EVENTS = 500000
+  _HEAP_MAXIMUM_EVENTS = 100000
 
   def __init__(self, worker_memory_limit=None, worker_timeout=None):
     """Initializes a psort multi-processing engine.


### PR DESCRIPTION
## One line description of pull request

Reduced the heap size in psort to 100k, as an opposed to 500k as it was prior.

## Description:

Psort hit some memory issues under certain conditions (running on docker containers ingesting data from Timesketch), reducing the heap size to 100k reduced the overall memory footprint of the tool, reducing the risk of memory errors.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [x] Reviewer assigned
