### PR TITLE
Added MacOS login window plugin

### DIFF
--- a/data/formatters/macos.yaml
+++ b/data/formatters/macos.yaml
@@ -348,23 +348,31 @@ short_message: 'Launchd service config {name} points to {program} with user:{use
 short_source: 'PLIST'
 source: 'MacOS launchd plist'
 ---
-type: 'basic'
-data_type: 'macos:login_window:auto_launched_application'
-message: 'Auto-launched application: {path}'
-short_message: 'Auto-launched application: {path}'
+type: 'conditional'
+data_type: 'macos:login_window:entry'
+message:
+- 'Login hook: {login_hook}'
+- 'Logout hook: {logout_hook}'
+short_message:
+- 'Login hook: {login_hook}'
+- 'Logout hook: {logout_hook}'
 short_source: 'PLIST'
-source: 'MacOS login window plist'
+source: 'Mac OS login window plist'
 ---
 type: 'conditional'
-data_type: 'macos:login_window:hook'
+data_type: 'macos:login_window:managed_login_item'
+boolean_helpers:
+- input_attribute: 'is_hidden'
+  output_attribute: 'is_hidden_string'
+  value_if_true: '(Hidden in Users & Groups items list)'
 message:
-- 'Path: {path}'
-- 'Hook type: {hook_type}'
+- 'Auto-launched application: {path}'
+- '{is_hidden_string}'
 short_message:
-- 'Path: {path}'
-- 'Hook type: {hook_type}'
+- 'Auto-launched application: {path}'
+- '{is_hidden_string}'
 short_source: 'PLIST'
-source: 'MacOS login window plist'
+source: 'Mac OS login window plist'
 ---
 type: 'conditional'
 data_type: 'macos:startup_item:entry'

--- a/data/formatters/macos.yaml
+++ b/data/formatters/macos.yaml
@@ -348,6 +348,24 @@ short_message: 'Launchd service config {name} points to {program} with user:{use
 short_source: 'PLIST'
 source: 'MacOS launchd plist'
 ---
+type: 'basic'
+data_type: 'macos:login_window:auto_launched_application'
+message: 'Auto-launched application: {path}'
+short_message: 'Auto-launched application: {path}'
+short_source: 'PLIST'
+source: 'MacOS login window plist'
+---
+type: 'conditional'
+data_type: 'macos:login_window:hook'
+message:
+- 'Path: {path}'
+- 'Hook type: {hook_type}'
+short_message:
+- 'Path: {path}'
+- 'Hook type: {hook_type}'
+short_source: 'PLIST'
+source: 'MacOS login window plist'
+---
 type: 'conditional'
 data_type: 'macos:startup_item:entry'
 message:

--- a/data/timeliner.yaml
+++ b/data/timeliner.yaml
@@ -747,6 +747,12 @@ place_holder_event: true
 data_type: 'macos:launchd:entry'
 place_holder_event: true
 ---
+data_type: 'macos:login_window:auto_launched_application'
+place_holder_event: true
+---
+data_type: 'macos:login_window:hook'
+place_holder_event: true
+---
 data_type: 'macos:lsquarantine:entry'
 attribute_mappings:
 - name: 'downloaded_time'

--- a/data/timeliner.yaml
+++ b/data/timeliner.yaml
@@ -747,12 +747,12 @@ place_holder_event: true
 data_type: 'macos:launchd:entry'
 place_holder_event: true
 ---
-data_type: 'macos:login_window:auto_launched_application'
-# TODO: add attribute_mappings
+data_type: 'macos:login_window:entry'
+# Note that the Mac OS login window entry has no date and time values.
 place_holder_event: true
 ---
-data_type: 'macos:login_window:hook'
-# TODO: add attribute_mappings
+data_type: 'macos:login_window:managed_login_item'
+# Note that the Mac OS login window managed login item has no date and time values.
 place_holder_event: true
 ---
 data_type: 'macos:lsquarantine:entry'

--- a/data/timeliner.yaml
+++ b/data/timeliner.yaml
@@ -748,9 +748,11 @@ data_type: 'macos:launchd:entry'
 place_holder_event: true
 ---
 data_type: 'macos:login_window:auto_launched_application'
+# TODO: add attribute_mappings
 place_holder_event: true
 ---
 data_type: 'macos:login_window:hook'
