### PR TITLE
Add timeline_id on the event level

### DIFF
--- a/plaso/output/opensearch_ts.py
+++ b/plaso/output/opensearch_ts.py
@@ -33,11 +33,13 @@ class OpenSearchTimesketchOutputModule(
       output_mediator (OutputMediator): mediates interactions between output
           modules and other components, such as storage and dfVFS.
       field_values (dict[str, str]): output field values per name.
-    """
-    event_document = {
-        '__ts_timeline_id': self._timeline_identifier,
-        'index': {'_index': self._index_name}}
+    """    
+    event_document = {'index': {'_index': self._index_name}}
 
+    # Add timeline_id on the event level. It is used in Timesketch to
+    # support shared indices.
+    field_values['__ts_timeline_id'] = self._timeline_identifier
+    
     self._event_documents.append(event_document)
     self._event_documents.append(field_values)
     self._number_of_buffered_events += 1


### PR DESCRIPTION
## One line description of pull request
Add timeline_id on the event level when indexing to opensearch Timesketch.


## Description:
The header line for bulk inserts was changed to include the timeline_id. This breaks the format that opensearch expects. This PR moves the timeline_id back to the event level.

**Related issue (if applicable):** fixes #<plaso issue number here>

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [ ] Automated checks (GitHub Actions, AppVeyor) pass
* [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
* [ ] Reviewer assigned
