### PR TITLE
Allowed launchd plists missing optional fields

### DIFF
--- a/plaso/parsers/plist_plugins/interface.py
+++ b/plaso/parsers/plist_plugins/interface.py
@@ -690,13 +690,13 @@ class PlistPlugin(plugins.BasePlugin):
   NAME = 'plist_plugin'
 
   # This is expected to be overridden by the processing plugin, for example:
-  # frozenset(PlistPathFilter('com.apple.bluetooth.plist'))
+  # PLIST_PATH_FILTERS = frozenset(PlistPathFilter('com.apple.bluetooth.plist'))
   PLIST_PATH_FILTERS = frozenset()
 
-  # PLIST_KEYS is a list of keys required by a plugin.
-  # This is expected to be overridden by the processing plugin.
-  # Ex. frozenset(['DeviceCache', 'PairedDevices'])
-  PLIST_KEYS = frozenset(['any'])
+  # PLIST_KEYS is a list of keys required by a plugin. This is expected to be
+  # overridden by the processing plugin, for example:
+  # PLIST_KEYS = frozenset(['DeviceCache', 'PairedDevices'])
+  PLIST_KEYS = frozenset()
 
   def _GetDateTimeValueFromPlistKey(self, plist_key, plist_value_name):
     """Retrieves a date and time value from a specific value in a plist key.
@@ -750,6 +750,7 @@ class PlistPlugin(plugins.BasePlugin):
       # Return an empty dict here if top_level is a list object, which happens
       # if the plist file is flat.
       return match
+
     keys = set(keys)
 
     if depth == 1:
@@ -856,6 +857,17 @@ class PlistPlugin(plugins.BasePlugin):
       match (Optional[dict[str: object]]): keys extracted from PLIST_KEYS.
       top_level (Optional[dict[str, object]]): plist top-level item.
     """
+
+  def CheckRequiredFormat(self, top_level):
+    """Check if the plist has the minimal structure required by the plugin.
+
+    Args:
+      top_level (dict[str, object]): plist top-level item.
+
+    Returns:
+      bool: True if this is the correct plugin, False otherwise.
+    """
+    return set(top_level.keys()).issuperset(self.PLIST_KEYS)
 
   def Process(self, parser_mediator, top_level=None, **kwargs):
     """Extracts events from a plist file.

--- a/plaso/parsers/plist_plugins/launchd.py
+++ b/plaso/parsers/plist_plugins/launchd.py
@@ -56,12 +56,7 @@ class MacOSLaunchdPlistPlugin(interface.PlistPlugin):
   # /Library/LaunchAgents/*.plist
   # ~/Library/LaunchAgents
 
-  PLIST_KEYS = frozenset([
-      'GroupName',
-      'Label',
-      'Program',
-      'ProgramArguments',
-      'UserName'])
+  PLIST_KEYS = frozenset(['Label'])
 
   # pylint: disable=arguments-differ
   def _ParsePlist(self, parser_mediator, top_level=None, **unused_kwargs):
@@ -74,8 +69,12 @@ class MacOSLaunchdPlistPlugin(interface.PlistPlugin):
     """
     program = top_level.get('Program', None)
     program_arguments = top_level.get('ProgramArguments', None)
+    if not (program or program_arguments):
+      return
     if program and program_arguments:
       program = ' '.join([program, ' '.join(program_arguments)])
+    elif program_arguments:
+      program = ' '.join(program_arguments)
 
     event_data = MacOSLaunchdEventData()
     event_data.group_name = top_level.get('GroupName')

--- a/plaso/parsers/plist_plugins/launchd.py
+++ b/plaso/parsers/plist_plugins/launchd.py
@@ -56,7 +56,25 @@ class MacOSLaunchdPlistPlugin(interface.PlistPlugin):
   # /Library/LaunchAgents/*.plist
   # ~/Library/LaunchAgents
 
+  # The Mac OS documentation indicates that Label and # ProgramArguments are
+  # required keys, lauchd plists have been observed  that contain Label and
+  # Program keys.
+
   PLIST_KEYS = frozenset(['Label'])
+
+  def CheckRequiredFormat(self, top_level):
+    """Check if the plist has the minimal structure required by the plugin.
+
+    Args:
+      top_level (dict[str, object]): plist top-level item.
+
+    Returns:
+      bool: True if this is the correct plugin, False otherwise.
+    """
+    if not super(MacOSLaunchdPlistPlugin, self).CheckRequiredFormat(top_level):
+      return False
+
+    return 'Program' in top_level or 'ProgramArguments' in top_level
 
   # pylint: disable=arguments-differ
   def _ParsePlist(self, parser_mediator, top_level=None, **unused_kwargs):

--- a/test_data/launchd.minimal.plist
+++ b/test_data/launchd.minimal.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>foo</string>
+	<key>Program</key>
+	<string>/usr/bin/true</string>
+</dict>
+</plist>

--- a/test_data/launchd.noprogram.plist
+++ b/test_data/launchd.noprogram.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>foo</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/bin/true</string>
+	</array>
+</dict>
+</plist>

--- a/tests/parsers/plist_plugins/launchd.py
+++ b/tests/parsers/plist_plugins/launchd.py
@@ -42,6 +42,62 @@ class MacOSLaunchdPlistPluginTest(test_lib.PlistPluginTestCase):
     event_data = storage_writer.GetAttributeContainerByIndex('event_data', 0)
     self.CheckEventData(event_data, expected_event_values)
 
+  def testProcessMinimal(self):
+    """Tests the Process function."""
+    plist_name = 'launchd.minimal.plist'
+
+    plugin = launchd.MacOSLaunchdPlistPlugin()
+    storage_writer = self._ParsePlistFileWithPlugin(
+        plugin, [plist_name], plist_name)
+
+    number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
+        'event_data')
+    self.assertEqual(number_of_event_data, 1)
+
+    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+        'extraction_warning')
+    self.assertEqual(number_of_warnings, 0)
+
+    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+        'recovery_warning')
+    self.assertEqual(number_of_warnings, 0)
+
+    expected_event_values = {
+        'data_type': 'macos:launchd:entry',
+        'name': 'foo',
+        'program': '/usr/bin/true'}
+
+    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 0)
+    self.CheckEventData(event_data, expected_event_values)
+
+  def testProcessNoProgram(self):
+    """Tests the Process function."""
+    plist_name = 'launchd.noprogram.plist'
+
+    plugin = launchd.MacOSLaunchdPlistPlugin()
+    storage_writer = self._ParsePlistFileWithPlugin(
+        plugin, [plist_name], plist_name)
+
+    number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
+        'event_data')
+    self.assertEqual(number_of_event_data, 1)
+
+    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+        'extraction_warning')
+    self.assertEqual(number_of_warnings, 0)
+
+    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+        'recovery_warning')
+    self.assertEqual(number_of_warnings, 0)
+
+    expected_event_values = {
+        'data_type': 'macos:launchd:entry',
+        'name': 'foo',
+        'program': '/usr/bin/true'}
+
+    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 0)
+    self.CheckEventData(event_data, expected_event_values)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
## One line description of pull request

This fixes parsing of launchd plists that are missing optional fields.

## Description:

I noticed many launchd plists failing to emit any events. According to [apple docs](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html), Label and ProgramArguments are required. In practice, it looks like ProgramArguments is also optional, with many LaunchDaemon plists on my macos 13.6 system having only Program set.

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [x] Automated checks (GitHub Actions, AppVeyor) pass
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
* [x] Reviewer assigned