+# TODO: add attribute_mappings
 place_holder_event: true
 ---
 data_type: 'macos:lsquarantine:entry'

--- a/plaso/parsers/plist_plugins/__init__.py
+++ b/plaso/parsers/plist_plugins/__init__.py
@@ -10,6 +10,7 @@ from plaso.parsers.plist_plugins import ios_carplay
 from plaso.parsers.plist_plugins import ios_identityservices
 from plaso.parsers.plist_plugins import ipod
 from plaso.parsers.plist_plugins import launchd
+from plaso.parsers.plist_plugins import macos_login_window
 from plaso.parsers.plist_plugins import macos_startup_item
 from plaso.parsers.plist_plugins import macos_user
 from plaso.parsers.plist_plugins import safari_downloads

--- a/plaso/parsers/plist_plugins/macos_login_window.py
+++ b/plaso/parsers/plist_plugins/macos_login_window.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""Plist parser plugin for MacOS login window plist files."""
+from plaso.containers import events
+from plaso.parsers import plist
+from plaso.parsers.plist_plugins import interface
+
+
+class MacOSLoginWindowAutoLaunchApplicationEventData(events.EventData):
+  """MacOS autolaunch application event data.
+
+  Attributes:
+    hidden (bool): if true, the item is hidden from the "Users & Groups" GUI.
+    path (str): A URL or path string to the item's location.
+  """
+
+  DATA_TYPE = 'macos:login_window:auto_launched_application'
+
+  def __init__(self):
+    """Initializes event data."""
+    super(MacOSLoginWindowAutoLaunchApplicationEventData, self).__init__(
+      data_type=self.DATA_TYPE
+    )
+    self.hidden = None
+    self.path = None
+
+
+class MacOSLoginWindowHookEventData(events.EventData):
+  """MacOS login window hook event data.
+
+  Attributes:
+    path (str): path to script invoked on login.
+    hook_type (str): either "login" or "logout".
+  """
+
+  DATA_TYPE = 'macos:login_window:hook'
+
+  def __init__(self):
+    """Initializes event data."""
+    super(MacOSLoginWindowHookEventData, self).__init__(
+      data_type=self.DATA_TYPE
+    )
+    self.path = None
+    self.hook_type = None
+
+
+class MacOSLoginWindowPlugin(interface.PlistPlugin):
+  """Plist parser plugin for MacOS login window plist files.
+  """
+
+  NAME = 'macos_login_window_plist'
+  DATA_FORMAT = 'MacOS login window plist file'
+
+  PLIST_PATH_FILTERS = frozenset([
+    interface.PlistPathFilter('loginwindow.plist'),
+    interface.PlistPathFilter('com.apple.loginwindow.plist'),
+  ])
+  PLIST_KEYS = frozenset([])
+
+  # pylint: disable=arguments-differ
+  def _ParsePlist(self, parser_mediator, top_level=None, **unused_kwargs):
+    """Extracts login window information from the plist.
+
+    Args:
+      parser_mediator (ParserMediator): mediates interactions between parsers
+        and other components, such as storage and dfVFS.
+      top_level (Optional[dict[str, object]]): plist top-level item.
+    """
+    for app_dict in top_level.get('AutoLaunchedApplicationDictionary', []):
+      event_data = MacOSLoginWindowAutoLaunchApplicationEventData()
+      event_data.hidden = app_dict.get('Hide')
+      event_data.path = app_dict.get('Path')
+      parser_mediator.ProduceEventData(event_data)
+
+    login_hook = top_level.get('LoginHook')
+    if login_hook is not None:
+      event_data = MacOSLoginWindowHookEventData()
+      event_data.path = login_hook
+      event_data.hook_type = 'login'
+      parser_mediator.ProduceEventData(event_data)
+
+    logout_hook = top_level.get('LogoutHook')
+    if logout_hook is not None:
+      event_data = MacOSLoginWindowHookEventData()
+      event_data.path = logout_hook
+      event_data.hook_type = 'logout'
+      parser_mediator.ProduceEventData(event_data)
+
+
+plist.PlistParser.RegisterPlugin(MacOSLoginWindowPlugin)

--- a/plaso/parsers/plist_plugins/macos_login_window.py
+++ b/plaso/parsers/plist_plugins/macos_login_window.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Plist parser plugin for MacOS login window plist files."""
+
 from plaso.containers import events
 from plaso.parsers import plist
 from plaso.parsers.plist_plugins import interface
