### PR TITLE
Add Event Cleared Windows tagging

### DIFF
--- a/data/tag_windows.txt
+++ b/data/tag_windows.txt
@@ -126,3 +126,9 @@ registry_modified
 # Service Control Manager - Event ID 7045: A new service was installed in the system
 service_new
   data_type is 'windows:evtx:record' AND source_name is 'Service Control Manager' AND event_identifier is 7045
+
+# Tags audit log cleared events
+# 517 is for older Windows
+eventlog_cleared
+  data_type is 'windows:evt:record' AND source_name is 'Security' AND event_identifier is 517
+  data_type is 'windows:evtx:record' AND source_name is 'Microsoft-Windows-Eventlog' AND (event_identifier is 104 OR event_identifier is 1102)

--- a/tests/data/tag_windows.py
+++ b/tests/data/tag_windows.py
@@ -645,6 +645,27 @@ class WindowsTaggingFileTest(test_lib.TaggingFileTestCase):
         winevtx.WinEvtxRecordEventData, attribute_values_per_name,
         ['service_new'])
 
+  def testEventLogCleared(self):
+    """Tests the eventlog_cleared tagging rule."""
+    # Test: data_type is 'windows:evt:record' AND
+    #       source_name is 'Security' AND
+    #       event_identifier is 517
+    attribute_values_per_name = {
+        'event_identifier': [517],
+        'source_name': ['Security']}
+    self._CheckTaggingRule(
+        winevt.WinEvtRecordEventData, attribute_values_per_name,
+        ['eventlog_cleared'])
+    # Test: data_type is 'windows:evtx:record' AND
+    #       source_name is 'Microsoft-Windows-Eventlog' AND
+    #       (event_identifier is 104 OR event_identifier is 1102)
+    attribute_values_per_name = {
+        'event_identifier': [104, 1102],
+        'source_name': ['Microsoft-Windows-Eventlog']}
+    self._CheckTaggingRule(
+        winevtx.WinEvtxRecordEventData, attribute_values_per_name,
+        ['eventlog_cleared'])
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
References:

* <https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=517>
* <https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=1102>

## One line description of pull request

Add Event Cleared Windows tagging

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
