### PR TITLE
Changes to Apache access parser to handle badly formed requests

### DIFF
--- a/plaso/parsers/apache_access.py
+++ b/plaso/parsers/apache_access.py
@@ -79,7 +79,7 @@ class ApacheAccessParser(text_parser.PyparsingSingleLineTextParser):
 
   _HTTP_REQUEST = (
       pyparsing.Suppress('"') +
-      pyparsing.SkipTo('"').setResultsName('http_request') +
+      pyparsing.SkipTo('" ').setResultsName('http_request') +
       pyparsing.Suppress('"'))
 
   _PORT_NUMBER = text_parser.PyparsingConstants.INTEGER.setResultsName(
@@ -95,7 +95,7 @@ class ApacheAccessParser(text_parser.PyparsingSingleLineTextParser):
 
   _REFERER = (
       pyparsing.Suppress('"') +
-      pyparsing.SkipTo('"').setResultsName('referer') +
+      pyparsing.SkipTo('" ').setResultsName('referer') +
       pyparsing.Suppress('"'))
 
   _SERVER_NAME = (

--- a/plaso/parsers/apache_access.py
+++ b/plaso/parsers/apache_access.py
@@ -108,7 +108,7 @@ class ApacheAccessParser(text_parser.PyparsingSingleLineTextParser):
       pyparsing.Suppress('"'))
 
   _USER_NAME = (
-      pyparsing.Word(pyparsing.alphanums + '.') |
+      pyparsing.Word(pyparsing.alphanums) |
       pyparsing.Literal('-')).setResultsName('user_name')
 
   # Defined in https://httpd.apache.org/docs/2.4/logs.html

--- a/plaso/parsers/apache_access.py
+++ b/plaso/parsers/apache_access.py
@@ -108,7 +108,7 @@ class ApacheAccessParser(text_parser.PyparsingSingleLineTextParser):
       pyparsing.Suppress('"'))
 
   _USER_NAME = (
-      pyparsing.Word(pyparsing.alphanums) |
+      pyparsing.Word(pyparsing.alphanums + '.') |
       pyparsing.Literal('-')).setResultsName('user_name')
 
   # Defined in https://httpd.apache.org/docs/2.4/logs.html

--- a/test_data/access.log
+++ b/test_data/access.log
@@ -10,3 +10,5 @@ plaso.log2timeline.net:443 10.1.1.2 - - [13/Jan/2018:19:31:17 +0000] "GET /wp-co
 plaso.log2timeline.net:443 192.168.0.2 - - [13/Jan/2018:19:31:17 +0000] "GET /wp-content/themes/darkmode/evil.php HTTP/1.1" 200 1063 "-" "Mozilla/5.0 (Windows NT 7.1) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.112 Safari/534.30"
 plaso-2.log2timeline.net:443 192.168.0.2 - - [13/Jan/2018:19:31:19 +0000] "GET /wp-content/themes/darkmode/evil.php?cmd=ver%3B+uname+-a HTTP/1.1" 200 694 "-" "Mozilla/5.0 (Windows  U  Windows NT 5.1  en-US) AppleWebKit/534.12 (KHTML, like Gecko) Chrome/9.0.583.0 Safari/534.12"
 plaso-2.log2timeline.net:443 192.168.0.2 - - [13/Jan/2018:19:31:20 +0200] "GET /wp-content/themes/darkmode/evil.php?cmd=uname+-a HTTP/1.1" 200 694 "http://localhost/" "Mozilla/5.0 (X11; Linux i686; rv:2.0b12pre) Gecko/20100101 Firefox/4"
+1.2.3.4 - - [25/Apr/2021:06:15:33 +0000] "GET /aaaa.xxxx/SomeText?action=edit&template=<script>alert("text")</script> HTTP/1.0" 404 1164
+1.2.3.4 - - [25/Apr/2021:06:15:33 +0000] "GET /$%7B("TextString"+"123456")%7D/actionChain1.action HTTP/1.0" 404 1164

--- a/tests/parsers/apache_access.py
+++ b/tests/parsers/apache_access.py
@@ -18,7 +18,7 @@ class ApacheAccessUnitTest(test_lib.ParserTestCase):
     storage_writer = self._ParseFile(['access.log'], parser)
 
     self.assertEqual(storage_writer.number_of_warnings, 1)
-    self.assertEqual(storage_writer.number_of_events, 11)
+    self.assertEqual(storage_writer.number_of_events, 13)
 
     # The order in which parser generates events is nondeterministic hence
     # we sort the events.


### PR DESCRIPTION


## One line description of pull request
Fixes the error of log2timline not correctly parsing apache access logs when the username has a dot, like first.last. 



## Description:
Fixes the error of log2timline not correctly parsing apache access logs when the username has a dot, like first.last. 


**Related issue (if applicable):** fixes #<plaso issue number here>
https://github.com/log2timeline/plaso/issues/3557#issuecomment-820527270

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
