### PR TITLE
Added MacOS startup item plugin

### DIFF
--- a/data/formatters/macos.yaml
+++ b/data/formatters/macos.yaml
@@ -349,6 +349,20 @@ short_source: 'PLIST'
 source: 'MacOS launchd plist'
 ---
 type: 'conditional'
+data_type: 'macos:startupitem:entry'
+message:
+- 'Startup item: [{description}]'
+- 'Provides: {provides}'
+- 'Order Preference: {order_preference}'
+- 'Requires: {requires}'
+- 'Uses: {uses}'
+short_message:
+- 'Startup item: [{description}]'
+- 'Provides: {provides}'
+short_source: 'PLIST'
+source: 'MacOS startup item plist'
+---
+type: 'conditional'
 data_type: 'macos:securityd_log:entry'
 message:
 - 'Sender: {sender}'

--- a/data/formatters/macos.yaml
+++ b/data/formatters/macos.yaml
@@ -349,7 +349,7 @@ short_source: 'PLIST'
 source: 'MacOS launchd plist'
 ---
 type: 'conditional'
-data_type: 'macos:startupitem:entry'
+data_type: 'macos:startup_item:entry'
 message:
 - 'Startup item: [{description}]'
 - 'Provides: {provides}'

--- a/data/timeliner.yaml
+++ b/data/timeliner.yaml
@@ -781,8 +781,8 @@ attribute_mappings:
   description: 'Update Time'
 place_holder_event: true
 ---
-data_type: 'macos:startupitem:entry'
-# TODO: add attribute_mappings
+data_type: 'macos:startup_item:entry'
+# Note that the Mac OS startup item has no date and time values.
 place_holder_event: true
 ---
 data_type: 'macos:tcc_entry'

--- a/data/timeliner.yaml
+++ b/data/timeliner.yaml
@@ -781,6 +781,10 @@ attribute_mappings:
   description: 'Update Time'
 place_holder_event: true
 ---
+data_type: 'macos:startupitem:entry'
+# TODO: add attribute_mappings
+place_holder_event: true
+---
 data_type: 'macos:tcc_entry'
 attribute_mappings:
 - name: 'modification_time'

--- a/plaso/parsers/plist_plugins/__init__.py
+++ b/plaso/parsers/plist_plugins/__init__.py
@@ -10,6 +10,7 @@ from plaso.parsers.plist_plugins import ios_carplay
 from plaso.parsers.plist_plugins import ios_identityservices
 from plaso.parsers.plist_plugins import ipod
 from plaso.parsers.plist_plugins import launchd
+from plaso.parsers.plist_plugins import macos_startup_item
 from plaso.parsers.plist_plugins import macos_user
 from plaso.parsers.plist_plugins import safari_downloads
 from plaso.parsers.plist_plugins import safari_history

--- a/plaso/parsers/plist_plugins/macos_startup_item.py
+++ b/plaso/parsers/plist_plugins/macos_startup_item.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Plist parser plugin for MacOS startup item plist files."""
+
 from plaso.containers import events
 from plaso.parsers import plist
 from plaso.parsers.plist_plugins import interface
@@ -20,9 +21,7 @@ class MacOSStartupItemEventData(events.EventData):
 
   def __init__(self):
     """Initializes event data."""
-    super(MacOSStartupItemEventData, self).__init__(
-      data_type=self.DATA_TYPE
-    )
+    super(MacOSStartupItemEventData, self).__init__(data_type=self.DATA_TYPE)
     self.description = None
     self.order_preference = None
     self.provides = None
@@ -31,15 +30,14 @@ class MacOSStartupItemEventData(events.EventData):
 
 
 class MacOSStartupItemPlugin(interface.PlistPlugin):
-  """Plist parser plugin for MacOS startup item plist files.
-  """
+  """Plist parser plugin for MacOS startup item plist files."""
 
   NAME = 'macos_startup_item_plist'
   DATA_FORMAT = 'MacOS startup item plist file'
 
   PLIST_PATH_FILTERS = frozenset([
-    interface.PlistPathFilter('StartupParameters.plist')]
-  )
+      interface.PlistPathFilter('StartupParameters.plist')])
+
   PLIST_KEYS = frozenset([])
 
   # pylint: disable=arguments-differ
@@ -48,7 +46,7 @@ class MacOSStartupItemPlugin(interface.PlistPlugin):
 
     Args:
       parser_mediator (ParserMediator): mediates interactions between parsers
-        and other components, such as storage and dfVFS.
+          and other components, such as storage and dfVFS.
       top_level (Optional[dict[str, object]]): plist top-level item.
     """
     event_data = MacOSStartupItemEventData()

