### PR TITLE
Support multiline bash_history

### DIFF
--- a/plaso/parsers/text_plugins/bash_history.py
+++ b/plaso/parsers/text_plugins/bash_history.py
@@ -45,7 +45,11 @@ class BashHistoryTextPlugin(interface.TextPlugin):
   _COMMAND_LINE = (
       pyparsing.restOfLine().setResultsName('command') + _END_OF_LINE)
 
-  _LOG_LINE = _TIMESTAMP_LINE + _COMMAND_LINE
+  _LOG_LINE_END = pyparsing.StringEnd() | (_TIMESTAMP_LINE)
+
+  _LOG_LINE = _TIMESTAMP_LINE + pyparsing.SkipTo(
+      _LOG_LINE_END).setResultsName('command') + pyparsing.ZeroOrMore(
+          _END_OF_LINE)
 
   _LINE_STRUCTURES = [('log_line', _LOG_LINE)]
 

--- a/plaso/parsers/text_plugins/powershell_transcript.py
+++ b/plaso/parsers/text_plugins/powershell_transcript.py
@@ -130,7 +130,7 @@ class PowerShellTranscriptLogTextPlugin(interface.TextPlugin):
   # TODO: handle footer with end time.
 
   def __init__(self):
-    """Initializes instance attributes needed for processing."""
+    """Initializes a text parser plugin."""
     super(PowerShellTranscriptLogTextPlugin, self).__init__()
     self._command_history = []
     self._event_data = None

--- a/test_data/bash_history
+++ b/test_data/bash_history
@@ -4,3 +4,8 @@
 /bin/bash
 #1380630979
 /usr/local/bin/splunk -p 8080
+#1623364236
+binary argument1 "--params=\
+param1=foo,
+param2=bar
+" argument2

--- a/test_data/bash_history_desync
+++ b/test_data/bash_history_desync
@@ -5,3 +5,8 @@
 /bin/bash
 #1380630979
 /usr/local/bin/splunk -p 8080
+#1623364236
+binary argument1 "--params=\
+param1=foo,
+param2=bar
+" argument2

