### PR TITLE
Renamed UnableToParseFile exception to WrongParser, removed WrongBencodePlugin exception

### DIFF
--- a/plaso/engine/extractors.py
+++ b/plaso/engine/extractors.py
@@ -173,7 +173,7 @@ class EventExtractor(object):
       int: parse result which is _PARSE_RESULT_FAILURE if the file entry
           could not be parsed, _PARSE_RESULT_SUCCESS if the file entry
           successfully was parsed or _PARSE_RESULT_UNSUPPORTED when
-          UnableToParseFile was raised.
+          WrongParser was raised.
 
     Raises:
       TypeError: if parser object is not a supported parser type.
@@ -201,7 +201,7 @@ class EventExtractor(object):
               parser.NAME, display_name, exception))
       result = self._PARSE_RESULT_FAILURE
 
-    except errors.UnableToParseFile as exception:
+    except errors.WrongParser as exception:
       display_name = parser_mediator.GetDisplayName(file_entry)
       logger.debug(
           '{0:s} unable to parse file: {1:s} with error: {2!s}'.format(
@@ -230,7 +230,7 @@ class EventExtractor(object):
       int: parse result which is _PARSE_RESULT_FAILURE if the file entry
           could not be parsed, _PARSE_RESULT_SUCCESS if the file entry
           successfully was parsed or _PARSE_RESULT_UNSUPPORTED when
-          UnableToParseFile was raised or no names of parser were provided.
+          WrongParser was raised or no names of parser were provided.
 
     Raises:
       RuntimeError: if the parser object is missing.

--- a/plaso/lib/errors.py
+++ b/plaso/lib/errors.py
@@ -86,16 +86,8 @@ class UnableToLoadRegistryHelper(Error):
   """Raised when unable to load a Registry helper object."""
 
 
-class UnableToParseFile(Error):
-  """Raised when a parser is not designed to parse a file."""
-
-
 class UserAbort(Error):
   """Class that defines an user initiated abort exception."""
-
-
-class WrongBencodePlugin(Error):
-  """Error reporting wrong bencode plugin used."""
 
 
 class WrongFormatter(Error):
@@ -104,6 +96,10 @@ class WrongFormatter(Error):
 
 class WrongPlugin(Error):
   """Raised when the plugin is of the wrong type."""
+
+
+class WrongParser(Error):
+  """Raised when a parser is not designed to parse a file."""
 
 
 class WrongQueueType(Error):

--- a/plaso/parsers/android_app_usage.py
+++ b/plaso/parsers/android_app_usage.py
@@ -48,16 +48,16 @@ class AndroidAppUsageParser(interface.FileObjectParser):
       file_object (dfvfs.FileIO): file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     data = file_object.read(self._HEADER_READ_SIZE)
     if not data.startswith(b'<?xml'):
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Not an Android usage history file [not XML]')
 
     _, _, data = data.partition(b'\n')
     if not data.startswith(b'<usage-history'):
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Not an Android usage history file [wrong XML root key]')
 
     # The current offset of the file-like object needs to point at

--- a/plaso/parsers/asl.py
+++ b/plaso/parsers/asl.py
@@ -278,7 +278,7 @@ class ASLParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       file_object (dfvfs.FileIO): file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     file_header_map = self._GetDataTypeMap('asl_file_header')
 
@@ -286,7 +286,7 @@ class ASLParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       file_header, _ = self._ReadStructureFromFileObject(
           file_object, 0, file_header_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse file header with error: {0!s}'.format(
               exception))
 

--- a/plaso/parsers/bencode_parser.py
+++ b/plaso/parsers/bencode_parser.py
@@ -145,11 +145,11 @@ class BencodeParser(interface.FileObjectParser):
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     header_data = file_object.read(2)
     if not self._BENCODE_RE.match(header_data):
-      raise errors.UnableToParseFile('Not a valid Bencoded file.')
+      raise errors.WrongParser('Not a valid Bencoded file.')
 
     bencode_file = BencodeFile()
 
@@ -157,7 +157,7 @@ class BencodeParser(interface.FileObjectParser):
       bencode_file.Open(file_object)
     except IOError as exception:
       display_name = parser_mediator.GetDisplayName()
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           '[{0:s}] unable to parse file: {1:s} with error: {2!s}'.format(
               self.NAME, display_name, exception))
 

--- a/plaso/parsers/bsm.py
+++ b/plaso/parsers/bsm.py
@@ -912,7 +912,7 @@ class BSMParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     file_offset = file_object.get_offset()
     file_size = file_object.get_size()
@@ -921,7 +921,7 @@ class BSMParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
         self._ParseRecord(parser_mediator, file_object)
       except errors.ParseError as exception:
         if file_offset == 0:
-          raise errors.UnableToParseFile(
+          raise errors.WrongParser(
               'Unable to parse first event record with error: {0!s}'.format(
                   exception))
 

--- a/plaso/parsers/chrome_cache.py
+++ b/plaso/parsers/chrome_cache.py
@@ -445,14 +445,14 @@ class ChromeCacheParser(interface.FileEntryParser):
       file_entry (dfvfs.FileEntry): file entry.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     index_file_parser = ChromeCacheIndexFileParser()
 
     file_object = file_entry.GetFileObject()
     if not file_object:
       display_name = parser_mediator.GetDisplayName()
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           '[{0:s}] unable to parse index file {1:s}'.format(
               self.NAME, display_name))
 
@@ -460,7 +460,7 @@ class ChromeCacheParser(interface.FileEntryParser):
       index_file_parser.ParseFileObject(parser_mediator, file_object)
     except (IOError, errors.ParseError) as exception:
       display_name = parser_mediator.GetDisplayName()
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           '[{0:s}] unable to parse index file {1:s} with error: {2!s}'.format(
               self.NAME, display_name, exception))
 

--- a/plaso/parsers/chrome_preferences.py
+++ b/plaso/parsers/chrome_preferences.py
@@ -195,11 +195,11 @@ class ChromePreferencesParser(interface.FileObjectParser):
       file_object (dfvfs.FileIO): file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     # First pass check for initial character being open brace.
     if file_object.read(1) != b'{':
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           '[{0:s}] {1:s} is not a valid Preference file, '
           'missing opening brace.').format(
               self.NAME, parser_mediator.GetDisplayName()))
@@ -210,7 +210,7 @@ class ChromePreferencesParser(interface.FileObjectParser):
     try:
       file_content = codecs.decode(file_content, self._ENCODING)
     except UnicodeDecodeError:
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           '[{0:s}] {1:s} is not a valid Preference file, '
           'unable to decode UTF-8.').format(
               self.NAME, parser_mediator.GetDisplayName()))
