### PR TITLE
Updated GC log parser to include status fields

### DIFF
--- a/plaso/parsers/jsonl_plugins/gcp_log.py
+++ b/plaso/parsers/jsonl_plugins/gcp_log.py
@@ -58,8 +58,8 @@ class GCPLogEventData(events.EventData):
     source_images (list[str]): source images of disks attached to a compute
         engine instance.
     status_code (str): operation success or failure code.
-    status_message (str); operation success or failure message.
-    status_reasons (list[str]): reasons for operation failure.
+    status_message (str): operation success or failure message.
+    status_reasons ([str]): reasons for operation failure.
     text_payload (str): text payload for logs not using a JSON or proto payload.
     user_agent (str): user agent used in the request.
   """


### PR DESCRIPTION
## One line description of pull request

Added parsing for protoPayload.status.message and protoPayload.status.details[0].reason to the Google Cloud log parser

## Description:

This adds parsing for additional data from Google Cloud logs. Specifically the `protoPayload.status`. This now parses the `status.message` and `status.details[0].reason` fields into status_message and status_reason respectively. 

This has been tested using dftimewolf to download the data and pass it to a custom container and tested locally.

**Related issue (if applicable):** fixes #<plaso issue number here>
Fixing issue https://github.com/log2timeline/plaso/issues/4917

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [x] Automated checks (GitHub Actions, AppVeyor) pass
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
* [x] Reviewer assigned
