### PR TITLE
Changes for chardet and incompatible sphinx 4.1.0 or newer #3800

### DIFF
--- a/dependencies.ini
+++ b/dependencies.ini
@@ -24,6 +24,7 @@ rpm_name: python3-cffi
 version_property: __version__
 
 [chardet]
+skip_check: true
 skip_requires: true
 dpkg_name: python3-chardet
 minimum_version: 2.0.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 docutils
 pyparsing
 recommonmark
-sphinx >= 2.0.1
+sphinx < 4.1.0
 sphinx-markdown-tables
 sphinx-rtd-theme >= 0.5.1

--- a/plaso/dependencies.py
+++ b/plaso/dependencies.py
@@ -19,7 +19,6 @@ PYTHON_DEPENDENCIES = {
     'artifacts': ('__version__', '20210620', None, True),
     'bencode': ('', '', None, True),
     'certifi': ('__version__', '2016.9.26', None, True),
-    'chardet': ('__version__', '2.0.1', None, True),
     'cryptography': ('__version__', '2.0.2', None, True),
     'dateutil': ('__version__', '1.5', None, True),
     'defusedxml': ('__version__', '0.5.0', None, True),

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ artifacts >= 20210620
 bencode.py
 certifi >= 2016.9.26
 cffi >= 1.9.1
+chardet >= 4.0.0
 cryptography >= 2.0.2
 defusedxml >= 0.5.0
 dfdatetime >= 20210509

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ artifacts >= 20210620
 bencode.py
 certifi >= 2016.9.26
 cffi >= 1.9.1
-chardet >= 4.0.0
 cryptography >= 2.0.2
 defusedxml >= 0.5.0
 dfdatetime >= 20210509


### PR DESCRIPTION
## One line description of pull request

Update version specifier for sphinx to ignore versions >= 4.1.0

## Description:

This is a fix to allow tox docs to successfully complete.

**Related issue (if applicable):** fixes #3800

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
