### PR TITLE
Changed amcache.hve parser to extract file identifier and application key modification time

### DIFF
--- a/plaso/data/formatters/windows.yaml
+++ b/plaso/data/formatters/windows.yaml
@@ -384,6 +384,7 @@ type: 'conditional'
 data_type: 'windows:registry:amcache'
 message:
 - 'path: {full_path}'
+- 'file_identifier: {file_identifier}'
 - 'file_reference: {file_reference}'
 - 'sha1: {sha1}'
 - 'product_name: {product_name}'

--- a/plaso/parsers/winreg_plugins/amcache.py
+++ b/plaso/parsers/winreg_plugins/amcache.py
@@ -18,6 +18,8 @@ class AMCacheFileEventData(events.EventData):
   """AMCache file event data.
 
   Attributes:
+    application_key_last_written_time (dfdatetime.DateTimeValues): last written
+        date and time of the application key.
     company_name (str): company name that created product file belongs to.
     file_creation_time (dfdatetime.DateTimeValues): file entry creation date
         and time.
@@ -49,6 +51,7 @@ class AMCacheFileEventData(events.EventData):
   def __init__(self):
     """Initializes event data."""
     super(AMCacheFileEventData, self).__init__(data_type=self.DATA_TYPE)
+    self.application_key_last_written_time = None
     self.company_name = None
     self.file_creation_time = None
     self.file_description = None
@@ -239,7 +242,8 @@ class AMCachePlugin(interface.WindowsRegistryPlugin):
       event_data.link_time = self._ParseDateStringValue(
           parser_mediator, application_sub_key.path, link_date_value)
 
-    event_data.last_written_time = application_sub_key.last_written_time
+    event_data.application_key_last_written_time = (
+        application_sub_key.last_written_time)
 
     parser_mediator.ProduceEventData(event_data)
 

--- a/plaso/parsers/winreg_plugins/amcache.py
+++ b/plaso/parsers/winreg_plugins/amcache.py
@@ -115,6 +115,7 @@ class AMCachePlugin(interface.WindowsRegistryPlugin):
 
   # Contains: {value name: attribute name}
   _APPLICATION_SUB_KEY_VALUES = {
+      'FileId': 'sha1',
       'LowerCaseLongPath': 'full_path',
       'ProductName': 'product_name',
       'ProductVersion': 'file_version',
@@ -217,6 +218,10 @@ class AMCachePlugin(interface.WindowsRegistryPlugin):
         value_data = self._GetValueDataAsObject(
             parser_mediator, application_sub_key.path, value_name, value)
 
+        if attribute_name == 'sha1' and value_data.startswith('0000'):
+          # Strip off the 4 leading zero's from the sha1 hash.
+          value_data = value_data[4:]
+
         setattr(event_data, attribute_name, value_data)
 
     install_date_value = application_sub_key.GetValueByName('InstallDate')
@@ -234,6 +239,8 @@ class AMCachePlugin(interface.WindowsRegistryPlugin):
     if link_date_value:
       event_data.link_time = self._ParseDateStringValue(
           parser_mediator, application_sub_key.path, link_date_value)
+
+    event_data.last_written_time = application_sub_key.last_written_time
 
     parser_mediator.ProduceEventData(event_data)
 

--- a/plaso/parsers/winreg_plugins/amcache.py
+++ b/plaso/parsers/winreg_plugins/amcache.py
@@ -22,6 +22,8 @@ class AMCacheFileEventData(events.EventData):
     file_creation_time (dfdatetime.DateTimeValues): file entry creation date
         and time.
     file_description (str): description of file.
+    file_identifier (str): identifier of file (SHA-1 of the first 31,457,280 
+        bytes of file, preceded by '0000').
     file_modification_time (dfdatetime.DateTimeValues): file entry last
         modification date and time.
     file_reference (str): file system file reference, for example 9-1 (MFT
@@ -50,6 +52,7 @@ class AMCacheFileEventData(events.EventData):
     self.company_name = None
     self.file_creation_time = None
     self.file_description = None
+    self.file_identifier = None
     self.file_modification_time = None
     self.file_reference = None
     self.file_size = None
@@ -115,7 +118,7 @@ class AMCachePlugin(interface.WindowsRegistryPlugin):
 
   # Contains: {value name: attribute name}
   _APPLICATION_SUB_KEY_VALUES = {
-      'FileId': 'sha1',
+      'FileId': 'file_identifier',
       'LowerCaseLongPath': 'full_path',
       'ProductName': 'product_name',
       'ProductVersion': 'file_version',
@@ -217,10 +220,6 @@ class AMCachePlugin(interface.WindowsRegistryPlugin):
       if value:
         value_data = self._GetValueDataAsObject(
             parser_mediator, application_sub_key.path, value_name, value)
-
-        if attribute_name == 'sha1' and value_data.startswith('0000'):
-          # Strip off the 4 leading zero's from the sha1 hash.
-          value_data = value_data[4:]
 
         setattr(event_data, attribute_name, value_data)
 

--- a/plaso/parsers/winreg_plugins/amcache.py
+++ b/plaso/parsers/winreg_plugins/amcache.py
@@ -22,8 +22,8 @@ class AMCacheFileEventData(events.EventData):
     file_creation_time (dfdatetime.DateTimeValues): file entry creation date
         and time.
     file_description (str): description of file.
-    file_identifier (str): identifier of file (SHA-1 of the first 31,457,280 
-        bytes of file, preceded by '0000').
+    file_identifier (str): identifier of file (SHA-1 of the first 30 MiB
+        (31457280 bytes) of file, preceded by "0000").
     file_modification_time (dfdatetime.DateTimeValues): file entry last
         modification date and time.
     file_reference (str): file system file reference, for example 9-1 (MFT

--- a/tests/parsers/winreg_plugins/amcache.py
+++ b/tests/parsers/winreg_plugins/amcache.py
@@ -118,9 +118,10 @@ class AMCachePluginTest(test_lib.RegistryPluginTestCase):
         'file_modification_time': None,
         'full_path': 'c:\\windows\\system32\\svchost.exe',
         'installation_time': None,
-        'last_written_time': None,
+        'last_written_time': '2019-12-17T05:30:28.2416496+00:00',
         'link_time': '1997-01-10T22:26:24+00:00',
-        'msi_installation_time': None}
+        'msi_installation_time': None,
+        'sha1': '75c5a97f521f760e32a4a9639a653eed862e9c61'}
 
     event_data = storage_writer.GetAttributeContainerByIndex('event_data', 135)
     self.CheckEventData(event_data, expected_event_values)

--- a/tests/parsers/winreg_plugins/amcache.py
+++ b/tests/parsers/winreg_plugins/amcache.py
@@ -55,6 +55,7 @@ class AMCachePluginTest(test_lib.RegistryPluginTestCase):
         'is-f4510.tmp\\idafree50.tmp')
 
     expected_event_values = {
+        'application_key_last_written_time': None,
         'data_type': 'windows:registry:amcache',
         'file_creation_time': '2017-08-01T12:43:35.1772758+00:00',
         'file_modification_time': '2017-08-01T12:43:35.3024523+00:00',
@@ -113,13 +114,14 @@ class AMCachePluginTest(test_lib.RegistryPluginTestCase):
     self.assertEqual(number_of_warnings, 0)
 
     expected_event_values = {
+        'application_key_last_written_time': '2019-12-17T05:30:28.2416496+00:00',
         'data_type': 'windows:registry:amcache',
         'file_creation_time': None,
         'file_identifier': '000075c5a97f521f760e32a4a9639a653eed862e9c61',
         'file_modification_time': None,
         'full_path': 'c:\\windows\\system32\\svchost.exe',
         'installation_time': None,
-        'last_written_time': '2019-12-17T05:30:28.2416496+00:00',
+        'last_written_time': None,
         'link_time': '1997-01-10T22:26:24+00:00',
         'msi_installation_time': None}
 

--- a/tests/parsers/winreg_plugins/amcache.py
+++ b/tests/parsers/winreg_plugins/amcache.py
@@ -114,7 +114,8 @@ class AMCachePluginTest(test_lib.RegistryPluginTestCase):
     self.assertEqual(number_of_warnings, 0)
 
     expected_event_values = {
-        'application_key_last_written_time': '2019-12-17T05:30:28.2416496+00:00',
+        'application_key_last_written_time': (
+            '2019-12-17T05:30:28.2416496+00:00'),
         'data_type': 'windows:registry:amcache',
         'file_creation_time': None,
         'file_identifier': '000075c5a97f521f760e32a4a9639a653eed862e9c61',

--- a/tests/parsers/winreg_plugins/amcache.py
+++ b/tests/parsers/winreg_plugins/amcache.py
@@ -115,7 +115,7 @@ class AMCachePluginTest(test_lib.RegistryPluginTestCase):
     expected_event_values = {
         'data_type': 'windows:registry:amcache',
         'file_creation_time': None,
-        'file_identifier': '75c5a97f521f760e32a4a9639a653eed862e9c61',
+        'file_identifier': '000075c5a97f521f760e32a4a9639a653eed862e9c61',
         'file_modification_time': None,
         'full_path': 'c:\\windows\\system32\\svchost.exe',
         'installation_time': None,

--- a/tests/parsers/winreg_plugins/amcache.py
+++ b/tests/parsers/winreg_plugins/amcache.py
@@ -115,13 +115,13 @@ class AMCachePluginTest(test_lib.RegistryPluginTestCase):
     expected_event_values = {
         'data_type': 'windows:registry:amcache',
         'file_creation_time': None,
+        'file_identifier': '75c5a97f521f760e32a4a9639a653eed862e9c61',
         'file_modification_time': None,
         'full_path': 'c:\\windows\\system32\\svchost.exe',
         'installation_time': None,
         'last_written_time': '2019-12-17T05:30:28.2416496+00:00',
         'link_time': '1997-01-10T22:26:24+00:00',
-        'msi_installation_time': None,
-        'sha1': '75c5a97f521f760e32a4a9639a653eed862e9c61'}
+        'msi_installation_time': None}
 
     event_data = storage_writer.GetAttributeContainerByIndex('event_data', 135)
     self.CheckEventData(event_data, expected_event_values)


### PR DESCRIPTION
## One line description of pull request

Add sha1 and last_written_time to Amcache parser

## Description:

The winreg_amcache parser should include the sha1 and last_written_time for `Root\\InventoryApplicationFile` keys. These fields are critical for export for forensic analysis.


**Related issue (if applicable):** fixes #<plaso issue number here>

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [x] Automated checks (GitHub Actions, AppVeyor) pass
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
* [x] Reviewer assigned
