### PR TITLE
Add data type counter to storage

### DIFF
--- a/plaso/containers/counts.py
+++ b/plaso/containers/counts.py
@@ -5,6 +5,33 @@ from acstore.containers import interface
 from acstore.containers import manager
 
 
+class DataTypeCount(interface.AttributeContainer):
+  """Data type count attribute container.
+
+  Attributes:
+    name (str): name of the data type.
+    number_of_events (int): number of events generated with this data type.
+  """
+
+  CONTAINER_TYPE = 'data_type_count'
+
+  SCHEMA = {
+      'name': 'str',
+      'number_of_events': 'int'}
+
+  def __init__(self, name=None, number_of_events=None):
+    """Initializes a data type count attribute container.
+
+    Args:
+      name (Optional[str]): name of the data type.
+      number_of_events (Optional[int]): number of events generated with this
+          data type.
+    """
+    super(DataTypeCount, self).__init__()
+    self.name = name
+    self.number_of_events = number_of_events
+
+
 class EventLabelCount(interface.AttributeContainer):
   """Event label count attribute container.
 
@@ -61,4 +88,4 @@ class ParserCount(interface.AttributeContainer):
 
 
 manager.AttributeContainersManager.RegisterAttributeContainers([
-    EventLabelCount, ParserCount])
+    DataTypeCount, EventLabelCount, ParserCount])

--- a/plaso/engine/timeliner.py
+++ b/plaso/engine/timeliner.py
@@ -19,6 +19,7 @@ class EventDataTimeliner(object):
   """The event data timeliner.
 
   Attributes:
+    data_types_counter (collections.Counter): number of events per data types.
     number_of_produced_events (int): number of produced events.
     parsers_counter (collections.Counter): number of events per parser or
         parser plugin.
@@ -50,6 +51,7 @@ class EventDataTimeliner(object):
     self._preferred_year = preferred_year
     self._system_configurations = system_configurations
 
+    self.data_types_counter = collections.Counter()
     self.number_of_produced_events = 0
     self.parsers_counter = collections.Counter()
 
@@ -280,6 +282,8 @@ class EventDataTimeliner(object):
         event_data.data_type not in self._place_holder_event):
       return
 
+    data_type_name = getattr(event_data, 'data_type', None)
+
     parser_name = None
     parser_chain = getattr(event_data, '_parser_chain', None)
     if parser_chain:
@@ -305,6 +309,10 @@ class EventDataTimeliner(object):
 
         number_of_events += 1
 
+        if data_type_name:
+          self.data_types_counter[data_type_name] += 1
+        self.data_types_counter['total'] += 1
+
         if parser_name:
           self.parsers_counter[parser_name] += 1
         self.parsers_counter['total'] += 1
@@ -321,6 +329,10 @@ class EventDataTimeliner(object):
           definitions.TIME_DESCRIPTION_NOT_A_TIME)
 
       storage_writer.AddAttributeContainer(event)
+
+      if data_type_name:
+        self.data_types_counter[data_type_name] += 1
+      self.data_types_counter['total'] += 1
 
       if parser_name:
         self.parsers_counter[parser_name] += 1


### PR DESCRIPTION
## One line description of pull request

Introduces a new data type counter into storage file.

## Description:

This patch add a new `data_type_count` counter into plaso storage file.

While the `parser_count` counter does a good job to describe "how" events are generated, this new counter allows a better overview of "what" kinds of event are actually stored in the storage file (i.e. data_type).

The patches does three things:

- Add a new `DataTypeCount` counter which add a new `data_type_count` table into storage file
- The container is populated by the extraction engine
- Pinfo is modified to display the data type counter in the "event" section

This patch is a pre-requisite for an upcoming patch series focusing on **additional fields** exploitation. The later is actually only usable when events are narrowed down to a single data type. For instance, specifying `--additional_fields event_identifier,source_name` only make sense when event data type is `windows:evtx:record`. Having the data type counter in storage avoid brute-forcing all possible combinations of data_types/additional_fields.

_PS:_ It is very likely that the storage version needs to be upgraded since it might lead to inconsistency with existing storage files.

_PS-2:_ The patch has a lots of duplicate/similar code with the `parser_count`. I intentionaly did not factorize the code to ease reviewing. Let me know if you want this MR to actually include it.


## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [ ] Automated checks (GitHub Actions, AppVeyor) pass
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
* [ ] Reviewer assigned
