### PR TITLE
generalized ios_mobile_installation.py into ios_sysdiag_log.py

### DIFF
--- a/data/formatters/ios.yaml
+++ b/data/formatters/ios.yaml
@@ -44,7 +44,7 @@ short_message:
 - 'Body: {body}'
 ---
 type: 'conditional'
-data_type: 'ios:mobile_installation:line'
+data_type: 'ios:sysdiag:log:line'
 message:
 - 'Originating call: {originating_call}'
 - 'Body: {body}'

--- a/data/formatters/legacy.yaml
+++ b/data/formatters/legacy.yaml
@@ -35,6 +35,14 @@ short_message:
 - 'Layer ID: {layer_id}'
 ---
 type: 'conditional'
+data_type: 'ios:mobile_installation:line'
+message:
+- 'Originating call: {originating_call}'
+- 'Body: {body}'
+short_message:
+- 'Body: {body}'
+---
+type: 'conditional'
 data_type: 'pe:compilation:compilation_time'
 message:
 - 'PE Type: {pe_type}'

--- a/plaso/parsers/__init__.py
+++ b/plaso/parsers/__init__.py
@@ -25,7 +25,7 @@ from plaso.parsers import google_logging
 from plaso.parsers import iis
 from plaso.parsers import ios_lockdownd
 from plaso.parsers import ios_logd
-from plaso.parsers import ios_mobile_installation_log
+from plaso.parsers import ios_sysdiag_log
 from plaso.parsers import java_idx
 from plaso.parsers import jsonl_parser
 from plaso.parsers import locate

--- a/plaso/parsers/ios_sysdiag_log.py
+++ b/plaso/parsers/ios_sysdiag_log.py
@@ -27,8 +27,7 @@ class IOSSysdiagLogEventData(events.EventData):
 
   def __init__(self):
     """Initializes event data."""
-    super(
-        IOSSysdiagLogEventData, self).__init__(data_type=self.DATA_TYPE)
+    super(IOSSysdiagLogEventData, self).__init__(data_type=self.DATA_TYPE)
     self.body = None
     self.originating_call = None
     self.process_identifier = None

--- a/plaso/parsers/ios_sysdiag_log.py
+++ b/plaso/parsers/ios_sysdiag_log.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Parser for iOS mobile installation log files."""
+"""Parser for iOS sysdiag log files."""
 
 import pyparsing
 
@@ -13,8 +13,8 @@ from plaso.parsers import manager
 from plaso.parsers import text_parser
 
 
-class IOSMobileInstallationEventData(events.EventData):
-  """iOS mobile installation log event data.
+class IOSSysdiagLogEventData(events.EventData):
+  """iOS sysdiagnose log event data.
 
   Attributes:
     body (str): body of the event line.
@@ -23,23 +23,23 @@ class IOSMobileInstallationEventData(events.EventData):
     severity (str): severity of the message.
   """
 
-  DATA_TYPE = 'ios:mobile_installation:line'
+  DATA_TYPE = 'ios:sysdiag:log:line'
 
   def __init__(self):
     """Initializes event data."""
     super(
-        IOSMobileInstallationEventData, self).__init__(data_type=self.DATA_TYPE)
+        IOSSysdiagLogEventData, self).__init__(data_type=self.DATA_TYPE)
     self.body = None
     self.originating_call = None
     self.process_identifier = None
     self.severity = None
 
 
-class IOSMobileInstallationLogParser(text_parser.PyparsingMultiLineTextParser):
+class IOSSysdiagLogParser(text_parser.PyparsingMultiLineTextParser):
   """Parser for iOS mobile installation log files."""
 
-  NAME = 'ios:mobile_installation:log'
-  DATA_FORMAT = 'iOS mobile installation log'
+  NAME = 'ios:sydiag:log'
+  DATA_FORMAT = 'iOS sysdiag log'
 
   MONTHS = {
       'Jan': 1,
@@ -81,15 +81,14 @@ class IOSMobileInstallationLogParser(text_parser.PyparsingMultiLineTextParser):
       pyparsing.Word(pyparsing.alphanums).setResultsName('id') +
       pyparsing.Suppress(')'))
 
-  _ELEMENT_ORIGINATOR = (
-      (pyparsing.Suppress('+[') | pyparsing.Suppress('-[')) +
-      pyparsing.SkipTo(pyparsing.Literal(']')).setResultsName(
-          'originating_call') +
-      pyparsing.Suppress(']: '))
+  _ELEMENT_ORIGINATOR = pyparsing.SkipTo(
+      pyparsing.Literal(': ')).setResultsName('originating_call')
 
   _BODY_END = pyparsing.StringEnd() | _TIMESTAMP
 
