### PR TITLE
message formatter for opensearch output

### DIFF
--- a/plaso/output/shared_opensearch.py
+++ b/plaso/output/shared_opensearch.py
@@ -38,6 +38,7 @@ class SharedOpenSearchFieldFormattingHelper(
       'datetime': '_FormatDateTime',
       'display_name': '_FormatDisplayName',
       'inode': '_FormatInode',
+      'message': '_FormatMessage',
       'source_long': '_FormatSource',
       'source_short': '_FormatSourceShort',
       'tag': '_FormatTag',

--- a/tests/output/shared_opensearch.py
+++ b/tests/output/shared_opensearch.py
@@ -129,7 +129,7 @@ class SharedOpenSearchOutputModuleTest(test_lib.OutputModuleTestCase):
         'display_name': 'FAKE:log/syslog.1',
         'filename': 'log/syslog.1',
         'hostname': 'ubuntu',
-        'message': '-',
+        'message': '[',
         'my_number': 123,
         'path_spec': (
             '{"__type__": "PathSpec", "location": "log/syslog.1", '


### PR DESCRIPTION
## One line description of pull request
Adding back message formatter for opensearch output

## Description:
The FIELD_FORMAT_CALLBACK for the message field was removed in #4614 . This PR adds it back so that custom formatter can be used.

**Related issue (if applicable):** fixes #<plaso issue number here>

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [x] Automated checks (GitHub Actions, AppVeyor) pass
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
* [x] Reviewer assigned
