### PR TITLE
Changed Dockerfile to use single RUN statement for similar commands

### DIFF
--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -13,21 +13,18 @@ ARG PPA_TRACK=stable
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Combining the apt-get commands into a single run reduces the size of the resulting image.
+# The apt-get installations below are interdependent and need to be done in sequence.
 RUN apt-get -y update && \
     apt-get -y install apt-transport-https apt-utils && \
     apt-get -y install libterm-readline-gnu-perl software-properties-common && \
-    add-apt-repository -y ppa:gift/$PPA_TRACK && \
-    \
-    apt-get -y update && \
+    add-apt-repository -y ppa:gift/$PPA_TRACK && apt-get -y update &&
     apt-get -y upgrade && \
-    \
     apt-get -y install locales plaso-tools && \
-    \
     apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
 # Set terminal to UTF-8 by default
-RUN locale-gen en_US.UTF-8 && \
-    update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 

--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:jammy
-MAINTAINER Log2Timeline <log2timeline-dev@googlegroups.com>
+LABEL maintainer="Log2Timeline <log2timeline-dev@googlegroups.com>"
 
 # Create container with:
 # docker build --no-cache --build-arg PPA_TRACK="[dev|stable]" \
@@ -13,22 +13,21 @@ ARG PPA_TRACK=stable
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -y update
-RUN apt-get -y install apt-transport-https apt-utils
-RUN apt-get -y install libterm-readline-gnu-perl software-properties-common
-RUN add-apt-repository -y ppa:gift/$PPA_TRACK
-
-RUN apt-get -y update
-RUN apt-get -y upgrade
-
-RUN apt-get -y install locales plaso-tools
-
-# Clean up apt-get cache files
-RUN apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+RUN apt-get -y update;\
+    apt-get -y install apt-transport-https apt-utils;\
+    apt-get -y install libterm-readline-gnu-perl software-properties-common;\
+    add-apt-repository -y ppa:gift/$PPA_TRACK;\
+    \
+    apt-get -y update;\
+    apt-get -y upgrade;\
+    \
+    apt-get -y install locales plaso-tools;\
+    \
+    apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
 # Set terminal to UTF-8 by default
-RUN locale-gen en_US.UTF-8
-RUN update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+RUN locale-gen en_US.UTF-8;\
+    update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 

--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -13,20 +13,20 @@ ARG PPA_TRACK=stable
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -y update;\
-    apt-get -y install apt-transport-https apt-utils;\
-    apt-get -y install libterm-readline-gnu-perl software-properties-common;\
-    add-apt-repository -y ppa:gift/$PPA_TRACK;\
+RUN apt-get -y update && \
+    apt-get -y install apt-transport-https apt-utils && \
+    apt-get -y install libterm-readline-gnu-perl software-properties-common && \
+    add-apt-repository -y ppa:gift/$PPA_TRACK && \
     \
-    apt-get -y update;\
-    apt-get -y upgrade;\
+    apt-get -y update && \
+    apt-get -y upgrade && \
     \
-    apt-get -y install locales plaso-tools;\
+    apt-get -y install locales plaso-tools && \
     \
     apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
 # Set terminal to UTF-8 by default
-RUN locale-gen en_US.UTF-8;\
+RUN locale-gen en_US.UTF-8 && \
     update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8


### PR DESCRIPTION
This commit reduces the size of plaso docker images and implements best practices for Dockerfiles.



## Description:

This commit merges subsequent apt calls into one RUN command in the Dockerfile. This reduces the number of layers created and the total size of the container image:

```
REPOSITORY           TAG       IMAGE ID       CREATED             SIZE
log2timeline/plaso   test      873096d9c022   20 minutes ago      410MB
log2timeline/plaso   latest    51cc3cae181f   26 minutes ago      453MB
```

(`test` is after changing the Dockerfile.)

Furthermore, the deprecated MAINTAINER statement is replaced by the recommended LABEL statement.

The problems were identified i.a. by using `trivy config Dockerfile`. (see https://github.com/aquasecurity/trivy)

The commit does not change the logic or order of the commands in the Dockerfile.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
