### PR TITLE
Added check for already-deserialized pathspecs, add test for serializers

### DIFF
--- a/plaso/storage/serializers.py
+++ b/plaso/storage/serializers.py
@@ -55,17 +55,19 @@ class JSONPathSpecAttributeSerializer(acstore_interface.AttributeSerializer):
     Returns:
       dfvfs.PathSpec: runtime value.
     """
-    json_dict = json.loads(value)
+    # Some parent pathspecs may already be deserialized.
+    # See issue #4655 for more detail.
+    if isinstance(value, dict):
+      json_dict = value
+    else:
+      json_dict = json.loads(value)
 
     type_indicator = json_dict.get('type_indicator', None)
     if type_indicator:
       del json_dict['type_indicator']
 
     if 'parent' in json_dict:
-      # Some parent pathspecs may already be deserialized.
-      # See issue #4655 for more detail.
-      if isinstance(json_dict['parent'], str):
-        json_dict['parent'] = self.DeserializeValue(json_dict['parent'])
+      json_dict['parent'] = self.DeserializeValue(json_dict['parent'])
 
     # Remove the class type from the JSON dictionary since we cannot pass it.
     del json_dict['__type__']

--- a/plaso/storage/serializers.py
+++ b/plaso/storage/serializers.py
@@ -62,7 +62,10 @@ class JSONPathSpecAttributeSerializer(acstore_interface.AttributeSerializer):
       del json_dict['type_indicator']
 
     if 'parent' in json_dict:
-      json_dict['parent'] = self.DeserializeValue(json_dict['parent'])
+      # Some parent pathspecs may already be deserialized.
+      # See issue #4655 for more detail.
+      if isinstance(json_dict['parent'], str):
+        json_dict['parent'] = self.DeserializeValue(json_dict['parent'])
 
     # Remove the class type from the JSON dictionary since we cannot pass it.
     del json_dict['__type__']

--- a/tests/storage/serializers.py
+++ b/tests/storage/serializers.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the serializers."""
+
+from dfdatetime import time_elements as dfdatetime_time_elements
+
+from dfvfs.lib import definitions as dfvfs_definitions
+from dfvfs.path import factory as dfvfs_path_spec_factory
+
+from plaso.storage import serializers
+from tests.storage import test_lib
+
+
+class SerializersTest(test_lib.StorageTestCase):
+  """Tests for the serializers."""
+
+  def testJSONDateTimeAttributeSerializer(self):
+    """Tests the JSON date time values attribute serializer."""
+    serializer = serializers.JSONDateTimeAttributeSerializer()
+
+    datetime_value = dfdatetime_time_elements.TimeElementsInMicroseconds(
+        is_delta=True, time_elements_tuple=(2016, 1, 1, 12, 0, 0, 30))
+
+    serialized_value = serializer.SerializeValue(datetime_value)
+    deserialized_value = serializer.DeserializeValue(serialized_value)
+
+    self.assertEqual(deserialized_value, datetime_value)
+
+  def testJSONPathSpecAttributeSerializer(self):
+    """Tests the JSON path specification attribute serializer."""
+    serializer = serializers.JSONPathSpecAttributeSerializer()
+
+    parent_path_spec = dfvfs_path_spec_factory.Factory.NewPathSpec(
+        dfvfs_definitions.TYPE_INDICATOR_OS, location='/compressed.gz')
+
+    path_spec = dfvfs_path_spec_factory.Factory.NewPathSpec(
+        dfvfs_definitions.TYPE_INDICATOR_GZIP, parent=parent_path_spec)
+
+    serialized_value = serializer.SerializeValue(path_spec)
+
+    deserialized_value = serializer.DeserializeValue(serialized_value)
+
+    self.assertEqual(deserialized_value.comparable, path_spec.comparable)
+
+
+  def testJSONStringsListAttributeSerializer(self):
+    """Tests the JSON strings list attribute serializer."""
+    serializer = serializers.JSONStringsListAttributeSerializer()
+
+    serialized_value = serializer.SerializeValue(['a', 'b', 'c'])
+    deserialized_value = serializer.DeserializeValue(serialized_value)
+
+    self.assertEqual(deserialized_value, ['a', 'b', 'c'])

--- a/tests/storage/serializers.py
+++ b/tests/storage/serializers.py
@@ -42,7 +42,6 @@ class SerializersTest(test_lib.StorageTestCase):
 
     self.assertEqual(deserialized_value.comparable, path_spec.comparable)
 
-
   def testJSONStringsListAttributeSerializer(self):
     """Tests the JSON strings list attribute serializer."""
     serializer = serializers.JSONStringsListAttributeSerializer()


### PR DESCRIPTION
## One line description of pull request

Added check for already-deserialized pathspecs, add test for serializers

## Description:


**Related issue (if applicable):** 4655

## Checklist:
* [x] Automated checks (GitHub Actions, AppVeyor) pass
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
* [x] Reviewer assigned