@@ -219,29 +219,29 @@ class ChromePreferencesParser(interface.FileObjectParser):
     try:
       json_dict = json.loads(file_content)
     except ValueError as exception:
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           '[{0:s}] Unable to parse file {1:s} as JSON: {2!s}').format(
               self.NAME, parser_mediator.GetDisplayName(), exception))
     except IOError as exception:
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           '[{0:s}] Unable to open file {1:s} for parsing as'
           'JSON: {2!s}').format(
               self.NAME, parser_mediator.GetDisplayName(), exception))
 
     # Third pass to verify the file has the correct keys in it for Preferences
     if not set(self.REQUIRED_KEYS).issubset(set(json_dict.keys())):
-      raise errors.UnableToParseFile('File does not contain Preference data.')
+      raise errors.WrongParser('File does not contain Preference data.')
 
     extensions_setting_dict = json_dict.get('extensions')
     if not extensions_setting_dict:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           '[{0:s}] {1:s} is not a valid Preference file, '
           'does not contain extensions value.'.format(
               self.NAME, parser_mediator.GetDisplayName()))
 
     extensions_dict = extensions_setting_dict.get('settings')
     if not extensions_dict:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           '[{0:s}] {1:s} is not a valid Preference file, '
           'does not contain extensions settings value.'.format(
               self.NAME, parser_mediator.GetDisplayName()))

--- a/plaso/parsers/cups_ipp.py
+++ b/plaso/parsers/cups_ipp.py
@@ -341,21 +341,21 @@ class CupsIppParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       file_object (dfvfs.FileIO): file-like object.
 
     Raises:
-      UnableToParseFile: when the header cannot be parsed.
+      WrongParser: when the header cannot be parsed.
     """
     header_map = self._GetDataTypeMap('cups_ipp_header')
 
     try:
       header, _ = self._ReadStructureFromFileObject(file_object, 0, header_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           '[{0:s}] Unable to parse header with error: {1!s}'.format(
               self.NAME, exception))
 
     format_version = '{0:d}.{1:d}'.format(
         header.major_version, header.minor_version)
     if format_version not in self._SUPPORTED_FORMAT_VERSIONS:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           '[{0:s}] Unsupported format version {1:s}.'.format(
               self.NAME, format_version))
 
@@ -376,7 +376,7 @@ class CupsIppParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       file_object (dfvfs.FileIO): file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     self._last_charset_attribute = 'ascii'
 
@@ -401,7 +401,7 @@ class CupsIppParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       error_message = (
           'unable to parse attribute group with error: {0!s}').format(exception)
       if is_first_attribute_group:
-        raise errors.UnableToParseFile(error_message)
+        raise errors.WrongParser(error_message)
 
       parser_mediator.ProduceExtractionWarning(error_message)
       return

--- a/plaso/parsers/custom_destinations.py
+++ b/plaso/parsers/custom_destinations.py
@@ -99,7 +99,7 @@ class CustomDestinationsParser(
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     file_entry = parser_mediator.GetFileEntry()
     display_name = parser_mediator.GetDisplayName()
@@ -110,17 +110,17 @@ class CustomDestinationsParser(
       file_header, file_offset = self._ReadStructureFromFileObject(
           file_object, 0, file_header_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           'Invalid Custom Destination: {0:s} - unable to parse file header '
           'with error: {1!s}').format(display_name, exception))
 
     if file_header.unknown1 != 2:
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           'Unsupported Custom Destination file: {0:s} - invalid unknown1: '
           '{1:d}.').format(display_name, file_header.unknown1))
 
     if file_header.header_values_type > 2:
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           'Unsupported Custom Destination file: {0:s} - invalid header value '
           'type: {1:d}.').format(display_name, file_header.header_values_type))
 
@@ -135,7 +135,7 @@ class CustomDestinationsParser(
       _, value_data_size = self._ReadStructureFromFileObject(
           file_object, file_offset, file_header_value_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           'Invalid Custom Destination: {0:s} - unable to parse file header '
           'value with error: {1!s}').format(display_name, exception))
 
@@ -157,7 +157,7 @@ class CustomDestinationsParser(
 
       except (ValueError, errors.ParseError) as exception:
         if not first_guid_checked:
-          raise errors.UnableToParseFile((
+          raise errors.WrongParser((
               'Invalid Custom Destination file: {0:s} - unable to parse '
               'entry header with error: {1!s}').format(
                   display_name, exception))
@@ -169,7 +169,7 @@ class CustomDestinationsParser(
 
       if entry_header.guid != self._LNK_GUID:
         if not first_guid_checked:
-          raise errors.UnableToParseFile((
+          raise errors.WrongParser((
               'Unsupported Custom Destination file: {0:s} - invalid entry '
               'header signature offset: 0x{1:08x}.').format(
                   display_name, file_offset))

--- a/plaso/parsers/czip.py
+++ b/plaso/parsers/czip.py
@@ -30,12 +30,12 @@ class CompoundZIPParser(interface.FileObjectParser):
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     display_name = parser_mediator.GetDisplayName()
 
     if not zipfile.is_zipfile(file_object):
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           '[{0:s}] unable to parse file: {1:s} with error: {2:s}'.format(
               self.NAME, display_name, 'Not a Zip file.'))
 
@@ -46,7 +46,7 @@ class CompoundZIPParser(interface.FileObjectParser):
     # error like a negative seek (IOError). Note that this function can raise
     # many different exceptions.
     except Exception as exception:  # pylint: disable=broad-except
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           '[{0:s}] unable to parse file: {1:s} with error: {2!s}'.format(
               self.NAME, display_name, exception))
 

--- a/plaso/parsers/czip_plugins/oxml.py
+++ b/plaso/parsers/czip_plugins/oxml.py
@@ -196,9 +196,6 @@ class OpenXMLPlugin(interface.CompoundZIPPlugin):
       zip_file (zipfile.ZipFile): the zip file containing OXML content. It is
           not be closed in this method, but will be closed by the parser logic
            in czip.py.
-
-    Raises:
-      WrongParser: when the file cannot be parsed.
     """
     try:
       xml_data = zip_file.read('_rels/.rels')

--- a/plaso/parsers/czip_plugins/oxml.py
+++ b/plaso/parsers/czip_plugins/oxml.py
@@ -198,7 +198,7 @@ class OpenXMLPlugin(interface.CompoundZIPPlugin):
            in czip.py.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     try:
       xml_data = zip_file.read('_rels/.rels')

--- a/plaso/parsers/docker.py
+++ b/plaso/parsers/docker.py
@@ -118,7 +118,7 @@ class DockerJSONParser(interface.FileObjectParser):
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file is not a valid layer config file.
+      WrongParser: when the file is not a valid layer config file.
     """
     file_content = file_object.read()
     file_content = codecs.decode(file_content, self._ENCODING)
@@ -126,7 +126,7 @@ class DockerJSONParser(interface.FileObjectParser):
     json_dict = json.loads(file_content)
 
     if 'docker_version' not in json_dict:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'not a valid Docker layer configuration file, missing '
           '\'docker_version\' key.')
 
@@ -166,7 +166,7 @@ class DockerJSONParser(interface.FileObjectParser):
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file is not a valid container config file.
+      WrongParser: when the file is not a valid container config file.
     """
     file_content = file_object.read()
     file_content = codecs.decode(file_content, self._ENCODING)