@@ -18,8 +19,7 @@ class MacOSLoginWindowAutoLaunchApplicationEventData(events.EventData):
   def __init__(self):
     """Initializes event data."""
     super(MacOSLoginWindowAutoLaunchApplicationEventData, self).__init__(
-      data_type=self.DATA_TYPE
-    )
+        data_type=self.DATA_TYPE)
     self.hidden = None
     self.path = None
 
@@ -37,23 +37,21 @@ class MacOSLoginWindowHookEventData(events.EventData):
   def __init__(self):
     """Initializes event data."""
     super(MacOSLoginWindowHookEventData, self).__init__(
-      data_type=self.DATA_TYPE
-    )
+        data_type=self.DATA_TYPE)
     self.path = None
     self.hook_type = None
 
 
 class MacOSLoginWindowPlugin(interface.PlistPlugin):
-  """Plist parser plugin for MacOS login window plist files.
-  """
+  """Plist parser plugin for MacOS login window plist files."""
 
   NAME = 'macos_login_window_plist'
   DATA_FORMAT = 'MacOS login window plist file'
 
   PLIST_PATH_FILTERS = frozenset([
     interface.PlistPathFilter('loginwindow.plist'),
-    interface.PlistPathFilter('com.apple.loginwindow.plist'),
-  ])
+    interface.PlistPathFilter('com.apple.loginwindow.plist')])
+
   PLIST_KEYS = frozenset([])
 
   # pylint: disable=arguments-differ
@@ -62,7 +60,7 @@ class MacOSLoginWindowPlugin(interface.PlistPlugin):
 
     Args:
       parser_mediator (ParserMediator): mediates interactions between parsers
-        and other components, such as storage and dfVFS.
+          and other components, such as storage and dfVFS.
       top_level (Optional[dict[str, object]]): plist top-level item.
     """
     for app_dict in top_level.get('AutoLaunchedApplicationDictionary', []):

--- a/plaso/parsers/plist_plugins/macos_login_window.py
+++ b/plaso/parsers/plist_plugins/macos_login_window.py
@@ -1,52 +1,61 @@
 # -*- coding: utf-8 -*-
-"""Plist parser plugin for MacOS login window plist files."""
+"""Plist parser plugin for Mac OS login window plist files."""
 
 from plaso.containers import events
 from plaso.parsers import plist
 from plaso.parsers.plist_plugins import interface
 
 
-class MacOSLoginWindowAutoLaunchApplicationEventData(events.EventData):
-  """MacOS autolaunch application event data.
+class MacOSLoginWindowEventData(events.EventData):
+  """Mac OS login window event data.
+
+  Also see:
+  * https://developer.apple.com/documentation/devicemanagement/loginwindow
+  * https://developer.apple.com/documentation/devicemanagement/
+    loginwindowscripts
 
   Attributes:
-    hidden (bool): if true, the item is hidden from the "Users & Groups" GUI.
-    path (str): A URL or path string to the item's location.
+    login_hook (str): path of the script to run during login.
+    logout_hook (str): path of the script to run during logout.
   """
 
-  DATA_TYPE = 'macos:login_window:auto_launched_application'
+  DATA_TYPE = 'macos:login_window:entry'
 
   def __init__(self):
     """Initializes event data."""
-    super(MacOSLoginWindowAutoLaunchApplicationEventData, self).__init__(
-        data_type=self.DATA_TYPE)
-    self.hidden = None
-    self.path = None
+    super(MacOSLoginWindowEventData, self).__init__(data_type=self.DATA_TYPE)
+    self.login_hook = None
+    self.logout_hook = None
 
 
-class MacOSLoginWindowHookEventData(events.EventData):
-  """MacOS login window hook event data.
+class MacOSLoginWindowManagedLoginItemEventData(events.EventData):
+  """Mac OS login window managed login item event data.
+
+  Also see:
+  * https://developer.apple.com/documentation/devicemanagement/
+    loginitemsmanageditems/loginitem
 
   Attributes:
