### PR TITLE
Corrected filter file path in session object (#4935)

### DIFF
--- a/plaso/cli/extraction_tool.py
+++ b/plaso/cli/extraction_tool.py
@@ -512,7 +512,7 @@ class ExtractionTool(
     session.debug_mode = self._debug_mode
     session.enabled_parser_names = enabled_parser_names
     session.extract_winevt_resources = self._extract_winevt_resources
-    session.filter_file_path = self._filter_file
+    session.filter_file = self._filter_file
     session.parser_filter_expression = self._parser_filter_expression
     session.preferred_codepage = self._preferred_codepage
     session.preferred_encoding = self.preferred_encoding


### PR DESCRIPTION
## One line description of pull request

Fix a typo in ExtractionTool.

## Description:

The `session.filter_file_path` attribute is written by Extraction tool instead of `session.filter_file`.

**Related issue:** fixes #4935

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [ ] Automated checks (GitHub Actions, AppVeyor) pass
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
* [x] Reviewer assigned