-  _ELEMENT_BODY = pyparsing.SkipTo(_BODY_END).setResultsName('body')
+  _ELEMENT_BODY = (
+      pyparsing.Optional(pyparsing.Suppress(pyparsing.Literal(': '))) +
+      pyparsing.SkipTo(_BODY_END).setResultsName('body'))
 
   _LINE_GRAMMAR = (
       _TIMESTAMP + _ELEMENT_NUMBER + _ELEMENT_SEVERITY +
@@ -123,7 +122,7 @@ class IOSMobileInstallationLogParser(text_parser.PyparsingMultiLineTextParser):
     minutes = self._GetValueFromStructure(structure, 'minutes')
     seconds = self._GetValueFromStructure(structure, 'seconds')
 
-    event_data = IOSMobileInstallationEventData()
+    event_data = IOSSysdiagLogEventData()
     event_data.process_identifier = self._GetValueFromStructure(
         structure, 'process_identifier')
     event_data.severity = self._GetValueFromStructure(structure, 'severity')
@@ -158,4 +157,4 @@ class IOSMobileInstallationLogParser(text_parser.PyparsingMultiLineTextParser):
     return bool(list(match_generator))
 
 
-manager.ParsersManager.RegisterParser(IOSMobileInstallationLogParser)
+manager.ParsersManager.RegisterParser(IOSSysdiagLogParser)

--- a/test_data/ios_sysdiag.log
+++ b/test_data/ios_sysdiag.log
@@ -18,3 +18,17 @@ Wed Aug 11 05:51:03 2021 [176] <err> (0x16bae7000) -[MIBundle _validateWithError
 Wed Aug 11 05:51:04 2021 [176] <notice> (0x16bae7000) -[MIContainer makeContainerLiveReplacingContainer:reason:waitForDeletion:withError:]: Made container live for com.apple.AppleMediaServices.FollowUpExtension at /private/var/mobile/Containers/Data/PluginKitPlugin/19375ED0-857C-4443-82C9-AF18585428D0
 Wed Aug 11 05:51:04 2021 [176] <notice> (0x16bae7000) -[MIContainer makeContainerLiveReplacingContainer:reason:waitForDeletion:withError:]: Made container live for com.apple.WorkflowKit.BackgroundShortcutRunner at /private/var/mobile/Containers/Data/PluginKitPlugin/DA5F4EF2-9E2F-4607-BECF-7EF4A5F216F4
 Wed Aug 11 05:51:04 2021 [176] <notice> (0x16bae7000) -[MIContainer makeContainerLiveReplacingContainer:reason:waitForDeletion:withError:]: Made container live for com.apple.WorkflowKit.ShortcutsIntents at /private/var/mobile/Containers/Data/PluginKitPlugin/3CC29067-C554-4202-855A-3D1E32FC259D
+Sun Jan 17 14:30:18 2021 [66] <notice> (0x16d0f7000) -[MCMCodeSigningMapping _onQueue_removeReferenceForGroupIdentifiers:ofType:commandQueue:]: Would have removed system group container references for (
+    "systemgroup.com.apple.configurationprofiles"
+)
+Sun Jan 17 14:30:18 2021 [66] <notice> (0x16d0f7000) -[MCMCodeSigningMapping _onQueue_removeReferenceForGroupIdentifiers:ofType:commandQueue:]: Would have removed system group container references for (
+    "systemgroup.com.apple.configurationprofiles"
+)
+Sun Jan 17 11:20:29 2021 [66] <notice> (0x16d183000) _containermanagerd_init_block_invoke: containermanagerd first boot cleanup complete
+Sun Jan 17 11:20:39 2021 [66] <notice> (0x16d20f000) _containermanagerd_init_block_invoke: containermanagerd cleanup complete
+Sun Jan 17 11:20:41 2021 [66] <err> (0x16d327000) server_get_process_containers: Invalid data container class for com.apple.mobilesafari: 0
+Sun Jan 17 11:20:41 2021 [66] <notice> (0x16d327000) server_get_process_containers: SB Type: 0, falling back to class: 2
+Fri Feb  5 18:03:23 2021 [1272] <notice> (0x16b663000) -[ACXRemoteAppList remoteDeviceConnected]_block_invoke: Remote device connected
+Mon Oct 25 07:05:03 2021 [145] <debug> (0x16d6d7000) MA: main: soc_generation: H11
+Mon Oct 25 07:05:03 2021 [145] <debug> (0x16d6d7000) MA: main: ____________________________________________________________________
+Wed Aug 11 05:51:27 2021 [178] <notice> (0x16cfbf000) -[MIFileManager _stageURLByCopying:toItemName:inStagingDir:stagingMode:settingUID:gid:hasSymlink:error:]_block_invoke: Preserving compressed bit on /private/var/containers/Shared/SystemGroup/systemgroup.com.apple.installcoordinationd/Library/InstallCoordination/PromiseStaging/C15EEEBC-6A1C-4A7A-A6E8-C9876BB32E92/Notes.app/PlugIns/com.apple.mobilenotes.WidgetExtension.appex/PlaceholderEntitlements.plist

--- a/tests/parsers/ios_sysdiag_log.py
+++ b/tests/parsers/ios_sysdiag_log.py
@@ -69,8 +69,7 @@ class IOSSysdiagLogParserTest(test_lib.ParserTestCase):
     self.CheckEventValues(storage_writer, events[14], expected_event_values)
 
     expected_event_values = {
-        'body': (
-            'containermanagerd first boot cleanup complete'),
+        'body': 'containermanagerd first boot cleanup complete',
         'originating_call': '_containermanagerd_init_block_invoke',
         'process_identifier': '66',
         'severity': 'notice',

--- a/tests/parsers/ios_sysdiag_log.py
+++ b/tests/parsers/ios_sysdiag_log.py
@@ -4,21 +4,21 @@
 
 import unittest
 
-from plaso.parsers import ios_mobile_installation_log
+from plaso.parsers import ios_sysdiag_log
 
 from tests.parsers import test_lib
 
 
-class IOSMobileInstallationLogParserTest(test_lib.ParserTestCase):
+class IOSSysdiagLogParserTest(test_lib.ParserTestCase):
   """Tests for the iOS Mobile Installation log parser"""
 
   def testParseLog(self):
     """Tests the Parse function"""
-    parser = ios_mobile_installation_log.IOSMobileInstallationLogParser()
-    storage_writer = self._ParseFile(['mobile_installation.log.0'], parser)
+    parser = ios_sysdiag_log.IOSSysdiagLogParser()
+    storage_writer = self._ParseFile(['ios_sysdiag.log'], parser)
 
     number_of_events = storage_writer.GetNumberOfAttributeContainers('event')
-    self.assertEqual(number_of_events, 18)
+    self.assertEqual(number_of_events, 28)
 
     number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
         'extraction_warning')
@@ -29,15 +29,13 @@ class IOSMobileInstallationLogParserTest(test_lib.ParserTestCase):
     expected_event_values = {
         'body': (
             'Ignoring plugin at /System/Library/PrivateFrameworks/'
-            'AccessibilityUtilities.framework/PlugIns/'
-            'com.apple.accessibility.Accessibility.HearingAidsTapToRadar.'
-            'appex due to validation issue(s). '
-            'See previous log messages for details.'),
+            'AccessibilityUtilities.framework/PlugIns/com.apple.accessibility.'
+            'Accessibility.HearingAidsTapToRadar.appex due to validation '
+            'issue(s). See previous log messages for details.'),
         'originating_call': (
-            'MILaunchServicesDatabaseGatherer '
+            '+[MILaunchServicesDatabaseGatherer '
             'enumeratePluginKitPluginsInBundle:updatingPluginParentID:'
-            'ensurePluginsAreExecutable:installProfiles:error:'
-            'enumerator:'),
+            'ensurePluginsAreExecutable:installProfiles:error:enumerator:]'),
         'process_identifier': '176',
         'severity': 'err',
         'timestamp': '2021-08-11 05:51:02.000000'}
@@ -63,12 +61,22 @@ class IOSMobileInstallationLogParserTest(test_lib.ParserTestCase):
             '000002a6 };\n} keyCount=22 keySample={ CFBundleName DTXcode '
             'DTSDKName DTSDKBuild '
             'CFBundleDevelopmentRegion }'),
-        'originating_call': 'MIBundle _validateWithError:',
+        'originating_call': '-[MIBundle _validateWithError:]',
         'process_identifier': '176',
         'severity': 'err',
         'timestamp': '2021-08-11 05:51:03.000000'}
 
     self.CheckEventValues(storage_writer, events[14], expected_event_values)
+
+    expected_event_values = {
+        'body': (
+            'containermanagerd first boot cleanup complete'),
+        'originating_call': '_containermanagerd_init_block_invoke',
+        'process_identifier': '66',
+        'severity': 'notice',
+        'timestamp': '2021-01-17 11:20:29.000000'}
+
+    self.CheckEventValues(storage_writer, events[20], expected_event_values)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## One line description of pull request
generalized ios_mobile_installation.py into ios_sysdiag_log.py which covers 5 types of log files found in iOS sysdiagnose dumps.


## Description:


**Related issue (if applicable):** fixes #4092

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