-    path (str): path to script invoked on login.
-    hook_type (str): either "login" or "logout".
+    is_hidden (bool): True if the item should is not shown in the "Users &
+        Groups" items list.
+    path (str): URL or path of the location of the item.
   """
 
-  DATA_TYPE = 'macos:login_window:hook'
+  DATA_TYPE = 'macos:login_window:managed_login_item'
 
   def __init__(self):
     """Initializes event data."""
-    super(MacOSLoginWindowHookEventData, self).__init__(
+    super(MacOSLoginWindowManagedLoginItemEventData, self).__init__(
         data_type=self.DATA_TYPE)
+    self.is_hidden = None
     self.path = None
-    self.hook_type = None
 
 
 class MacOSLoginWindowPlugin(interface.PlistPlugin):
-  """Plist parser plugin for MacOS login window plist files."""
+  """Plist parser plugin for Mac OS login window plist files."""
 
   NAME = 'macos_login_window_plist'
-  DATA_FORMAT = 'MacOS login window plist file'
+  DATA_FORMAT = 'Mac OS login window plist file'
 
   PLIST_PATH_FILTERS = frozenset([
     interface.PlistPathFilter('loginwindow.plist'),
@@ -63,25 +72,16 @@ class MacOSLoginWindowPlugin(interface.PlistPlugin):
           and other components, such as storage and dfVFS.
       top_level (Optional[dict[str, object]]): plist top-level item.
     """
-    for app_dict in top_level.get('AutoLaunchedApplicationDictionary', []):
-      event_data = MacOSLoginWindowAutoLaunchApplicationEventData()
-      event_data.hidden = app_dict.get('Hide')
-      event_data.path = app_dict.get('Path')
+    for item in top_level.get('AutoLaunchedApplicationDictionary', []):
+      event_data = MacOSLoginWindowManagedLoginItemEventData()
+      event_data.is_hidden = item.get('Hide')
+      event_data.path = item.get('Path')
       parser_mediator.ProduceEventData(event_data)
 
-    login_hook = top_level.get('LoginHook')
-    if login_hook is not None:
-      event_data = MacOSLoginWindowHookEventData()
-      event_data.path = login_hook
-      event_data.hook_type = 'login'
-      parser_mediator.ProduceEventData(event_data)
-
-    logout_hook = top_level.get('LogoutHook')
-    if logout_hook is not None:
-      event_data = MacOSLoginWindowHookEventData()
-      event_data.path = logout_hook
-      event_data.hook_type = 'logout'
-      parser_mediator.ProduceEventData(event_data)
+    event_data = MacOSLoginWindowEventData()
+    event_data.login_hook = top_level.get('LoginHook')
+    event_data.logout_hook = top_level.get('LogoutHook')
+    parser_mediator.ProduceEventData(event_data)
 
 
 plist.PlistParser.RegisterPlugin(MacOSLoginWindowPlugin)

--- a/test_data/loginwindow.plist
+++ b/test_data/loginwindow.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AutoLaunchedApplicationDictionary</key>
+	<array>
+		<dict>
+			<key>Hide</key>
+			<true/>
+			<key>Path</key>
+			<string>/Applications/SafeConnect.app</string>
+		</dict>
+	</array>
+	<key>Vendor</key>
+	<dict>
+		<key>ID</key>
+		<string>SafeConnect</string>
+	</dict>
+	<key>LoginHook</key>
+	<string>/Users/matthew/login.sh</string>
+	<key>LogoutHook</key>
+	<string>/Users/matthew/logout.sh</string>
+</dict>
+</plist>

