### PR TITLE
Changes to address TypeError exception in edge case

### DIFF
--- a/plaso/preprocessors/mediator.py
+++ b/plaso/preprocessors/mediator.py
@@ -113,11 +113,12 @@ class PreprocessMediator(object):
       KeyError: if the user account already exists.
     """
     if not user_account.username:
-      logger.debug(f'adding user account: {user_account.identifier:s}')
+      logger.debug('adding user account: {0!s}'.format(user_account.username))
     else:
-      logger.debug(
-          f'adding user account: {user_account.username:s} '
-          f'({user_account.identifier:s})')
+      logger.debug('adding user account: {0!s} ({1!s})'.format(
+        user_account.username,
+        user_account.identifier
+      ))
 
     if self._storage_writer:
       self._storage_writer.AddAttributeContainer(user_account)


### PR DESCRIPTION
## One line description of pull request
Use the usual "format" string method in mediator.py to avoid early f-string interpolation that causes TypeError issues and make log2timeline crashes

## Description:

When username is None, using 'f-strings' raise a "TypeErrpr: unsupported format string passed to NoneType.__format__"
Long before the KeyError that is supposed to catch the issue can be raised.
Therefore, in _ParseKey, in preprocessors/windows.py, we failed to catch the error and log2timeline stops with a failure.

![TypeError](https://github.com/user-attachments/assets/c8c894fa-dd2d-4f74-b665-620e4d09fe2d)

**Related issue (if applicable):** fixes #<plaso issue number here>

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [ ] Automated checks (GitHub Actions, AppVeyor) pass
* [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
* [ ] Reviewer assigned