@@ -174,20 +174,20 @@ class DockerJSONParser(interface.FileObjectParser):
     json_dict = json.loads(file_content)
 
     if 'Driver' not in json_dict:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'not a valid Docker container configuration file, ' 'missing '
           '\'Driver\' key.')
 
     container_id_from_path = self._GetIdentifierFromPath(parser_mediator)
     container_id_from_json = json_dict.get('ID', None)
     if not container_id_from_json:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'not a valid Docker layer configuration file, the \'ID\' key is '
           'missing from the JSON dict (should be {0:s})'.format(
               container_id_from_path))
 
     if container_id_from_json != container_id_from_path:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'not a valid Docker container configuration file. The \'ID\' key of '
           'the JSON dict ({0:s}) is different from the layer ID taken from the'
           ' path to the file ({1:s}) JSON file.)'.format(
@@ -313,12 +313,12 @@ class DockerJSONParser(interface.FileObjectParser):
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
       ValueError: if the JSON file cannot be decoded.
     """
     # Trivial JSON format check: first character must be an open brace.
     if file_object.read(1) != b'{':
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'is not a valid JSON file, missing opening brace.')
 
     file_object.seek(0, os.SEEK_SET)
@@ -342,7 +342,7 @@ class DockerJSONParser(interface.FileObjectParser):
           self._ParseLayerConfigJSON(parser_mediator, file_object)
     except ValueError as exception:
       if exception == 'No JSON object could be decoded':
-        raise errors.UnableToParseFile(exception)
+        raise errors.WrongParser(exception)
       raise
 
 

--- a/plaso/parsers/dsv_parser.py
+++ b/plaso/parsers/dsv_parser.py
@@ -203,13 +203,13 @@ class DSVParser(interface.FileObjectParser):
       file_object (dfvfs.FileIO): file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     encoding, text_offset = self._CheckForByteOrderMark(file_object)
 
     if encoding and self._encoding and encoding != self._encoding:
       display_name = parser_mediator.GetDisplayName()
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           '[{0:s}] Unable to parse DSV file: {1:s} encoding does not match the '
           'one required by the parser.').format(self._encoding, display_name))
 
@@ -223,13 +223,13 @@ class DSVParser(interface.FileObjectParser):
     try:
       if not self._HasExpectedLineLength(file_object, encoding=encoding):
         display_name = parser_mediator.GetDisplayName()
-        raise errors.UnableToParseFile((
+        raise errors.WrongParser((
             '[{0:s}] Unable to parse DSV file: {1:s} with error: '
             'unexpected line length.').format(self.NAME, display_name))
 
     except UnicodeDecodeError as exception:
       display_name = parser_mediator.GetDisplayName()
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           '[{0:s}] Unable to parse DSV file: {1:s} with error: {2!s}.'.format(
               self.NAME, display_name, exception))
 
@@ -240,7 +240,7 @@ class DSVParser(interface.FileObjectParser):
       row = next(reader)
     except (StopIteration, UnicodeDecodeError, csv.Error) as exception:
       display_name = parser_mediator.GetDisplayName()
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           '[{0:s}] Unable to parse DSV file: {1:s} with error: {2!s}.'.format(
               self.NAME, display_name, exception))
 
@@ -249,7 +249,7 @@ class DSVParser(interface.FileObjectParser):
 
     if number_of_records != number_of_columns:
       display_name = parser_mediator.GetDisplayName()
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           '[{0:s}] Unable to parse DSV file: {1:s}. Wrong number of '
           'records (expected: {2:d}, got: {3:d})').format(
               self.NAME, display_name, number_of_columns,
@@ -258,13 +258,13 @@ class DSVParser(interface.FileObjectParser):
     for key, value in row.items():
       if self._MAGIC_TEST_STRING in (key, value):
         display_name = parser_mediator.GetDisplayName()
-        raise errors.UnableToParseFile((
+        raise errors.WrongParser((
             '[{0:s}] Unable to parse DSV file: {1:s}. Signature '
             'mismatch.').format(self.NAME, display_name))
 
     if not self.VerifyRow(parser_mediator, row):
       display_name = parser_mediator.GetDisplayName()
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           '[{0:s}] Unable to parse DSV file: {1:s}. Verification '
           'failed.').format(self.NAME, display_name))
 

--- a/plaso/parsers/firefox_cache.py
+++ b/plaso/parsers/firefox_cache.py
@@ -165,7 +165,7 @@ class FirefoxCacheParser(
           record offset.
 
     Raises:
-      UnableToParseFile: if no valid cache record could be found.
+      WrongParser: if no valid cache record could be found.
     """
     # There ought to be a valid record within the first 4 MiB. We use this
     # limit to prevent reading large invalid files.
@@ -200,7 +200,7 @@ class FirefoxCacheParser(
         logger.debug('[{0:s}] {1:s}:{2:d}: Invalid record.'.format(
             self.NAME, display_name, offset))
 
-    raise errors.UnableToParseFile(
+    raise errors.WrongParser(
         'Could not find a valid cache record. Not a Firefox cache file.')
 
   def _ParseCacheEntry(
@@ -337,13 +337,13 @@ class FirefoxCacheParser(
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     filename = parser_mediator.GetFilename()
 
     if (not self._CACHE_FILENAME_RE.match(filename) and
         not filename.startswith('_CACHE_00')):
-      raise errors.UnableToParseFile('Not a Firefox cache1 file.')
+      raise errors.WrongParser('Not a Firefox cache1 file.')
 
     display_name = parser_mediator.GetDisplayName()
     firefox_config = self._GetFirefoxConfig(file_object, display_name)
@@ -394,7 +394,7 @@ class FirefoxCache2Parser(
           of the file.
 
     Raises:
-      UnableToParseFile: if the size of the cache file metadata cannot be
+      WrongParser: if the size of the cache file metadata cannot be
           determined.
     """
     file_object.seek(-4, os.SEEK_END)
@@ -406,7 +406,7 @@ class FirefoxCache2Parser(
       metadata_size, _ = self._ReadStructureFromFileObject(
           file_object, file_offset, metadata_size_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse cache file metadata size with error: {0!s}'.format(
               exception))
 
@@ -446,18 +446,18 @@ class FirefoxCache2Parser(
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     filename = parser_mediator.GetFilename()
     if not self._CACHE_FILENAME_RE.match(filename):
-      raise errors.UnableToParseFile('Not a Firefox cache2 file.')
+      raise errors.WrongParser('Not a Firefox cache2 file.')
 
     # The file needs to be at least 36 bytes in size for it to contain
     # a cache2 file metadata header and a 4-byte offset that points to its
     # location in the file.
     file_size = file_object.get_size()
     if file_size < 36:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'File size too small for Firefox cache2 file.')
 
     file_offset = self._GetCacheFileMetadataHeaderOffset(file_object)
@@ -468,12 +468,12 @@ class FirefoxCache2Parser(
       file_metadata_header, _ = self._ReadStructureFromFileObject(
           file_object, file_offset, file_metadata_header_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           'Unable to parse Firefox cache2 file metadata header with error: '
           '{0!s}').format(exception))
 
     if not self._ValidateCacheFileMetadataHeader(file_metadata_header):
-      raise errors.UnableToParseFile('Not a valid Firefox cache2 record.')
+      raise errors.WrongParser('Not a valid Firefox cache2 record.')
 
     if file_metadata_header.format_version >= 2:
       file_object.seek(4, os.SEEK_CUR)

--- a/plaso/parsers/fish_history.py
+++ b/plaso/parsers/fish_history.py
@@ -58,12 +58,12 @@ class FishHistoryParser(interface.FileObjectParser):
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     filename = parser_mediator.GetFilename()
 
     if filename != self._FILENAME:
-      raise errors.UnableToParseFile('Not a Fish history file.')
+      raise errors.WrongParser('Not a Fish history file.')
 
     text_file_object = text_file.TextFile(file_object, encoding='utf-8')
 
@@ -71,7 +71,7 @@ class FishHistoryParser(interface.FileObjectParser):
     header_line_2 = text_file_object.readline()
     if (not self._YAML_FORMAT_RE_1.match(header_line_1) or
         not self._YAML_FORMAT_RE_2.match(header_line_2)):
-      raise errors.UnableToParseFile('Not a valid fish history file.')
+      raise errors.WrongParser('Not a valid fish history file.')
 
     file_size = file_object.get_size()
     if file_size > self._MAXIMUM_FISH_HISTORY_FILE_SIZE:

--- a/plaso/parsers/fseventsd.py
+++ b/plaso/parsers/fseventsd.py
@@ -153,7 +153,7 @@ class FseventsdParser(
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the header cannot be parsed.
+      WrongParser: when the header cannot be parsed.
     """
     page_header_map = self._GetDataTypeMap('dls_page_header')
 
@@ -161,7 +161,7 @@ class FseventsdParser(
       page_header, file_offset = self._ReadStructureFromFileObject(
           file_object, 0, page_header_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse page header with error: {0!s}'.format(
               exception))
 

--- a/plaso/parsers/gcp_logging.py
+++ b/plaso/parsers/gcp_logging.py
@@ -274,11 +274,11 @@ class GCPLogsParser(interface.FileObjectParser):
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     # Trivial JSON format check: first character must be an open brace.
     if file_object.read(1) != b'{':
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'is not a valid JSON file, missing opening brace.')
     file_object.seek(0, os.SEEK_SET)
 
@@ -289,13 +289,13 @@ class GCPLogsParser(interface.FileObjectParser):
       first_line = text_file_object.readline()
       first_line_json = json.loads(first_line)
     except JSONDecodeError:
-      raise errors.UnableToParseFile('could not decode json.')
+      raise errors.WrongParser('could not decode json.')
     file_object.seek(0, os.SEEK_SET)
 
     if first_line_json and 'logName' in first_line_json:
       self._ParseGCPLog(parser_mediator, file_object)
     else:
-      raise errors.UnableToParseFile('no logName field, not a GCP log entry.')
+      raise errors.WrongParser('no logName field, not a GCP log entry.')
 
 
 manager.ParsersManager.RegisterParser(GCPLogsParser)

--- a/plaso/parsers/interface.py
+++ b/plaso/parsers/interface.py
@@ -229,17 +229,17 @@ class FileEntryParser(BaseParser):
   """The file entry parser interface."""
 
   def Parse(self, parser_mediator):
-    """Parsers the file entry and extracts event objects.
+    """Parses the file entry and extracts event objects.
 
     Args:
       parser_mediator (ParserMediator): a parser mediator.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     file_entry = parser_mediator.GetFileEntry()
     if not file_entry:
-      raise errors.UnableToParseFile('Invalid file entry')
+      raise errors.WrongParser('Invalid file entry')
 
     parser_mediator.AppendToParserChain(self)
     try:
@@ -256,7 +256,7 @@ class FileEntryParser(BaseParser):
       file_entry (dfvfs.FileEntry): a file entry to parse.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
 
 
@@ -275,10 +275,10 @@ class FileObjectParser(BaseParser):
       file_object (dfvfs.FileIO): a file-like object to parse.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     if not file_object:
-      raise errors.UnableToParseFile('Invalid file object')
+      raise errors.WrongParser('Invalid file object')
 
     if self._INITIAL_FILE_OFFSET is not None:
       file_object.seek(self._INITIAL_FILE_OFFSET, os.SEEK_SET)
@@ -298,5 +298,5 @@ class FileObjectParser(BaseParser):
       file_object (dfvfs.FileIO): a file-like object to parse.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """

--- a/plaso/parsers/java_idx.py
+++ b/plaso/parsers/java_idx.py
@@ -73,7 +73,7 @@ class JavaIDXParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       file_object (dfvfs.FileIO): a file-like object to parse.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     file_header_map = self._GetDataTypeMap('java_idx_file_header')
 
@@ -81,12 +81,12 @@ class JavaIDXParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       file_header, file_offset = self._ReadStructureFromFileObject(
           file_object, 0, file_header_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse file header with error: {0!s}'.format(
               exception))
 
     if not file_header.format_version in self._SUPPORTED_FORMAT_VERSIONS:
-      raise errors.UnableToParseFile('Unsupported format version.')
+      raise errors.WrongParser('Unsupported format version.')
 
     if file_header.format_version == 602:
       section1_map = self._GetDataTypeMap('java_idx_602_section1')
@@ -99,7 +99,7 @@ class JavaIDXParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       section1, data_size = self._ReadStructureFromFileObject(
           file_object, file_offset, section1_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           'Unable to parse section 1 (format version: {0:d}) with error: '
           '{1!s}').format(file_header.format_version, exception))
 
@@ -115,14 +115,14 @@ class JavaIDXParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       section2, data_size = self._ReadStructureFromFileObject(
           file_object, file_offset, section2_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           'Unable to parse section 2 (format version: {0:d}) with error: '
           '{1!s}').format(file_header.format_version, exception))
 
     file_offset += data_size
 
     if not section2.url:
-      raise errors.UnableToParseFile('URL not found in file.')
+      raise errors.WrongParser('URL not found in file.')
 
     date_http_header = None
     for _ in range(section2.number_of_http_headers):

--- a/plaso/parsers/locate.py
+++ b/plaso/parsers/locate.py
@@ -60,7 +60,7 @@ class LocateDatabaseParser(
       file_object (dfvfs.FileIO): file-like object to be parsed.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed, this will signal
+      WrongParser: when the file cannot be parsed, this will signal
           the event extractor to apply other parsers.
     """
     locate_database_header_map = self._GetDataTypeMap('locate_database_header')
@@ -69,7 +69,7 @@ class LocateDatabaseParser(
       locate_database_header, file_offset = self._ReadStructureFromFileObject(
           file_object, 0, locate_database_header_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse locate database header with error: {0!s}'.format(
               exception))
 

--- a/plaso/parsers/mac_keychain.py
+++ b/plaso/parsers/mac_keychain.py
@@ -882,12 +882,12 @@ class KeychainParser(
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     try:
       file_header = self._ReadFileHeader(file_object)
     except (ValueError, errors.ParseError):
-      raise errors.UnableToParseFile('Unable to parse file header.')
+      raise errors.WrongParser('Unable to parse file header.')
 
     tables = self._ReadTablesArray(file_object, file_header.tables_array_offset)
 

--- a/plaso/parsers/mactime.py
+++ b/plaso/parsers/mactime.py
@@ -111,7 +111,7 @@ class MactimeParser(interface.FileObjectParser):
       int: integer value or None if not available or invalid.
 
     Raises:
-      UnableToParseFile: when an invalid integer value is found on
+      WrongParser: when an invalid integer value is found on
           the first line.
     """
     integer_value = values.pop(-1) or None
@@ -122,7 +122,7 @@ class MactimeParser(interface.FileObjectParser):
         error_string = 'invalid {0:s} value in line: {1:d}'.format(
             description, line_number)
         if line_number == 0:
-          raise errors.UnableToParseFile(error_string)
+          raise errors.WrongParser(error_string)
 
         parser_mediator.ProduceRecoveryWarning(error_string)
         integer_value = None
@@ -144,7 +144,7 @@ class MactimeParser(interface.FileObjectParser):
       float: floating-point value or None if not available or invalid.
 
     Raises:
-      UnableToParseFile: when an invalid floating-point value is found on
+      WrongParser: when an invalid floating-point value is found on
           the first line.
     """
     float_value = values.pop(-1) or None
@@ -155,7 +155,7 @@ class MactimeParser(interface.FileObjectParser):
         error_string = 'invalid {0:s} value in line: {1:d}'.format(
             description, line_number)
         if line_number == 0:
-          raise errors.UnableToParseFile(error_string)
+          raise errors.WrongParser(error_string)
 
         parser_mediator.ProduceRecoveryWarning(error_string)
         float_value = None
@@ -171,7 +171,7 @@ class MactimeParser(interface.FileObjectParser):
       file_object (dfvfs.FileIO): file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     # Note that we cannot use the DSVParser here since the mactime bodyfile
     # format is not strict and clean file format.
@@ -183,7 +183,7 @@ class MactimeParser(interface.FileObjectParser):
     try:
       line = line_reader.readline()
     except UnicodeDecodeError as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'unable to read line: {0:d} with error: {1!s}'.format(
               line_number, exception))
 
@@ -194,7 +194,7 @@ class MactimeParser(interface.FileObjectParser):
         error_string = 'invalid number of values: {0:d} in line: {1:d}'.format(
             number_of_values, line_number)
         if line_number == 0:
-          raise errors.UnableToParseFile(error_string)
+          raise errors.WrongParser(error_string)
 
         parser_mediator.ProduceExtractionWarning(error_string)
 
@@ -206,7 +206,7 @@ class MactimeParser(interface.FileObjectParser):
           error_string = 'invalid MD5 value: {0:s} in line: {1:d}'.format(
               md5_value, line_number)
           if line_number == 0:
-            raise errors.UnableToParseFile(error_string)
+            raise errors.WrongParser(error_string)
 
           parser_mediator.ProduceRecoveryWarning(error_string)
 

--- a/plaso/parsers/olecf_plugins/automatic_destinations.py
+++ b/plaso/parsers/olecf_plugins/automatic_destinations.py
@@ -103,7 +103,7 @@ class AutomaticDestinationsOLECFPlugin(
       olecf_item (pyolecf.item): OLECF item.
 
     Raises:
-      UnableToParseFile: if the DestList cannot be parsed.
+      WrongParser: if the DestList cannot be parsed.
     """
     if olecf_item.size == 0:
       parser_mediator.ProduceExtractionWarning('empty DestList stream')
@@ -115,7 +115,7 @@ class AutomaticDestinationsOLECFPlugin(
       header, entry_offset = self._ReadStructureFromFileObject(
           olecf_item, 0, header_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse DestList header with error: {0!s}'.format(
               exception))
 
@@ -133,7 +133,7 @@ class AutomaticDestinationsOLECFPlugin(
         entry, entry_data_size = self._ReadStructureFromFileObject(
             olecf_item, entry_offset, entry_map)
       except (ValueError, errors.ParseError) as exception:
-        raise errors.UnableToParseFile(
+        raise errors.WrongParser(
             'Unable to parse DestList entry with error: {0!s}'.format(
                 exception))
 

--- a/plaso/parsers/opera.py
+++ b/plaso/parsers/opera.py
@@ -78,16 +78,16 @@ class OperaTypedHistoryParser(interface.FileObjectParser):
       file_object (dfvfs.FileIO): file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     data = file_object.read(self._HEADER_READ_SIZE)
     if not data.startswith(b'<?xml'):
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Not an Opera typed history file [not a XML]')
 
     _, _, data = data.partition(b'\n')
     if not data.startswith(b'<typed_history'):
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Not an Opera typed history file [wrong XML root key]')
 
     # For ElementTree to work we need to work on a file object seeked
@@ -304,12 +304,12 @@ class OperaGlobalHistoryParser(interface.FileObjectParser):
       file_object (dfvfs.FileIO): file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     encoding = self._ENCODING or parser_mediator.codepage
     text_file_object = text_file.TextFile(file_object, encoding=encoding)
     if not self._ParseAndValidateRecord(parser_mediator, text_file_object):
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse as Opera global_history.dat.')
 
     while self._ParseRecord(parser_mediator, text_file_object):

--- a/plaso/parsers/pe.py
+++ b/plaso/parsers/pe.py
@@ -395,14 +395,14 @@ class PEParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     pe_data_slice = dfvfs_data_slice.DataSlice(file_object)
     try:
       pefile_object = pefile.PE(data=pe_data_slice, fast_load=True)
       pefile_object.parse_data_directories(directories=self._PE_DIRECTORIES)
     except Exception as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to read PE file with error: {0!s}'.format(exception))
 
     event_data = PEEventData()

--- a/plaso/parsers/plist.py
+++ b/plaso/parsers/plist.py
@@ -80,17 +80,17 @@ class PlistParser(interface.FileObjectParser):
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     filename = parser_mediator.GetFilename()
     file_size = file_object.get_size()
 
     if file_size <= 0:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'File size: {0:d} bytes is less equal 0.'.format(file_size))
 
     if file_size > self._MAXIMUM_PLIST_FILE_SIZE:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'File size: {0:d} bytes is larger than 50 MB.'.format(file_size))
 
     plist_data = file_object.read()
@@ -116,7 +116,7 @@ class PlistParser(interface.FileObjectParser):
         plist_data = plist_data.rstrip()
 
         if not plist_data.endswith(plist_footer):
-          raise errors.UnableToParseFile(
+          raise errors.WrongParser(
               'Unable to parse XML plist with error: missing plist XML root '
               'element.')
 
@@ -125,7 +125,7 @@ class PlistParser(interface.FileObjectParser):
 
     except (AttributeError, binascii.Error, expat.ExpatError,
             plistlib.InvalidFileException) as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse plist with error: {0!s}'.format(exception))
 
     except (LookupError, ValueError) as exception:
@@ -155,7 +155,7 @@ class PlistParser(interface.FileObjectParser):
     try:
       top_level_keys = set(top_level_object.keys())
     except AttributeError as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse top level keys of: {0:s} with error: {1!s}.'.format(
               filename, exception))
 

--- a/plaso/parsers/pls_recall.py
+++ b/plaso/parsers/pls_recall.py
@@ -122,7 +122,7 @@ class PlsRecallParser(
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     file_offset = 0
     file_size = file_object.get_size()
@@ -134,7 +134,7 @@ class PlsRecallParser(
             file_object, file_offset, record_map)
       except (ValueError, errors.ParseError) as exception:
         if file_offset == 0:
-          raise errors.UnableToParseFile('Unable to parse first record.')
+          raise errors.WrongParser('Unable to parse first record.')
 
         parser_mediator.ProduceExtractionWarning((
             'unable to parse record at offset: 0x{0:08x} with error: '
@@ -143,7 +143,7 @@ class PlsRecallParser(
 
       if file_offset == 0 and not self._VerifyRecord(
           parser_mediator, pls_record):
-        raise errors.UnableToParseFile('Verification of first record failed.')
+        raise errors.WrongParser('Verification of first record failed.')
 
       event_data = PlsRecallEventData()
       event_data.database_name = pls_record.database_name.rstrip('\x00')

--- a/plaso/parsers/recycler.py
+++ b/plaso/parsers/recycler.py
@@ -98,14 +98,14 @@ class WinRecycleBinParser(
       file_object (dfvfs.FileIO): file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     # We may have to rely on filenames since this header is very generic.
 
     # TODO: Rethink this and potentially make a better test.
     filename = parser_mediator.GetFilename()
     if not filename.startswith('$I'):
-      raise errors.UnableToParseFile('Filename must start with $I.')
+      raise errors.WrongParser('Filename must start with $I.')
 
     file_header_map = self._GetDataTypeMap('recycle_bin_metadata_file_header')
 
@@ -113,12 +113,12 @@ class WinRecycleBinParser(
       file_header, _ = self._ReadStructureFromFileObject(
           file_object, 0, file_header_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           'Unable to parse Windows Recycle.Bin metadata file header with '
           'error: {0!s}').format(exception))
 
     if file_header.format_version not in self._SUPPORTED_FORMAT_VERSIONS:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unsupported format version: {0:d}.'.format(
               file_header.format_version))
 
@@ -239,7 +239,7 @@ class WinRecyclerInfo2Parser(
       file_object (dfvfs.FileIO): file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     # Since this header value is really generic it is hard not to use filename
     # as an indicator too.
@@ -255,7 +255,7 @@ class WinRecyclerInfo2Parser(
       file_header, _ = self._ReadStructureFromFileObject(
           file_object, 0, file_header_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           'Unable to parse Windows Recycler INFO2 file header with '
           'error: {0!s}').format(exception))
 

--- a/plaso/parsers/safari_cookies.py
+++ b/plaso/parsers/safari_cookies.py
@@ -211,7 +211,7 @@ class BinaryCookieParser(
 
     Raises:
       ParseError: when the page sizes array cannot be parsed.
-      UnableToParseFile: when the file cannot be parsed, this will signal
+      WrongParser: when the file cannot be parsed, this will signal
           the event extractor to apply other parsers.
     """
     file_header_map = self._GetDataTypeMap('binarycookies_file_header')
@@ -220,7 +220,7 @@ class BinaryCookieParser(
       file_header, file_header_data_size = self._ReadStructureFromFileObject(
           file_object, 0, file_header_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to read file header with error: {0!s}.'.format(exception))
 
     file_offset = file_header_data_size

--- a/plaso/parsers/spotlight_storedb.py
+++ b/plaso/parsers/spotlight_storedb.py
@@ -1048,12 +1048,12 @@ class SpotlightStoreDatabaseParser(
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     try:
       file_header = self._ReadFileHeader(file_object)
     except (ValueError, errors.ParseError):
-      raise errors.UnableToParseFile('Unable to parse file header.')
+      raise errors.WrongParser('Unable to parse file header.')
 
     try:
       self._map_values = []

--- a/plaso/parsers/sqlite.py
+++ b/plaso/parsers/sqlite.py
@@ -411,9 +411,6 @@ class SQLiteParser(interface.FileEntryParser):
     Args:
       parser_mediator (ParserMediator): parser mediator.
       file_entry (dfvfs.FileEntry): file entry to be parsed.
-
-    Raises:
-      WrongParser: when the file cannot be parsed.
     """
     filename = parser_mediator.GetFilename()
     database = SQLiteDatabase(

--- a/plaso/parsers/sqlite.py
+++ b/plaso/parsers/sqlite.py
@@ -413,7 +413,7 @@ class SQLiteParser(interface.FileEntryParser):
       file_entry (dfvfs.FileEntry): file entry to be parsed.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     filename = parser_mediator.GetFilename()
     database = SQLiteDatabase(

--- a/plaso/parsers/systemd_journal.py
+++ b/plaso/parsers/systemd_journal.py
@@ -281,7 +281,7 @@ class SystemdJournalParser(
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the header cannot be parsed.
+      WrongParser: when the header cannot be parsed.
     """
     file_header_map = self._GetDataTypeMap('systemd_journal_file_header')
 
@@ -289,12 +289,12 @@ class SystemdJournalParser(
       file_header, _ = self._ReadStructureFromFileObject(
           file_object, 0, file_header_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse file header with error: {0!s}'.format(
               exception))
 
     if file_header.header_size not in self._SUPPORTED_FILE_HEADER_SIZES:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unsupported file header size: {0:d}.'.format(
               file_header.header_size))
 

--- a/plaso/parsers/text_parser.py
+++ b/plaso/parsers/text_parser.py
@@ -422,10 +422,10 @@ class PyparsingSingleLineTextParser(interface.FileObjectParser):
       file_object (dfvfs.FileIO): file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     if not self._line_structures:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Line structure undeclared, unable to proceed.')
 
     encoding = self._ENCODING or parser_mediator.codepage
@@ -438,11 +438,11 @@ class PyparsingSingleLineTextParser(interface.FileObjectParser):
     try:
       line = self._ReadLine(text_file_object, max_len=self.MAX_LINE_LENGTH)
     except UnicodeDecodeError:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Not a text file or encoding not supported.')
 
     if not line:
-      raise errors.UnableToParseFile('Not a text file.')
+      raise errors.WrongParser('Not a text file.')
 
     if len(line) == self.MAX_LINE_LENGTH or len(
         line) == self.MAX_LINE_LENGTH - 1:
@@ -453,10 +453,10 @@ class PyparsingSingleLineTextParser(interface.FileObjectParser):
               self.MAX_LINE_LENGTH, repr(line[-10:]), self.NAME))
 
     if not self._IsText(line):
-      raise errors.UnableToParseFile('Not a text file, unable to proceed.')
+      raise errors.WrongParser('Not a text file, unable to proceed.')
 
     if not self.VerifyStructure(parser_mediator, line):
-      raise errors.UnableToParseFile('Wrong file structure.')
+      raise errors.WrongParser('Wrong file structure.')
 
     self._parser_mediator = parser_mediator
 
@@ -504,7 +504,7 @@ class PyparsingSingleLineTextParser(interface.FileObjectParser):
         consecutive_line_failures += 1
         if (consecutive_line_failures >
             self.MAXIMUM_CONSECUTIVE_LINE_FAILURES):
-          raise errors.UnableToParseFile(
+          raise errors.WrongParser(
               'more than {0:d} consecutive failures to parse lines.'.format(
                   self.MAXIMUM_CONSECUTIVE_LINE_FAILURES))
 
@@ -691,10 +691,10 @@ class PyparsingMultiLineTextParser(PyparsingSingleLineTextParser):
       file_object (dfvfs.FileIO): file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     if not self._line_structures:
-      raise errors.UnableToParseFile('Missing line structures.')
+      raise errors.WrongParser('Missing line structures.')
 
     encoding = self._ENCODING or parser_mediator.codepage
     text_reader = EncodedTextReader(
@@ -705,11 +705,11 @@ class PyparsingMultiLineTextParser(PyparsingSingleLineTextParser):
     try:
       text_reader.ReadLines(file_object)
     except UnicodeDecodeError as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Not a text file, with error: {0!s}'.format(exception))
 
     if not self.VerifyStructure(parser_mediator, text_reader.lines):
-      raise errors.UnableToParseFile('Wrong file structure.')
+      raise errors.WrongParser('Wrong file structure.')
 
     consecutive_line_failures = 0
     # Read every line in the text file.
@@ -767,7 +767,7 @@ class PyparsingMultiLineTextParser(PyparsingSingleLineTextParser):
           consecutive_line_failures += 1
           if (consecutive_line_failures >
               self.MAXIMUM_CONSECUTIVE_LINE_FAILURES):
-            raise errors.UnableToParseFile(
+            raise errors.WrongParser(
                 'more than {0:d} consecutive failures to parse lines.'.format(
                     self.MAXIMUM_CONSECUTIVE_LINE_FAILURES))
 

--- a/plaso/parsers/trendmicroav.py
+++ b/plaso/parsers/trendmicroav.py
@@ -107,7 +107,7 @@ class TrendMicroBaseParser(dsv_parser.DSVParser):
       dict[str, str]: column values keyed by column header.
 
     Raises:
-      UnableToParseFile: if a log line cannot be parsed.
+      WrongParser: if a log line cannot be parsed.
     """
     for line in line_reader:
       stripped_line = line.strip()
@@ -116,12 +116,12 @@ class TrendMicroBaseParser(dsv_parser.DSVParser):
       number_of_columns = len(self.COLUMNS)
 
       if number_of_values < self.MIN_COLUMNS:
-        raise errors.UnableToParseFile(
+        raise errors.WrongParser(
             'Expected at least {0:d} values, found {1:d}'.format(
                 self.MIN_COLUMNS, number_of_values))
 
       if number_of_values > number_of_columns:
-        raise errors.UnableToParseFile(
+        raise errors.WrongParser(
             'Expected at most {0:d} values, found {1:d}'.format(
                 number_of_columns, number_of_values))
 

--- a/plaso/parsers/utmp.py
+++ b/plaso/parsers/utmp.py
@@ -155,7 +155,7 @@ class UtmpParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     file_offset = 0
 
@@ -163,21 +163,21 @@ class UtmpParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       timestamp, event_data, warning_strings = self._ReadEntry(
           parser_mediator, file_object, file_offset)
     except errors.ParseError as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse first utmp entry with error: {0!s}'.format(
               exception))
 
     if not timestamp:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse first utmp entry with error: missing timestamp')
 
     if not event_data.username and event_data.type != self._DEAD_PROCESS_TYPE:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse first utmp entry with error: missing username')
 
     if warning_strings:
       all_warnings = ', '.join(warning_strings)
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse first utmp entry with error: {0:s}'.format(
               all_warnings))
 

--- a/plaso/parsers/utmpx.py
+++ b/plaso/parsers/utmpx.py
@@ -155,7 +155,7 @@ class UtmpxParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     file_offset = 0
 
@@ -163,16 +163,16 @@ class UtmpxParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       timestamp, event_data = self._ReadEntry(
           parser_mediator, file_object, file_offset)
     except errors.ParseError as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse utmpx file header with error: {0!s}'.format(
               exception))
 
     if event_data.username != self._FILE_HEADER_USERNAME:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse utmpx file header with error: unsupported username')
 
     if event_data.type != self._FILE_HEADER_TYPE:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse utmp file header with error: unsupported type of '
           'login')
 

--- a/plaso/parsers/winjob.py
+++ b/plaso/parsers/winjob.py
@@ -186,7 +186,7 @@ class WinJobParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       file_object (dfvfs.FileIO): a file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     fixed_section_data_map = self._GetDataTypeMap(
         'job_fixed_length_data_section')
@@ -195,17 +195,17 @@ class WinJobParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       fixed_length_section, file_offset = self._ReadStructureFromFileObject(
           file_object, 0, fixed_section_data_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse fixed-length data section with error: {0!s}'.format(
               exception))
 
     if not fixed_length_section.product_version in self._PRODUCT_VERSIONS:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unsupported product version in: 0x{0:04x}'.format(
               fixed_length_section.product_version))
 
     if not fixed_length_section.format_version == 1:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unsupported format version in: {0:d}'.format(
               fixed_length_section.format_version))
 
@@ -216,7 +216,7 @@ class WinJobParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
       variable_length_section, data_size = self._ReadStructureFromFileObject(
           file_object, file_offset, variable_section_data_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile((
+      raise errors.WrongParser((
           'Unable to parse variable-length data section with error: '
           '{0!s}').format(exception))
 
@@ -237,7 +237,7 @@ class WinJobParser(interface.FileObjectParser, dtfabric_helper.DtFabricHelper):
         trigger, data_size = self._ReadStructureFromFileObject(
             file_object, file_offset, trigger_data_map)
       except (ValueError, errors.ParseError) as exception:
-        raise errors.UnableToParseFile((
+        raise errors.WrongParser((
             'Unable to parse trigger: {0:d} with error: {1!s}').format(
                 trigger_index, exception))
 

--- a/plaso/parsers/winrestore.py
+++ b/plaso/parsers/winrestore.py
@@ -58,7 +58,7 @@ class RestorePointLogParser(
       file_object (dfvfs.FileIO): file-like object.
 
     Raises:
-      UnableToParseFile: when the file cannot be parsed.
+      WrongParser: when the file cannot be parsed.
     """
     file_size = file_object.get_size()
 
@@ -68,7 +68,7 @@ class RestorePointLogParser(
       file_header, _ = self._ReadStructureFromFileObject(
           file_object, 0, file_header_map)
     except (ValueError, errors.ParseError) as exception:
-      raise errors.UnableToParseFile(
+      raise errors.WrongParser(
           'Unable to parse file header with error: {0!s}'.format(
               exception))
 

--- a/tests/parsers/apt_history.py
+++ b/tests/parsers/apt_history.py
@@ -245,7 +245,7 @@ class APTHistoryLogUnitTest(test_lib.ParserTestCase):
   def testParseInvalidLog(self):
     """Tests the Parse function on a non APT History log."""
     parser = apt_history.APTHistoryLogParser()
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       self._ParseFile(['setupapi.dev.log'], parser)
 
 

--- a/tests/parsers/asl.py
+++ b/tests/parsers/asl.py
@@ -190,7 +190,7 @@ class ASLParserTest(test_lib.ParserTestCase):
     # Test with file header data too small.
     file_object = self._CreateFileObject('asl', file_header_data[:-1])
 
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       parser.ParseFileObject(parser_mediator, file_object)
 
     # Test with invalid signature.
@@ -200,7 +200,7 @@ class ASLParserTest(test_lib.ParserTestCase):
     storage_writer = self._CreateStorageWriter()
     parser_mediator = self._CreateParserMediator(storage_writer)
 
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       parser.ParseFileObject(parser_mediator, file_object)
 
     # Test with first record data too small.

--- a/tests/parsers/cups_ipp.py
+++ b/tests/parsers/cups_ipp.py
@@ -230,7 +230,7 @@ class CupsIppParserTest(test_lib.ParserTestCase):
     # Test with header data too small.
     file_object = self._CreateFileObject('cups_ipp', header_data[:-1])
 
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       parser._ParseHeader(parser_mediator, file_object)
 
     # Test with unsupported format version.
@@ -242,7 +242,7 @@ class CupsIppParserTest(test_lib.ParserTestCase):
     header_data = header_map.FoldByteStream(header)
     file_object = self._CreateFileObject('cups_ipp', header_data)
 
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       parser._ParseHeader(parser_mediator, file_object)
 
     # Test with unsupported operation identifier.

--- a/tests/parsers/czip.py
+++ b/tests/parsers/czip.py
@@ -50,13 +50,13 @@ class CompoundZIPTest(test_lib.ParserTestCase):
     # Try parsing a file that is not a ZIP file.
     parser = czip.CompoundZIPParser()
 
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       storage_writer = self._ParseFile(['syslog.xz'], parser)
 
     # Try parsing a file that is not a ZIP file but looks like one.
     parser = czip.CompoundZIPParser()
 
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       storage_writer = self._ParseFile(['passes_is_zipfile.bin'], parser)
 
 

--- a/tests/parsers/firefox_cache.py
+++ b/tests/parsers/firefox_cache.py
@@ -18,7 +18,7 @@ class FirefoxCacheParserTest(test_lib.ParserTestCase):
     parser = firefox_cache.FirefoxCacheParser()
     path_segments = ['firefox_cache', 'invalid_file']
 
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       self._ParseFile(path_segments, parser)
 
   def testParseCache_001(self):
@@ -275,7 +275,7 @@ class FirefoxCache2ParserTest(test_lib.ParserTestCase):
     path_segments = [
         'firefox_cache', 'cache2', 'C966EB70794E44E7E3E8A260106D0C72439AF65B']
 
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       self._ParseFile(path_segments, parser)
 
   def testParseVersion3Entry(self):

--- a/tests/parsers/google_logging.py
+++ b/tests/parsers/google_logging.py
@@ -61,7 +61,7 @@ class GooglelogParserTest(test_lib.ParserTestCase):
     invalid_file_path = self._GetTestFilePath([invalid_file_name])
     self._SkipIfPathNotExists(invalid_file_path)
 
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       self._ParseFile(
           [invalid_file_name], parser,
           knowledge_base_values=knowledge_base_values)

--- a/tests/parsers/plist.py
+++ b/tests/parsers/plist.py
@@ -88,7 +88,7 @@ class PlistParserTest(test_lib.ParserTestCase):
     """Tests the Parse function on a truncated plist file."""
     parser = plist.PlistParser()
 
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       self._ParseFile(['truncated.plist'], parser)
 
   def testParseWithXMLFileLeadingWhitespace(self):
@@ -127,39 +127,39 @@ class PlistParserTest(test_lib.ParserTestCase):
     """Tests the Parse function on an XML file that causes an ExpatError."""
     parser = plist.PlistParser()
 
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       self._ParseFile(['WMSDKNS.DTD'], parser)
 
   def testParseWithXMLFileBinASCIIError(self):
     """Tests the Parse function on an XML file that causes a binascii.Error."""
     parser = plist.PlistParser()
 
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       self._ParseFile(['manageconsolidatedProviders.aspx.resx'], parser)
 
   def testParseWithXMLFileNoTopLevel(self):
     """Tests the Parse function on an XML file without top level."""
     parser = plist.PlistParser()
 
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       test_path_segments = [
           'SettingsPane_{F8B5DB1C-D219-4bf9-A747-A1325024469B}'
           '.settingcontent-ms']
       self._ParseFile(test_path_segments, parser)
 
     # UTF-8 encoded XML file with byte-order-mark.
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       self._ParseFile(['ReAgent.xml'], parser)
 
     # UTF-16 little-endian encoded XML file with byte-order-mark.
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       self._ParseFile(['SampleMachineList.xml'], parser)
 
   def testParseWithXMLFileEncodingUnicode(self):
     """Tests the Parse function on an XML file with encoding Unicode."""
     parser = plist.PlistParser()
 
-    with self.assertRaises(errors.UnableToParseFile):
+    with self.assertRaises(errors.WrongParser):
       self._ParseFile(['SAFStore.xml'], parser)
 
   def testParseWithEmptyBinaryPlistFile(self):


### PR DESCRIPTION
## One line description of pull request
Renamed UnableToParseFile exception to WrongParser, removed WrongBencodePlugin exception


## Description:
* Renamed UnableToParseFile exception to WrongParser to better align with its definition ("Raised when a parser is not designed to parse a file")
* Removed now unused WrongBencodePlugin exception class

**Related issue (if applicable):** fixes #<plaso issue number here>

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [x] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [x] Reviewer assigned