--- a/tests/parsers/plist_plugins/macos_login_window.py
+++ b/tests/parsers/plist_plugins/macos_login_window.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Tests for the MacOS login window plist plugin."""
+"""Tests for the Mac OS login window plist plugin."""
 import unittest
 
 from plaso.parsers.plist_plugins import macos_login_window
@@ -9,7 +9,7 @@ from tests.parsers.plist_plugins import test_lib
 
 
 class MacOSLoginWindowPlistPluginTest(test_lib.PlistPluginTestCase):
-  """Tests for the MacOS login window plist plugin."""
+  """Tests for the Mac OS login window plist plugin."""
 
   def testProcess(self):
     """Tests the Process function."""
@@ -21,7 +21,7 @@ class MacOSLoginWindowPlistPluginTest(test_lib.PlistPluginTestCase):
 
     number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
         'event_data')
-    self.assertEqual(number_of_event_data, 3)
+    self.assertEqual(number_of_event_data, 2)
 
     number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
         'extraction_warning')
@@ -31,29 +31,21 @@ class MacOSLoginWindowPlistPluginTest(test_lib.PlistPluginTestCase):
         'recovery_warning')
     self.assertEqual(number_of_warnings, 0)
 
-    expected_autolaunch_event = {
-        'data_type': 'macos:login_window:auto_launched_application',
-        'hidden': True,
-        'path': '/Applications/SafeConnect.app',
-    }
+    expected_event_values = {
+        'data_type': 'macos:login_window:managed_login_item',
+        'is_hidden': True,
+        'path': '/Applications/SafeConnect.app'}
+
     event_data = storage_writer.GetAttributeContainerByIndex('event_data', 0)
-    self.CheckEventData(event_data, expected_autolaunch_event)
+    self.CheckEventData(event_data, expected_event_values)
 
-    expected_login_hook_event = {
-        'data_type': 'macos:login_window:hook',
-        'path': '/Users/matthew/login.sh',
-        'hook_type': 'login',
-    }
+    expected_event_values = {
+        'data_type': 'macos:login_window:entry',
+        'login_hook': '/Users/matthew/login.sh',
+        'logout_hook': '/Users/matthew/logout.sh'}
+
     event_data = storage_writer.GetAttributeContainerByIndex('event_data', 1)
-    self.CheckEventData(event_data, expected_login_hook_event)
-
-    expected_logout_hook_event = {
-        'data_type': 'macos:login_window:hook',
-        'path': '/Users/matthew/logout.sh',
-        'hook_type': 'logout',
-    }
-    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 2)
-    self.CheckEventData(event_data, expected_logout_hook_event)
+    self.CheckEventData(event_data, expected_event_values)
 
 
 if __name__ == '__main__':

--- a/tests/parsers/plist_plugins/macos_login_window.py
+++ b/tests/parsers/plist_plugins/macos_login_window.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the MacOS login window plist plugin."""
+import unittest
+
+from plaso.parsers.plist_plugins import macos_login_window
+
+from tests.parsers.plist_plugins import test_lib
+
+
+class MacOSLoginWindowPlistPluginTest(test_lib.PlistPluginTestCase):
+  """Tests for the MacOS login window plist plugin."""
+
+  def testProcess(self):
+    """Tests the Process function."""
+    plist_name = 'loginwindow.plist'
+
+    plugin = macos_login_window.MacOSLoginWindowPlugin()
+    storage_writer = self._ParsePlistFileWithPlugin(
+        plugin, [plist_name], plist_name)
+
+    number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
+        'event_data')
+    self.assertEqual(number_of_event_data, 3)
+
+    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+        'extraction_warning')
+    self.assertEqual(number_of_warnings, 0)
+
+    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+        'recovery_warning')
+    self.assertEqual(number_of_warnings, 0)
+
+    expected_autolaunch_event = {
+        'data_type': 'macos:login_window:auto_launched_application',
+        'hidden': True,
+        'path': '/Applications/SafeConnect.app',
+    }
+    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 0)
+    self.CheckEventData(event_data, expected_autolaunch_event)
+
+    expected_login_hook_event = {
+        'data_type': 'macos:login_window:hook',
+        'path': '/Users/matthew/login.sh',
+        'hook_type': 'login',
+    }
+    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 1)
+    self.CheckEventData(event_data, expected_login_hook_event)
+
+    expected_logout_hook_event = {
+        'data_type': 'macos:login_window:hook',
+        'path': '/Users/matthew/logout.sh',
+        'hook_type': 'logout',
+    }
+    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 2)
+    self.CheckEventData(event_data, expected_logout_hook_event)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
## One line description of pull request

Adds a parser for MacOS login window data containing autolaunch applications + login/logout hook scripts.

## Description:

Covers data stored in `/var/root/Library/Preferences/com.apple.loginwindow.plist`. Note this does not cover `%%users.homedir%%/Library/Preferences/ByHost/com.apple.loginwindow.*.plist` artifacts.

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [x] Automated checks (GitHub Actions, AppVeyor) pass
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
* [x] Reviewer assigned
