### PR TITLE
Added handling for unsupported memory limit on MacOS #4021

### DIFF
--- a/plaso/cli/tools.py
+++ b/plaso/cli/tools.py
@@ -134,7 +134,13 @@ class CLITool(object):
       elif memory_limit == 0:
         memory_limit = resource.RLIM_INFINITY
 
-      resource.setrlimit(resource.RLIMIT_DATA, (memory_limit, memory_limit))
+      try:
+        resource.setrlimit(resource.RLIMIT_DATA, (memory_limit, memory_limit))
+      except ValueError:
+        current_limit = resource.getrlimit(resource.RLIMIT_DATA)[0]
+        logger.warning(
+            'Unable to set memory limit to {0!s} '
+            'current limit is {1!s}.'.format(memory_limit, current_limit))
 
   def _GetPathSpecificationString(self, path_spec):
     """Retrieves a printable string representation of the path specification.


### PR DESCRIPTION
## One line description of pull request
Added handling for unsupported memory limit on MacOS #4021

## Description:
Catches and logs error when unable to set memory limit

**Related issue (if applicable):** fixes #<plaso issue number here>

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
