### PR TITLE
Fix for issue #4787

### DIFF
--- a/plaso/cli/pinfo_tool.py
+++ b/plaso/cli/pinfo_tool.py
@@ -1523,6 +1523,7 @@ class PinfoTool(tools.CLITool, tool_options.StorageFileOptions):
 
     self.AddBasicOptions(argument_parser)
     self.AddStorageOptions(argument_parser)
+    self.AddLogFileOptions(argument_parser)
 
     if self._CanEnforceProcessMemoryLimit():
       helpers_manager.ArgumentHelperManager.AddCommandLineArguments(
@@ -1607,6 +1608,8 @@ class PinfoTool(tools.CLITool, tool_options.StorageFileOptions):
       BadConfigOption: if the options are invalid.
     """
     self._ParseInformationalOptions(options)
+
+    self._ParseLogFileOptions(options)
 
     self._verbose = getattr(options, 'verbose', False)
 

--- a/plaso/cli/tools.py
+++ b/plaso/cli/tools.py
@@ -289,8 +289,9 @@ class CLITool(object):
     date_time_delta = datetime.datetime.utcnow() - version_date_time
 
     if date_time_delta.days > 180:
-      logger.warning('This version of plaso is more than 6 months old. '
-                     'We strongly recommend to update it.')
+      logger.warning((
+          'This version of plaso is more than 6 months old. We strongly '
+          'recommend to update it.'))
 
       self._PrintUserWarning((
           'the version of plaso you are using is more than 6 months old. We '

--- a/plaso/cli/tools.py
+++ b/plaso/cli/tools.py
@@ -200,8 +200,8 @@ class CLITool(object):
       warning_text (str): text used to warn the user.
     """
     warning_text = textwrap.wrap(f'WARNING: {warning_text:s}', 80)
-    print('\n'.join(warning_text))
-    print('')
+    print('\n'.join(warning_text), file=sys.stderr)
+    print('', file=sys.stderr)
 
     self._has_user_warning = True
 
@@ -289,7 +289,8 @@ class CLITool(object):
     date_time_delta = datetime.datetime.utcnow() - version_date_time
 
     if date_time_delta.days > 180:
-      logger.warning('This version of plaso is more than 6 months old.')
+      logger.warning('This version of plaso is more than 6 months old. '
+                     'We strongly recommend to update it.')
 
       self._PrintUserWarning((
           'the version of plaso you are using is more than 6 months old. We '


### PR DESCRIPTION
## One line description of pull request

Moving `_PrintUserWarning` output to stderr and adding a logfile argument to pinfo_tools. 

## Description:

This fixes the issues described in #4787

**Related issue (if applicable):** fixes #4787

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [x] Automated checks (GitHub Actions, AppVeyor) pass
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
* [x] Reviewer assigned
