### PR TITLE
printing out hex for binary in winreg hives

### DIFF
--- a/plaso/parsers/winreg_plugins/interface.py
+++ b/plaso/parsers/winreg_plugins/interface.py
@@ -289,8 +289,11 @@ class WindowsRegistryPlugin(plugins.BasePlugin):
                 registry_value.DataIsString()):
             value_string = '{0!s}'.format(value_object)
 
+          elif registry_value.DataIsBinaryData():
+            value_string = '0x{}'.format(value_object.hex())
+
           else:
-            # Represent remaining types like REG_BINARY and
+            # Represent remaining types like
             # REG_RESOURCE_REQUIREMENT_LIST.
             value_string = '({0:d} bytes)'.format(len(value_object))
 

--- a/tests/parsers/winreg_plugins/default.py
+++ b/tests/parsers/winreg_plugins/default.py
@@ -86,7 +86,8 @@ class TestDefaultRegistry(test_lib.RegistryPluginTestCase):
         'values': [
             ('MRUList', 'REG_SZ', 'acb'),
             ('a', 'REG_SZ', 'Some random text here'),
-            ('b', 'REG_BINARY', '(22 bytes)'),
+            ('b', 'REG_BINARY',
+             '0x63003a002f006500760069006c002e00650078006500'),
             ('c', 'REG_SZ', 'C:/looks_legit.exe')]}
 
     event_data = storage_writer.GetAttributeContainerByIndex('event_data', 0)

--- a/tests/parsers/winreg_plugins/interface.py
+++ b/tests/parsers/winreg_plugins/interface.py
@@ -217,7 +217,7 @@ class WindowsRegistryPluginTest(test_lib.RegistryPluginTestCase):
     plugin = interface.WindowsRegistryPlugin()
 
     expected_value_tuples = [
-        ('MRUList', 'REG_BINARY', '(2 bytes)'),
+        ('MRUList', 'REG_BINARY', '0x6100'),
         ('a', 'REG_SZ', 'one')]
 
     value_tuples = plugin._GetValuesFromKey(parser_mediator, registry_key)

--- a/tests/parsers/winreg_plugins/programscache.py
+++ b/tests/parsers/winreg_plugins/programscache.py
@@ -106,11 +106,14 @@ class ExplorerProgramCacheWindowsRegistryPluginTest(
         'key_path': key_path,
         'last_written_time': '2009-08-04T15:22:18.4196250+00:00',
         'values': [
-            ('StartMenu_Start_Time', 'REG_BINARY', '(8 bytes)'),
-            ('FavoritesResolve', 'REG_BINARY', '(8 bytes)'),
-            ('Favorites', 'REG_BINARY', '(55 bytes)'),
+            ('StartMenu_Start_Time', 'REG_BINARY', '0x74da83131615ca01'),
+            ('FavoritesResolve', 'REG_BINARY', '0x0000000000000000'),
+            ('Favorites', 'REG_BINARY',
+             ('0x001600000014001f80f4a15925d721d411bdaf00c04f60b9f'
+             '00000001600000014001f80f5a15925d721d411bdaf00c04f60b9'
+             'f00000ff')),
             ('FavoritesChanges', 'REG_DWORD_LE', '1'),
-            ('StartMenu_Balloon_Time', 'REG_BINARY', '(8 bytes)')]}
+            ('StartMenu_Balloon_Time', 'REG_BINARY', '0xba9dd4441715ca01')]}
 
     event_data = storage_writer.GetAttributeContainerByIndex('event_data', 26)
     self.CheckEventData(event_data, expected_event_values)


### PR DESCRIPTION
## One line description of pull request

Changing binary output in winreg from summary of bytes to actual outputs.


## Description:

Analysts sometimes have the need to read the binary data in a registry value, so this changes binary to be output as hex.
