### PR TITLE
Add timezone handling in dpkg

### DIFF
--- a/plaso/parsers/dpkg.py
+++ b/plaso/parsers/dpkg.py
@@ -154,6 +154,7 @@ class DpkgParser(text_parser.PyparsingSingleLineTextParser):
 
       date_time = dfdatetime_time_elements.TimeElements(time_elements_tuple=(
           year, month, day_of_month, hours, minutes, seconds))
+      date_time.is_local_time = True
 
     except (TypeError, ValueError):
       parser_mediator.ProduceExtractionWarning(
@@ -169,7 +170,9 @@ class DpkgParser(text_parser.PyparsingSingleLineTextParser):
     event_data.body = body_text
 
     event = time_events.DateTimeValuesEvent(
-        date_time, definitions.TIME_DESCRIPTION_ADDED)
+        date_time, definitions.TIME_DESCRIPTION_ADDED,
+        time_zone=parser_mediator.timezone
+        )
     parser_mediator.ProduceEventWithEventData(event, event_data)
 
   def VerifyStructure(self, parser_mediator, line):

--- a/plaso/parsers/dpkg.py
+++ b/plaso/parsers/dpkg.py
@@ -171,8 +171,7 @@ class DpkgParser(text_parser.PyparsingSingleLineTextParser):
 
     event = time_events.DateTimeValuesEvent(
         date_time, definitions.TIME_DESCRIPTION_ADDED,
-        time_zone=parser_mediator.timezone
-        )
+        time_zone=parser_mediator.timezone)
     parser_mediator.ProduceEventWithEventData(event, event_data)
 
   def VerifyStructure(self, parser_mediator, line):


### PR DESCRIPTION
## One line description of pull request

dpkg currently ignores the --timezone flag. 

## Description:

These changes mirror code seen in sophos_av [here](https://github.com/log2timeline/plaso/blob/720d553af5b7f4c7ad4e35dcd2a71a802608dbfa/plaso/parsers/sophos_av.py#L89) and [here](https://github.com/log2timeline/plaso/blob/720d553af5b7f4c7ad4e35dcd2a71a802608dbfa/plaso/parsers/sophos_av.py#L101) and vsftpd [here](https://github.com/log2timeline/plaso/blob/720d553af5b7f4c7ad4e35dcd2a71a802608dbfa/plaso/parsers/vsftpd.py#L95) and [here](https://github.com/log2timeline/plaso/blob/720d553af5b7f4c7ad4e35dcd2a71a802608dbfa/plaso/parsers/vsftpd.py#L106) to have dpkg properly apply the time zone.

Fixes #4143

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [X] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [x] Reviewer assigned