--- a/tests/parsers/text_plugins/bash_history.py
+++ b/tests/parsers/text_plugins/bash_history.py
@@ -26,7 +26,7 @@ class BashHistoryTextPluginTest(test_lib.TextPluginTestCase):
     """
     number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
         'event_data')
-    self.assertEqual(number_of_event_data, 3)
+    self.assertEqual(number_of_event_data, 4)
 
     number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
         'extraction_warning')
@@ -42,6 +42,17 @@ class BashHistoryTextPluginTest(test_lib.TextPluginTestCase):
         'written_time': '2013-10-01T12:36:17+00:00'}
 
     event_data = storage_writer.GetAttributeContainerByIndex('event_data', 0)
+    self.CheckEventData(event_data, expected_event_values)
+
+    # Test multiline
+    expected_event_values = {
+        'command':
+            ('binary argument1 "--params=\\\n'
+            'param1=foo,\nparam2=bar\n" argument2'),
+        'data_type': 'bash:history:entry',
+        'written_time': '2021-06-10T22:30:36+00:00'}
+
+    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 3)
     self.CheckEventData(event_data, expected_event_values)
 
   def testCheckRequiredFormat(self):

--- a/tests/parsers/text_plugins/bash_history.py
+++ b/tests/parsers/text_plugins/bash_history.py
@@ -15,46 +15,6 @@ from tests.parsers.text_plugins import test_lib
 class BashHistoryTextPluginTest(test_lib.TextPluginTestCase):
   """Testd for the bash history text parser plugin."""
 
-  def _TestEventsFromFile(
-      self, storage_writer, expected_number_of_extraction_warnings=0):
-    """Validates that all events are as expected.
-
-    Args:
-      storage_writer (FakeStorageWriter): storage writer.
-      expected_number_of_extraction_warnings (Optional[int]): number of expected
-          extraction warnings.
-    """
-    number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
-        'event_data')
-    self.assertEqual(number_of_event_data, 4)
-
-    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
-        'extraction_warning')
-    self.assertEqual(number_of_warnings, expected_number_of_extraction_warnings)
-
-    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
-        'recovery_warning')
-    self.assertEqual(number_of_warnings, 0)
-
-    expected_event_values = {
-        'command': '/usr/lib/plaso',
-        'data_type': 'bash:history:entry',
-        'written_time': '2013-10-01T12:36:17+00:00'}
-
-    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 0)
-    self.CheckEventData(event_data, expected_event_values)
-
-    # Test multiline
-    expected_event_values = {
-        'command':
-            ('binary argument1 "--params=\\\n'
-            'param1=foo,\nparam2=bar\n" argument2'),
-        'data_type': 'bash:history:entry',
-        'written_time': '2021-06-10T22:30:36+00:00'}
-
-    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 3)
-    self.CheckEventData(event_data, expected_event_values)
-
   def testCheckRequiredFormat(self):
     """Tests for the CheckRequiredFormat method."""
     plugin = bash_history.BashHistoryTextPlugin()
@@ -99,7 +59,36 @@ class BashHistoryTextPluginTest(test_lib.TextPluginTestCase):
     plugin = bash_history.BashHistoryTextPlugin()
     storage_writer = self._ParseTextFileWithPlugin(['bash_history'], plugin)
 
-    self._TestEventsFromFile(storage_writer)
+    number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
+        'event_data')
+    self.assertEqual(number_of_event_data, 4)
+
+    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+        'extraction_warning')
+    self.assertEqual(number_of_warnings, 0)
+
+    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+        'recovery_warning')
+    self.assertEqual(number_of_warnings, 0)
+
+    expected_event_values = {
+        'command': '/usr/lib/plaso',
+        'data_type': 'bash:history:entry',
+        'written_time': '2013-10-01T12:36:17+00:00'}
+
+    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 0)
+    self.CheckEventData(event_data, expected_event_values)
+
+    # Test multi line.
+    expected_event_values = {
+        'command': (
+            'binary argument1 "--params=\\\n'
+            'param1=foo,\nparam2=bar\n" argument2'),
+        'data_type': 'bash:history:entry',
+        'written_time': '2021-06-10T22:30:36+00:00'}
+
+    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 3)
+    self.CheckEventData(event_data, expected_event_values)
 
   def testProcessWithDesynchronizedFile(self):
     """Tests the Process function with a desynchronized file.
@@ -111,8 +100,36 @@ class BashHistoryTextPluginTest(test_lib.TextPluginTestCase):
     storage_writer = self._ParseTextFileWithPlugin(
         ['bash_history_desync'], plugin)
 
-    self._TestEventsFromFile(
-        storage_writer, expected_number_of_extraction_warnings=1)
+    number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
+        'event_data')
+    self.assertEqual(number_of_event_data, 5)
+
+    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+        'extraction_warning')
+    self.assertEqual(number_of_warnings, 0)
+
+    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+        'recovery_warning')
+    self.assertEqual(number_of_warnings, 0)
+
+    expected_event_values = {
+        'command': '/usr/lib/plaso',
+        'data_type': 'bash:history:entry',
+        'written_time': '2013-10-01T12:36:17+00:00'}
+
+    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 1)
+    self.CheckEventData(event_data, expected_event_values)
+
+    # Test multi line.
+    expected_event_values = {
+        'command': (
+            'binary argument1 "--params=\\\n'
+            'param1=foo,\nparam2=bar\n" argument2'),
+        'data_type': 'bash:history:entry',
+        'written_time': '2021-06-10T22:30:36+00:00'}
+
+    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 4)
+    self.CheckEventData(event_data, expected_event_values)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## One line description of pull request
Support multi line commands in .bash_history

## Description:
Bash commands can be split on to more than one line using the `\` line separator.
Currently the parser doesn't look like it supports this.


**Related issue (if applicable):** fixes #4743

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [ ] Automated checks (GitHub Actions, AppVeyor) pass
* [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
* [ ] Reviewer assigned
