### PR TITLE
Changed Apache access parser to support username with Kerberos principal #3831

### DIFF
--- a/plaso/parsers/apache_access.py
+++ b/plaso/parsers/apache_access.py
@@ -6,7 +6,6 @@ defined in https://httpd.apache.org/docs/2.4/logs.html
 """
 
 import pyparsing
-
 from dfdatetime import time_elements as dfdatetime_time_elements
 
 from plaso.containers import events
@@ -109,11 +108,12 @@ class ApacheAccessParser(text_parser.PyparsingSingleLineTextParser):
       pyparsing.Suppress('"'))
 
   _USER_NAME = (
+      pyparsing.Word(pyparsing.alphanums + '@' + pyparsing.alphanums + '.') |
       pyparsing.Word(pyparsing.alphanums) |
       pyparsing.Literal('-')).setResultsName('user_name')
 
-  # Defined in https://httpd.apache.org/docs/2.4/logs.html
-  # format: "%h %l %u %t \"%r\" %>s %b"
+    # Defined in https://httpd.apache.org/docs/2.4/logs.html
+    # format: "%h %l %u %t \"%r\" %>s %b"
   _COMMON_LOG_FORMAT_LINE = (
       text_parser.PyparsingConstants.IP_ADDRESS.setResultsName('ip_address') +
       _REMOTE_NAME +
@@ -124,8 +124,8 @@ class ApacheAccessParser(text_parser.PyparsingSingleLineTextParser):
       _RESPONSE_BYTES +
       pyparsing.lineEnd())
 
-  # Defined in https://httpd.apache.org/docs/2.4/logs.html
-  # format: "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\""
+    # Defined in https://httpd.apache.org/docs/2.4/logs.html
+    # format: "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\""
   _COMBINED_LOG_FORMAT_LINE = (
       text_parser.PyparsingConstants.IP_ADDRESS.setResultsName('ip_address') +
       _REMOTE_NAME +

--- a/plaso/parsers/apache_access.py
+++ b/plaso/parsers/apache_access.py
@@ -6,6 +6,7 @@ defined in https://httpd.apache.org/docs/2.4/logs.html
 """
 
 import pyparsing
+
 from dfdatetime import time_elements as dfdatetime_time_elements
 
 from plaso.containers import events

--- a/plaso/parsers/apache_access.py
+++ b/plaso/parsers/apache_access.py
@@ -112,8 +112,8 @@ class ApacheAccessParser(text_parser.PyparsingSingleLineTextParser):
       pyparsing.Word(pyparsing.alphanums) |
       pyparsing.Literal('-')).setResultsName('user_name')
 
-    # Defined in https://httpd.apache.org/docs/2.4/logs.html
-    # format: "%h %l %u %t \"%r\" %>s %b"
+  # Defined in https://httpd.apache.org/docs/2.4/logs.html
+  # format: "%h %l %u %t \"%r\" %>s %b"
   _COMMON_LOG_FORMAT_LINE = (
       text_parser.PyparsingConstants.IP_ADDRESS.setResultsName('ip_address') +
       _REMOTE_NAME +
@@ -124,8 +124,8 @@ class ApacheAccessParser(text_parser.PyparsingSingleLineTextParser):
       _RESPONSE_BYTES +
       pyparsing.lineEnd())
 
-    # Defined in https://httpd.apache.org/docs/2.4/logs.html
-    # format: "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\""
+  # Defined in https://httpd.apache.org/docs/2.4/logs.html
+  # format: "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\""
   _COMBINED_LOG_FORMAT_LINE = (
       text_parser.PyparsingConstants.IP_ADDRESS.setResultsName('ip_address') +
       _REMOTE_NAME +

--- a/test_data/access.log
+++ b/test_data/access.log
@@ -12,3 +12,4 @@ plaso-2.log2timeline.net:443 192.168.0.2 - - [13/Jan/2018:19:31:19 +0000] "GET /
 plaso-2.log2timeline.net:443 192.168.0.2 - - [13/Jan/2018:19:31:20 +0200] "GET /wp-content/themes/darkmode/evil.php?cmd=uname+-a HTTP/1.1" 200 694 "http://localhost/" "Mozilla/5.0 (X11; Linux i686; rv:2.0b12pre) Gecko/20100101 Firefox/4"
 1.2.3.4 - - [25/Apr/2021:06:15:33 +0000] "GET /aaaa.xxxx/SomeText?action=edit&template=<script>alert("text")</script> HTTP/1.0" 404 1164
 1.2.3.4 - - [25/Apr/2021:06:15:33 +0000] "GET /$%7B("TextString"+"123456")%7D/actionChain1.action HTTP/1.0" 404 1164
+192.168.0.64 - pyllyukko@EXAMPLE.COM [16/Nov/2019:09:46:42 +0200] "GET / HTTP/1.1" 200 8264

--- a/tests/parsers/apache_access.py
+++ b/tests/parsers/apache_access.py
@@ -3,7 +3,6 @@
 """Tests for Apache access log parser."""
 
 import unittest
-
 from plaso.containers import warnings
 from plaso.parsers import apache_access
 
@@ -19,8 +18,7 @@ class ApacheAccessUnitTest(test_lib.ParserTestCase):
     storage_writer = self._ParseFile(['access.log'], parser)
 
     number_of_events = storage_writer.GetNumberOfAttributeContainers('event')
-    self.assertEqual(number_of_events, 13)
-
+    self.assertEqual(number_of_events, 14)
     number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
         'extraction_warning')
     self.assertEqual(number_of_warnings, 1)
@@ -97,7 +95,21 @@ class ApacheAccessUnitTest(test_lib.ParserTestCase):
         'server_name': 'plaso.log2timeline.net',
         'user_name': '-'}
 
+
     self.CheckEventValues(storage_writer, events[9], expected_event_values)
+
+    # Test common log format parser event with Kerberos user name
+    expected_event_values = {
+        'data_type': 'apache:access',
+        'date_time': '2019-11-16 09:46:42',
+        'http_request': ('GET / HTTP/1.1'),
+        'http_response_code': 200,
+        'http_response_bytes': 8264,
+        'ip_address': '192.168.0.64',
+        'remote_name': '-',
+        'user_name': 'pyllyukko@EXAMPLE.COM'}
+
+    self.CheckEventValues(storage_writer, events[11], expected_event_values)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/apache_access.py
+++ b/tests/parsers/apache_access.py
@@ -97,7 +97,6 @@ class ApacheAccessUnitTest(test_lib.ParserTestCase):
         'server_name': 'plaso.log2timeline.net',
         'user_name': '-'}
 
-
     self.CheckEventValues(storage_writer, events[9], expected_event_values)
 
     # Test common log format parser event with Kerberos user name

--- a/tests/parsers/apache_access.py
+++ b/tests/parsers/apache_access.py
@@ -3,6 +3,7 @@
 """Tests for Apache access log parser."""
 
 import unittest
+
 from plaso.containers import warnings
 from plaso.parsers import apache_access
 
@@ -19,6 +20,7 @@ class ApacheAccessUnitTest(test_lib.ParserTestCase):
 
     number_of_events = storage_writer.GetNumberOfAttributeContainers('event')
     self.assertEqual(number_of_events, 14)
+
     number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
         'extraction_warning')
     self.assertEqual(number_of_warnings, 1)


### PR DESCRIPTION
## One line description of pull request
Current parser grammar does not support Kerberos principal names in the user name field.

## Description:
This pull request adds support for Kerberos principal names in the apache access log user name field.

**Related issue (if applicable):** fixes #3831 

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
