### PR TITLE
Added tag for system waking from sleep

### DIFF
--- a/data/tag_windows.txt
+++ b/data/tag_windows.txt
@@ -100,7 +100,7 @@ system_sleep
 
 # Tags system wake events.
 system_wake
-data_type is 'windows:evtx:record' AND source_name is 'Microsoft-Windows-Power-Troubleshooter' AND event_identifier is '1'
+data_type is 'windows:evtx:record' AND source_name is 'Microsoft-Windows-Power-Troubleshooter' AND event_identifier is 1
 
 # Tags auto run events.
 autorun

--- a/data/tag_windows.txt
+++ b/data/tag_windows.txt
@@ -100,7 +100,7 @@ system_sleep
 
 # Tags system wake events.
 system_wake
-  data_type is 'windows:evtx:record' AND source_name is 'Microsoft-Windows-Power-Troubleshooter' AND event_identifier is 1
+  data_type is 'windows:evtx:record' AND (provider_identifier is '{cdc05e28-c449-49c6-b9d2-88cf761644df}' OR source_name is 'Microsoft-Windows-Power-Troubleshooter') AND event_identifier is 1
 
 # Tags auto run events.
 autorun

--- a/data/tag_windows.txt
+++ b/data/tag_windows.txt
@@ -100,7 +100,7 @@ system_sleep
 
 # Tags system wake events.
 system_wake
-data_type is 'windows:evtx:record' AND source_name is 'Microsoft-Windows-Power-Troubleshooter' AND event_identifier is 1
+  data_type is 'windows:evtx:record' AND source_name is 'Microsoft-Windows-Power-Troubleshooter' AND event_identifier is 1
 
 # Tags auto run events.
 autorun

--- a/data/tag_windows.txt
+++ b/data/tag_windows.txt
@@ -98,6 +98,10 @@ system_start
 system_sleep
   data_type is 'windows:evtx:record' AND source_name is 'Microsoft-Windows-Kernel-Power' AND event_identifier is 42
 
+# Tags system wake events.
+system_wake
+data_type is 'windows:evtx:record' AND source_name is 'Microsoft-Windows-Power-Troubleshooter' AND event_identifier is '1'
+
 # Tags auto run events.
 autorun
   data_type is 'windows:registry:boot_execute' AND (value contains '.exe' OR value contains '.dll')

--- a/tests/data/tag_windows.py
+++ b/tests/data/tag_windows.py
@@ -534,6 +534,18 @@ class WindowsTaggingFileTest(test_lib.TaggingFileTestCase):
         winevtx.WinEvtxRecordEventData, attribute_values_per_name,
         ['system_sleep'])
 
+  def testSystemWake(self):
+    """Tests the system_wake tagging rule."""
+    # Test: data_type is 'windows:evtx:record' AND
+    #       source_name is 'Microsoft-Windows-Power-Troubleshooter' AND
+    #       event_identifier is 1
+    attribute_values_per_name = {
+        'event_identifier': [1],
+        'source_name': ['Microsoft-Windows-Power-Troubleshooter']}
+    self._CheckTaggingRule(
+        winevtx.WinEvtxRecordEventData, attribute_values_per_name,
+        ['system_wake'])
+
   def testAutorun(self):
     """Tests the autorun tagging rule."""
     # Test: data_type is 'windows:registry:boot_execute' AND

--- a/tests/data/tag_windows.py
+++ b/tests/data/tag_windows.py
@@ -536,11 +536,13 @@ class WindowsTaggingFileTest(test_lib.TaggingFileTestCase):
 
   def testSystemWake(self):
     """Tests the system_wake tagging rule."""
-    # Test: data_type is 'windows:evtx:record' AND
-    #       source_name is 'Microsoft-Windows-Power-Troubleshooter' AND
+    # Test: data_type is 'windows:evtx:record' AND (
+    #       provider_identifier is '{cdc05e28-c449-49c6-b9d2-88cf761644df}' OR
+    #       source_name is 'Microsoft-Windows-Power-Troubleshooter') AND
     #       event_identifier is 1
     attribute_values_per_name = {
         'event_identifier': [1],
+        'provider_identifier': ['{cdc05e28-c449-49c6-b9d2-88cf761644df}'],
         'source_name': ['Microsoft-Windows-Power-Troubleshooter']}
     self._CheckTaggingRule(
         winevtx.WinEvtxRecordEventData, attribute_values_per_name,

--- a/tests/data/tag_windows.py
+++ b/tests/data/tag_windows.py
@@ -542,7 +542,13 @@ class WindowsTaggingFileTest(test_lib.TaggingFileTestCase):
     #       event_identifier is 1
     attribute_values_per_name = {
         'event_identifier': [1],
-        'provider_identifier': ['{cdc05e28-c449-49c6-b9d2-88cf761644df}'],
+        'provider_identifier': ['{cdc05e28-c449-49c6-b9d2-88cf761644df}']}
+    self._CheckTaggingRule(
+        winevtx.WinEvtxRecordEventData, attribute_values_per_name,
+        ['system_wake'])
+
+    attribute_values_per_name = {
+        'event_identifier': [1],
         'source_name': ['Microsoft-Windows-Power-Troubleshooter']}
     self._CheckTaggingRule(
         winevtx.WinEvtxRecordEventData, attribute_values_per_name,


### PR DESCRIPTION
Event ID- 1 from source- Microsoft-Windows-Power-Troubleshooter explicitly identifies that the system has returned from a low power state. The event also contains the exact times that the system went to sleet and woke up, as opposed to when sleep mode was initiated.

Refer to the screenshot in https://answers.microsoft.com/en-us/windows/forum/all/windows-wakes-up-unwantedly/fc50b926-3a26-420d-aa91-6ba796ca7f2a for an example.

This event could have its own tag as proposed or it could also make sense to add it to the system start events tag.

## One line description of pull request



## Description: Edit plaso/data/tag_windows.txt to add tag for system waking from sleep.


**Related issue (if applicable): N/A

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [x] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