--- a/plaso/parsers/plist_plugins/macos_startup_item.py
+++ b/plaso/parsers/plist_plugins/macos_startup_item.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Plist parser plugin for MacOS startup item plist files."""
+from plaso.containers import events
+from plaso.parsers import plist
+from plaso.parsers.plist_plugins import interface
+
+
+class MacOSStartupItemEventData(events.EventData):
+  """MacOS startup item event data.
+
+  Attributes:
+    description (str): a short description of the startup item.
+    order_preference (str): string representing startup order preference.
+    provides (list[str]): names of services provided by the startup item.
+    requires (list[str]): services required prior to this startup item.
+    uses (list[str]): services that should be started before this startup item.
+  """
+
+  DATA_TYPE = 'macos:startupitem:entry'
+
+  def __init__(self):
+    """Initializes event data."""
+    super(MacOSStartupItemEventData, self).__init__(
+      data_type=self.DATA_TYPE
+    )
+    self.description = None
+    self.order_preference = None
+    self.provides = None
+    self.requires = None
+    self.uses = None
+
+
+class MacOSStartupItemPlugin(interface.PlistPlugin):
+  """Plist parser plugin for MacOS startup item plist files.
+  """
+
+  NAME = 'macos_startup_item_plist'
+  DATA_FORMAT = 'MacOS startup item plist file'
+
+  PLIST_PATH_FILTERS = frozenset([
+    interface.PlistPathFilter('StartupParameters.plist')]
+  )
+  PLIST_KEYS = frozenset([])
+
+  # pylint: disable=arguments-differ
+  def _ParsePlist(self, parser_mediator, top_level=None, **unused_kwargs):
+    """Extracts startup item information from the plist.
+
+    Args:
+      parser_mediator (ParserMediator): mediates interactions between parsers
+        and other components, such as storage and dfVFS.
+      top_level (Optional[dict[str, object]]): plist top-level item.
+    """
+    event_data = MacOSStartupItemEventData()
+    event_data.description = top_level.get('Description')
+    event_data.order_preference = top_level.get('OrderPreference')
+    event_data.provides = top_level.get('Provides')
+    event_data.requires = top_level.get('Requires')
+    event_data.uses = top_level.get('Uses')
+    parser_mediator.ProduceEventData(event_data)
+
+
+plist.PlistParser.RegisterPlugin(MacOSStartupItemPlugin)

--- a/plaso/parsers/plist_plugins/macos_startup_item.py
+++ b/plaso/parsers/plist_plugins/macos_startup_item.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Plist parser plugin for MacOS startup item plist files."""
+"""Plist parser plugin for Mac OS startup item plist files."""
 
 from plaso.containers import events
 from plaso.parsers import plist
@@ -7,17 +7,17 @@ from plaso.parsers.plist_plugins import interface
 
 
 class MacOSStartupItemEventData(events.EventData):
-  """MacOS startup item event data.
+  """Mac OS startup item event data.
 
   Attributes:
