### PR TITLE
Changes to Confluence access log parser for pyparsing 2.4 #4137

### DIFF
--- a/plaso/parsers/confluence_access.py
+++ b/plaso/parsers/confluence_access.py
@@ -97,7 +97,7 @@ class ConfluenceAccessParser(text_parser.PyparsingSingleLineTextParser):
       pyparsing.Word(pyparsing.alphanums + '-').setResultsName('thread_name')
   )
 
-  _USER_AGENT = pyparsing.rest_of_line.setResultsName('user_agent')
+  _USER_AGENT = pyparsing.restOfLine.setResultsName('user_agent')
 
   _USER_NAME = (
       pyparsing.Word(pyparsing.alphanums + '@' + pyparsing.alphanums + '.') |
@@ -105,7 +105,7 @@ class ConfluenceAccessParser(text_parser.PyparsingSingleLineTextParser):
       pyparsing.Literal('-')).setResultsName('user_name')
 
   _HTTP_METHOD = (
-      pyparsing.one_of(
+      pyparsing.oneOf(
           ['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST',
               'PUT', 'TRACE'])).setResultsName('http_method')
 


### PR DESCRIPTION
Confluence access log parser is a recently introduced parser https://github.com/log2timeline/plaso/pull/4123