-    description (str): a short description of the startup item.
-    order_preference (str): string representing startup order preference.
+    description (str): description of the startup item.
+    order_preference (str): startup order preference.
     provides (list[str]): names of services provided by the startup item.
     requires (list[str]): services required prior to this startup item.
     uses (list[str]): services that should be started before this startup item.
   """
 
-  DATA_TYPE = 'macos:startupitem:entry'
+  DATA_TYPE = 'macos:startup_item:entry'
 
   def __init__(self):
     """Initializes event data."""
@@ -30,10 +30,10 @@ class MacOSStartupItemEventData(events.EventData):
 
 
 class MacOSStartupItemPlugin(interface.PlistPlugin):
-  """Plist parser plugin for MacOS startup item plist files."""
+  """Plist parser plugin for Mac OS startup item plist files."""
 
   NAME = 'macos_startup_item_plist'
-  DATA_FORMAT = 'MacOS startup item plist file'
+  DATA_FORMAT = 'Mac OS startup item plist file'
 
   PLIST_PATH_FILTERS = frozenset([
       interface.PlistPathFilter('StartupParameters.plist')])

--- a/test_data/StartupParameters.plist
+++ b/test_data/StartupParameters.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
+<plist version="0.9">
+    <dict>
+        <key>Description</key>
+        <string>Apple Serial Terminal Support</string>
+        <key>OrderPreference</key>
+        <string>Late</string>
+        <key>Provides</key>
+        <array>
+                <string>Serial Terminal Support</string>
+        </array>
+        <key>Uses</key>
+        <array>
+                <string>SystemLog</string>
+        </array>
+    </dict>
+</plist>

--- a/test_data/StartupParameters.plist
+++ b/test_data/StartupParameters.plist
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
 <plist version="0.9">
-    <dict>
-        <key>Description</key>
-        <string>Apple Serial Terminal Support</string>
-        <key>OrderPreference</key>
-        <string>Late</string>
-        <key>Provides</key>
-        <array>
-                <string>Serial Terminal Support</string>
-        </array>
-        <key>Uses</key>
-        <array>
-                <string>SystemLog</string>
-        </array>
-    </dict>
+<dict>
+	<key>Description</key>
+	<string>My Awesome Service</string>
+	<key>OrderPreference</key>
+	<string>None</string>
+	<key>Provides</key>
+	<array>
+		<string>The best service ever</string>
+	</array>
+	<key>Uses</key>
+	<array>
+		<string>Network</string>
+		<string>SystemLog</string>
+	</array>
+</dict>
 </plist>

--- a/tests/parsers/plist_plugins/macos_startup_item.py
+++ b/tests/parsers/plist_plugins/macos_startup_item.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the MacOS startup item plist plugin."""
+import unittest
+
+from plaso.parsers.plist_plugins import macos_startup_item
+
+from tests.parsers.plist_plugins import test_lib
+
+
+class MacOSStartupItemPlistPluginTest(test_lib.PlistPluginTestCase):
+  """Tests for the MacOS startup item plist plugin."""
+
+  def testProcess(self):
+    """Tests the Process function."""
+    plist_name = 'StartupParameters.plist'
+
+    plugin = macos_startup_item.MacOSStartupItemPlugin()
+    storage_writer = self._ParsePlistFileWithPlugin(
+        plugin, [plist_name], plist_name)
+
+    number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
+        'event_data')
+    self.assertEqual(number_of_event_data, 1)
+
+    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+        'extraction_warning')
+    self.assertEqual(number_of_warnings, 0)
+
+    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+        'recovery_warning')
+    self.assertEqual(number_of_warnings, 0)
+
+    expected_event_values = {
+        'data_type': 'macos:startupitem:entry',
+        'description': 'Apple Serial Terminal Support',
+        'order_preference': 'Late',
+        'provides': ['Serial Terminal Support'],
+        'uses': ['SystemLog'],
+    }
+
+    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 0)
+    self.CheckEventData(event_data, expected_event_values)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/parsers/plist_plugins/macos_startup_item.py
+++ b/tests/parsers/plist_plugins/macos_startup_item.py
@@ -33,11 +33,10 @@ class MacOSStartupItemPlistPluginTest(test_lib.PlistPluginTestCase):
 
     expected_event_values = {
         'data_type': 'macos:startupitem:entry',
-        'description': 'Apple Serial Terminal Support',
-        'order_preference': 'Late',
-        'provides': ['Serial Terminal Support'],
-        'uses': ['SystemLog'],
-    }
+        'description': 'My Awesome Service',
+        'order_preference': 'None',
+        'provides': ['The best service ever'],
+        'uses': ['Network', 'SystemLog']}
 
     event_data = storage_writer.GetAttributeContainerByIndex('event_data', 0)
     self.CheckEventData(event_data, expected_event_values)

--- a/tests/parsers/plist_plugins/macos_startup_item.py
+++ b/tests/parsers/plist_plugins/macos_startup_item.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Tests for the MacOS startup item plist plugin."""
+"""Tests for the Mac OS startup item plist plugin."""
+
 import unittest
 
 from plaso.parsers.plist_plugins import macos_startup_item
@@ -9,7 +10,7 @@ from tests.parsers.plist_plugins import test_lib
 
 
 class MacOSStartupItemPlistPluginTest(test_lib.PlistPluginTestCase):
-  """Tests for the MacOS startup item plist plugin."""
+  """Tests for the Mac OS startup item plist plugin."""
 
   def testProcess(self):
     """Tests the Process function."""
@@ -31,8 +32,9 @@ class MacOSStartupItemPlistPluginTest(test_lib.PlistPluginTestCase):
         'recovery_warning')
     self.assertEqual(number_of_warnings, 0)
 
+    # Note that the startup item event data has no date and time attribute.
     expected_event_values = {
-        'data_type': 'macos:startupitem:entry',
+        'data_type': 'macos:startup_item:entry',
         'description': 'My Awesome Service',
         'order_preference': 'None',
         'provides': ['The best service ever'],


### PR DESCRIPTION
## One line description of pull request

Adds a parser for MacOS startup item plist files, a pre-launchd service mechanism.

## Description:

[Apple docs](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/StartupItems.html)

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [x] Automated checks (GitHub Actions, AppVeyor) pass
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
* [x] Reviewer assigned
