### PR TITLE
Feature: Map Extracted Files to Artifact Definitions in image_export.py

### DIFF
--- a/plaso/cli/image_export_tool.py
+++ b/plaso/cli/image_export_tool.py
@@ -122,11 +122,8 @@ class ImageExportTool(storage_media_tool.StorageMediaTool):
     return hasher_object.GetStringDigest()
 
   def _CreateSanitizedDestination(
-          self,
-          source_file_entry,
-          file_system_path_spec,
-          source_data_stream_name,
-          destination_path):
+      self, source_file_entry, file_system_path_spec, source_data_stream_name,
+      destination_path):
     """Creates a sanitized path of both destination directory and filename.
 
     This function replaces non-printable and other characters defined in

--- a/plaso/cli/image_export_tool.py
+++ b/plaso/cli/image_export_tool.py
@@ -265,6 +265,7 @@ class ImageExportTool(storage_media_tool.StorageMediaTool):
     for data_stream in file_entry.data_streams:
       if self._abort:
         break
+
       self._ExtractDataStream(
           file_entry, data_stream.name, destination_path,
           skip_duplicates=skip_duplicates)
@@ -337,8 +338,7 @@ class ImageExportTool(storage_media_tool.StorageMediaTool):
 
     try:
       extraction_engine.BuildCollectionFilters(
-          environment_variables,
-          user_accounts,
+          environment_variables, user_accounts,
           artifact_filter_names=artifact_filters,
           filter_file_path=filter_file,
           enable_artifacts_map=self._enable_artifacts_map)

--- a/plaso/cli/image_export_tool.py
+++ b/plaso/cli/image_export_tool.py
@@ -233,8 +233,8 @@ class ImageExportTool(storage_media_tool.StorageMediaTool):
     if self._enable_artifacts_map:
       for artifact_name in self._filter_collection.GetMatchingArtifacts(
               path, os.sep):
-        self._artifacts_paths_map.setdefault(
-            artifact_name, []).append(path)
+        path_list = self._artifacts_paths_map.setdefault(artifact_name, [])
+        path_list.append(path)
 
     try:
       self._WriteFileEntry(file_entry, data_stream_name, target_path)

--- a/plaso/cli/image_export_tool.py
+++ b/plaso/cli/image_export_tool.py
@@ -76,10 +76,12 @@ class ImageExportTool(storage_media_tool.StorageMediaTool):
     self._abort = False
     self._artifact_definitions_path = None
     self._artifact_filters = None
+    self._artifacts_paths_map = collections.defaultdict(list)
     self._artifacts_registry = None
     self._custom_artifacts_path = None
     self._destination_path = None
     self._digests = {}
+    self._enable_artifacts_map = False
     self._filter_collection = file_entry_filters.FileEntryFilterCollection()
     self._filter_file = None
     self._no_hashes = False
@@ -91,8 +93,6 @@ class ImageExportTool(storage_media_tool.StorageMediaTool):
 
     self.has_filters = False
     self.list_signature_identifiers = False
-    self._enable_artifacts_map = False
-    self._artifacts_paths_map = collections.defaultdict(list)
 
   def _CalculateDigestHash(self, file_entry, data_stream_name):
     """Calculates a SHA-256 digest of the contents of the file entry.

--- a/plaso/cli/image_export_tool.py
+++ b/plaso/cli/image_export_tool.py
@@ -232,7 +232,7 @@ class ImageExportTool(storage_media_tool.StorageMediaTool):
     # Generate a map between artifacts and extracted paths.
     if self._enable_artifacts_map:
       for artifact_name in self._filter_collection.GetMatchingArtifacts(
-              path, os.sep):
+          path, os.sep):
         path_list = self._artifacts_paths_map.setdefault(artifact_name, [])
         path_list.append(path)
 

--- a/plaso/cli/image_export_tool.py
+++ b/plaso/cli/image_export_tool.py
@@ -347,8 +347,8 @@ class ImageExportTool(storage_media_tool.StorageMediaTool):
           f'Unable to build collection filters with error: {exception!s}')
 
     if self._enable_artifacts_map:
-      self._filter_collection.SetArtifactsTrie(
-          extraction_engine.GetArtifactsTrie())
+      atrifacts_trie = extraction_engine.GetArtifactsTrie()
+      self._filter_collection.SetArtifactsTrie(atrifacts_trie)
 
     excluded_find_specs = extraction_engine.GetCollectionExcludedFindSpecs()
     included_find_specs = extraction_engine.GetCollectionIncludedFindSpecs()
@@ -804,10 +804,10 @@ class ImageExportTool(storage_media_tool.StorageMediaTool):
     try:
       self.ScanSource(self._source_path)
       if self._source_type not in self._SOURCE_TYPES_TO_PREPROCESS:
-        self._output_writer.Write(
-            (
-                f'Input must be in {list(self._SOURCE_TYPES_TO_PREPROCESS)} '
-                f'the "{self._source_type}" type is not supported.\n'))
+        source_types = ', '.join(self._SOURCE_TYPES_TO_PREPROCESS)
+        self._output_writer.Write((
+            f'Input must be in "{source_types:s}" the type: '
+            f'"{self._source_type}" is not supported.\n'))
         return
     except dfvfs_errors.UserAbort as exception:
       raise errors.UserAbort(exception)

--- a/plaso/cli/image_export_tool.py
+++ b/plaso/cli/image_export_tool.py
@@ -229,7 +229,7 @@ class ImageExportTool(storage_media_tool.StorageMediaTool):
           f'exists.'))
       return
 
-    # Generate a map between artifacts and extracted paths
+    # Generate a map between artifacts and extracted paths.
     if self._enable_artifacts_map:
       for artifact_name in self._filter_collection.GetMatchingArtifacts(
               path, os.sep):

--- a/plaso/engine/artifact_filters.py
+++ b/plaso/engine/artifact_filters.py
@@ -2,15 +2,16 @@
 """Helper to create filters based on forensic artifact definitions."""
 
 import os
+
 from artifacts import definitions as artifact_types
 
 from dfvfs.helpers import file_system_searcher as dfvfs_file_system_searcher
 
 from dfwinreg import registry_searcher as dfwinreg_registry_searcher
 
+from plaso.engine import artifacts_trie
 from plaso.engine import logger
 from plaso.engine import path_helper
-from plaso.engine import artifacts_trie
 
 
 class ArtifactDefinitionsFiltersHelper(object):
@@ -30,10 +31,10 @@ class ArtifactDefinitionsFiltersHelper(object):
         generated Windows Registry find specifications.
     registry_find_specs (list[dfwinreg.FindSpec]): Windows Registry find
         specifications.
-    registry_find_specs_artifact_names (list[]str): Windows Registry artifact
+    registry_find_specs_artifact_names (list[str]): Windows Registry artifact
         names corresponding to the find specifications.
     artifacts_trie (ArtifactsTrie): Trie structure for storing artifact
-        definitionpaths.
+        definition paths.
   """
 
   _COMPATIBLE_REGISTRY_KEY_PATH_PREFIXES = frozenset([
@@ -62,12 +63,9 @@ class ArtifactDefinitionsFiltersHelper(object):
     self.artifacts_trie = artifacts_trie.ArtifactsTrie()
 
   def _BuildFindSpecsFromArtifact(
-          self,
-          definition,
-          environment_variables,
-          user_accounts,
+          self, definition, environment_variables, user_accounts,
           enable_artifacts_map=False,
-          original_registery_artifact_filter_names=None):
+          original_registry_artifact_filter_names=None):
     """Builds find specifications from an artifact definition.
 
     Args:
@@ -77,8 +75,8 @@ class ArtifactDefinitionsFiltersHelper(object):
       user_accounts (list[UserAccountArtifact]): user accounts.
       enable_artifacts_map (Optional[bool]): True if the artifacts path map
           should be generated. Defaults to False.
-      original_registery_artifact_filter_names (Optional[set[str]]): Set of
-          original registery filter names, used in case registery hive files
+      original_registry_artifact_filter_names (Optional[set[str]]): Set of
+          original registry filter names, used in case Windows Registry hive files
           are being requested as a result of a previous filter.
 
     Returns:
@@ -96,8 +94,8 @@ class ArtifactDefinitionsFiltersHelper(object):
               environment_variables,
               user_accounts,
               enable_artifacts_map=enable_artifacts_map,
-              original_registery_artifact_filter_names=(
-                  original_registery_artifact_filter_names))
+              original_registry_artifact_filter_names=(
+                  original_registry_artifact_filter_names))
           find_specs.extend(specifications)
           self.file_system_artifact_names.add(definition.name)
 
@@ -136,8 +134,8 @@ class ArtifactDefinitionsFiltersHelper(object):
               environment_variables,
               user_accounts,
               enable_artifacts_map=enable_artifacts_map,
-              original_registery_artifact_filter_names=(
-                  original_registery_artifact_filter_names))
+              original_registry_artifact_filter_names=(
+                  original_registry_artifact_filter_names))
           find_specs.extend(specifications)
 
       else:
@@ -153,7 +151,7 @@ class ArtifactDefinitionsFiltersHelper(object):
           environment_variables,
           user_accounts,
           enable_artifacts_map=False,
-          original_registery_artifact_filter_names=None):
+          original_registry_artifact_filter_names=None):
     """Builds find specifications from a artifact group name.
 
     Args:
@@ -163,8 +161,8 @@ class ArtifactDefinitionsFiltersHelper(object):
       user_accounts (list[UserAccountArtifact]): user accounts.
       enable_artifacts_map (Optional[bool]): True if the artifacts path map
           should be generated. Defaults to False.
-      original_registery_artifact_filter_names (Optional[set[str]]): Set of
-          original registery filter names, used in case registery hive files
+      original_registry_artifact_filter_names (Optional[set[str]]): Set of
+          original registry filter names, used in case registry hive files
           are being requested as a result of a previous filter.
 
     Returns:
@@ -182,8 +180,8 @@ class ArtifactDefinitionsFiltersHelper(object):
         environment_variables,
         user_accounts,
         enable_artifacts_map=enable_artifacts_map,
-        original_registery_artifact_filter_names=(
-            original_registery_artifact_filter_names))
+        original_registry_artifact_filter_names=(
+            original_registry_artifact_filter_names))
 
   def _BuildFindSpecsFromRegistrySourceKey(self, key_path):
     """Build find specifications from a Windows Registry source type.
@@ -224,7 +222,7 @@ class ArtifactDefinitionsFiltersHelper(object):
           environment_variables,
           user_accounts,
           enable_artifacts_map=False,
-          original_registery_artifact_filter_names=None):
+          original_registry_artifact_filter_names=None):
     """Builds find specifications from a file source type.
 
     Args:
@@ -236,8 +234,8 @@ class ArtifactDefinitionsFiltersHelper(object):
       user_accounts (list[UserAccountArtifact]): user accounts.
       enable_artifacts_map (Optional[bool]): True if the artifacts path map
           should be generated. Defaults to False.
-      original_registery_artifact_filter_names (Optional[set[str]]): Set of
-          original registery filter names, used in case registery hive files
+      original_registry_artifact_filter_names (Optional[set[str]]): Set of
+          original registry filter names, used in case registry hive files
           are being requested as a result of a previous filter.
 
     Returns:
@@ -266,7 +264,7 @@ class ArtifactDefinitionsFiltersHelper(object):
         if enable_artifacts_map:
           self._AddToArtifactsTrie(artifact_name,
                                    expanded_path,
-                                   original_registery_artifact_filter_names,
+                                   original_registry_artifact_filter_names,
                                    path_separator)
 
     return find_specs
@@ -275,21 +273,21 @@ class ArtifactDefinitionsFiltersHelper(object):
           self,
           artifact_name,
           path,
-          original_registery_artifact_filter_names,
+          original_registry_artifact_filter_names,
           path_separator):
     """Adds a path to the artifacts trie.
 
     Args:
         artifact_name (str): artifact name.
         path (str): file system path.
-        original_registery_artifact_filter_names (Optional[set[str]]): Set of
-            original registery filter names.
+        original_registry_artifact_filter_names (Optional[set[str]]): Set of
+            original registry filter names.
         path_separator (str): path separator.
     """
     normalized_path = path.replace(path_separator, os.sep)
     self.artifacts_trie.AddPath(artifact_name, normalized_path, os.sep)
-    if original_registery_artifact_filter_names:
-      for name in original_registery_artifact_filter_names:
+    if original_registry_artifact_filter_names:
+      for name in original_registry_artifact_filter_names:
         self.artifacts_trie.AddPath(name, normalized_path, os.sep)
 
   def _ExpandPathVariables(self, path, environment_variables, path_separator):
@@ -345,7 +343,7 @@ class ArtifactDefinitionsFiltersHelper(object):
           environment_variables=None,
           user_accounts=None,
           enable_artifacts_map=False,
-          original_registery_artifact_filter_names=None):
+          original_registry_artifact_filter_names=None):
     """Builds find specifications from artifact definitions.
 
     Args:
@@ -356,8 +354,8 @@ class ArtifactDefinitionsFiltersHelper(object):
       user_accounts (Optional[list[UserAccountArtifact]]): user accounts.
       enable_artifacts_map (Optional[bool]): True if the artifacts path map
           should be generated. Defaults to False.
-      original_registery_artifact_filter_names (Optional[set[str]]): Set of
-          original registery filter names, used in case registery hive files
+      original_registry_artifact_filter_names (Optional[set[str]]): Set of
+          original registry filter names, used in case registry hive files
           are being requested as a result of a previous filter.
     """
     find_specs = {}
@@ -375,8 +373,8 @@ class ArtifactDefinitionsFiltersHelper(object):
           environment_variables,
           user_accounts,
           enable_artifacts_map=enable_artifacts_map,
-          original_registery_artifact_filter_names=(
-              original_registery_artifact_filter_names))
+          original_registry_artifact_filter_names=(
+              original_registry_artifact_filter_names))
       find_specs.setdefault(name, []).extend(artifact_find_specs)
 
     for name, find_spec_values in find_specs.items():
@@ -386,7 +384,7 @@ class ArtifactDefinitionsFiltersHelper(object):
 
         elif isinstance(find_spec, dfwinreg_registry_searcher.FindSpec):
           self.registry_find_specs.append(find_spec)
-          # Artifact names ordered similar to registery find specs
+          # Artifact names ordered similar to registry find specs
           self.registry_find_specs_artifact_names.append(name)
         else:
           type_string = type(find_spec)

--- a/plaso/engine/artifact_filters.py
+++ b/plaso/engine/artifact_filters.py
@@ -76,8 +76,8 @@ class ArtifactDefinitionsFiltersHelper(object):
       enable_artifacts_map (Optional[bool]): True if the artifacts path map
           should be generated. Defaults to False.
       original_registry_artifact_filter_names (Optional[set[str]]): Set of
-          original registry filter names, used in case Windows Registry hive files
-          are being requested as a result of a previous filter.
+          original registry filter names, used in case Windows Registry hive
+          files are being requested as a result of a previous filter.
 
     Returns:
       list[dfvfs.FindSpec|dfwinreg.FindSpec]: dfVFS or dfWinReg find

--- a/plaso/engine/artifact_filters.py
+++ b/plaso/engine/artifact_filters.py
@@ -63,9 +63,9 @@ class ArtifactDefinitionsFiltersHelper(object):
     self.artifacts_trie = artifacts_trie.ArtifactsTrie()
 
   def _BuildFindSpecsFromArtifact(
-          self, definition, environment_variables, user_accounts,
-          enable_artifacts_map=False,
-          original_registry_artifact_filter_names=None):
+      self, definition, environment_variables, user_accounts,
+      enable_artifacts_map=False,
+      original_registry_artifact_filter_names=None):
     """Builds find specifications from an artifact definition.
 
     Args:
@@ -88,11 +88,8 @@ class ArtifactDefinitionsFiltersHelper(object):
       if source.type_indicator == artifact_types.TYPE_INDICATOR_FILE:
         for path_entry in set(source.paths):
           specifications = self._BuildFindSpecsFromFileSourcePath(
-              definition.name,
-              path_entry,
-              source.separator,
-              environment_variables,
-              user_accounts,
+              definition.name, path_entry, source.separator,
+              environment_variables, user_accounts,
               enable_artifacts_map=enable_artifacts_map,
               original_registry_artifact_filter_names=(
                   original_registry_artifact_filter_names))
@@ -130,9 +127,7 @@ class ArtifactDefinitionsFiltersHelper(object):
             artifact_types.TYPE_INDICATOR_ARTIFACT_GROUP):
         for name in source.names:
           specifications = self._BuildFindSpecsFromGroupName(
-              name,
-              environment_variables,
-              user_accounts,
+              name, environment_variables, user_accounts,
               enable_artifacts_map=enable_artifacts_map,
               original_registry_artifact_filter_names=(
                   original_registry_artifact_filter_names))
@@ -146,12 +141,9 @@ class ArtifactDefinitionsFiltersHelper(object):
     return find_specs
 
   def _BuildFindSpecsFromGroupName(
-          self,
-          group_name,
-          environment_variables,
-          user_accounts,
-          enable_artifacts_map=False,
-          original_registry_artifact_filter_names=None):
+      self, group_name, environment_variables, user_accounts,
+      enable_artifacts_map=False,
+      original_registry_artifact_filter_names=None):
     """Builds find specifications from a artifact group name.
 
     Args:
@@ -176,9 +168,7 @@ class ArtifactDefinitionsFiltersHelper(object):
       return None
 
     return self._BuildFindSpecsFromArtifact(
-        definition,
-        environment_variables,
-        user_accounts,
+        definition, environment_variables, user_accounts,
         enable_artifacts_map=enable_artifacts_map,
         original_registry_artifact_filter_names=(
             original_registry_artifact_filter_names))
@@ -215,12 +205,8 @@ class ArtifactDefinitionsFiltersHelper(object):
     return find_specs
 
   def _BuildFindSpecsFromFileSourcePath(
-          self,
-          artifact_name,
-          source_path,
-          path_separator,
-          environment_variables,
-          user_accounts,
+      self, artifact_name, source_path, path_separator,
+          environment_variables, user_accounts,
           enable_artifacts_map=False,
           original_registry_artifact_filter_names=None):
     """Builds find specifications from a file source type.
@@ -262,19 +248,17 @@ class ArtifactDefinitionsFiltersHelper(object):
         find_specs.append(find_spec)
 
         if enable_artifacts_map:
-          self._AddToArtifactsTrie(artifact_name,
-                                   expanded_path,
-                                   original_registry_artifact_filter_names,
-                                   path_separator)
+          self._AddToArtifactsTrie(
+              artifact_name, expanded_path,
+              original_registry_artifact_filter_names,
+              path_separator)
 
     return find_specs
 
   def _AddToArtifactsTrie(
-          self,
-          artifact_name,
-          path,
-          original_registry_artifact_filter_names,
-          path_separator):
+      self, artifact_name, path,
+      original_registry_artifact_filter_names,
+      path_separator):
     """Adds a path to the artifacts trie.
 
     Args:
@@ -322,7 +306,6 @@ class ArtifactDefinitionsFiltersHelper(object):
       path (str): Path to match.
       path_separator (str): file system path segment separator.
 
-
     Returns:
         dfvfs.FindSpec: a find specification or None if one cannot be created.
     """
@@ -338,12 +321,9 @@ class ArtifactDefinitionsFiltersHelper(object):
       return None
 
   def BuildFindSpecs(
-          self,
-          artifact_filter_names,
-          environment_variables=None,
-          user_accounts=None,
-          enable_artifacts_map=False,
-          original_registry_artifact_filter_names=None):
+      self, artifact_filter_names, environment_variables=None,
+      user_accounts=None, enable_artifacts_map=False,
+      original_registry_artifact_filter_names=None):
     """Builds find specifications from artifact definitions.
 
     Args:

--- a/plaso/engine/artifact_filters.py
+++ b/plaso/engine/artifact_filters.py
@@ -284,7 +284,7 @@ class ArtifactDefinitionsFiltersHelper(object):
       path_separator (str): file system path segment separator.
 
     Returns:
-      str: expanded path, or None if the path is invalid
+      str: expanded path, or None if the path is invalid.
     """
     if '%' in path:
       path = path_helper.PathHelper.ExpandWindowsPath(

--- a/plaso/engine/artifact_filters.py
+++ b/plaso/engine/artifact_filters.py
@@ -262,11 +262,11 @@ class ArtifactDefinitionsFiltersHelper(object):
     """Adds a path to the artifacts trie.
 
     Args:
-        artifact_name (str): artifact name.
-        path (str): file system path.
-        original_registry_artifact_filter_names (Optional[set[str]]): Set of
-            original registry filter names.
-        path_separator (str): path separator.
+      artifact_name (str): artifact name.
+      path (str): file system path.
+      original_registry_artifact_filter_names (Optional[set[str]]): Set of
+          original registry filter names.
+      path_separator (str): path separator.
     """
     normalized_path = path.replace(path_separator, os.sep)
     self.artifacts_trie.AddPath(artifact_name, normalized_path, os.sep)

--- a/plaso/engine/artifacts_trie.py
+++ b/plaso/engine/artifacts_trie.py
@@ -168,34 +168,29 @@ class ArtifactsTrie(object):
     return list(matching_artifacts)
 
   def _ComparePathIfSanitized(
-          self,
-          current_path,
-          path_separator,
-          artifact_path,
-          atrifact_path_seperator):
+      self, current_path, path_separator, artifact_path,
+      artifact_path_seperator):
     """Compares a current path with an artifact path, handling sanitization.
 
     This method checks if the current_path matches the artifact_path,
     considering that the artifact_path might have been sanitized.
 
     Args:
-        current_path (str): The current path being checked.
-        path_separator (str): Path separator for the current path.
-        artifact_path (str): The artifact path to compare against.
-        atrifact_path_seperator (str): Path separator for the artifact path.
+      current_path (str): The current path being checked.
+      path_separator (str): Path separator for the current path.
+      artifact_path (str): The artifact path to compare against.
+      artifact_path_seperator (str): Path separator for the artifact path.
 
     Returns:
-        bool: True if the current path matches the artifact path (or its
-            sanitized version), False otherwise.
+      bool: True if the current path matches the artifact path or its
+          sanitized version, False otherwise.
     """
-    atrifact_path_segments = self._GetNonEmptyPathSegments(
-        artifact_path, atrifact_path_seperator)
-    return self._GetNonEmptyPathSegments(
-        current_path, path_separator) in [
-        atrifact_path_segments,
-            path_helper.PathHelper.SanitizePathSegments(
-                atrifact_path_segments)
-    ]
+    artifact_path_segments = self._GetNonEmptyPathSegments(
+        artifact_path, artifact_path_seperator)
+    sanitized_path_segments = path_helper.PathHelper.SanitizePathSegments(
+        artifact_path_segments)
+    return self._GetNonEmptyPathSegments(current_path, path_separator) in [
+        artifact_path_segments, sanitized_path_segments]
 
   def _GetNonEmptyPathSegments(self, path, separator):
     """Splits a path into segments and remove non-empty segments.

--- a/plaso/engine/artifacts_trie.py
+++ b/plaso/engine/artifacts_trie.py
@@ -58,7 +58,8 @@ class ArtifactsTrie(object):
       path_separator (str): path separator.
     """
     logger.debug(f'Adding path: "{path:s}" to artifact: "{artifact_name:s}"')
-    self.artifacts_paths.setdefault(artifact_name, []).append(path)
+    path_list = self.artifacts_paths.setdefault(artifact_name, [])
+    path_list.append(path)
 
     # Start at the root
     node = self.root
@@ -229,7 +230,8 @@ class ArtifactsTrie(object):
       """
       if node.artifacts_names:
         for artifact_name in node.artifacts_names:
-          artifacts.setdefault(artifact_name, []).append(current_path)
+          path_list = artifacts.setdefault(artifact_name, [])
+          path_list.append(current_path)
 
       for segment, child_node in node.children.items():
         # Ensure the path_separator attribute exists.

--- a/plaso/engine/artifacts_trie.py
+++ b/plaso/engine/artifacts_trie.py
@@ -130,6 +130,9 @@ class ArtifactsTrie(object):
     if node.artifacts_names:
       for artifact_name in node.artifacts_names:
         for artifact_path in self.artifacts_paths.get(artifact_name, []):
+          # Note that the sanitized path is used here to ensure consistency
+          # with the exported path.
+          # TODO: consider moving path sanitation out of engine.
           if self._ComparePathIfSanitized(
               current_path, path_separator, artifact_path,
               node.path_separator):

--- a/plaso/engine/artifacts_trie.py
+++ b/plaso/engine/artifacts_trie.py
@@ -203,11 +203,11 @@ class ArtifactsTrie(object):
     """Splits a path into segments and remove non-empty segments.
 
     Args:
-        path (str): The path string to be split.
-        separator (str): The path separator.
+      path (str): The path string to be split.
+      separator (str): The path separator.
 
     Returns:
-        list[str]: A list of non-empty path segments.
+      list[str]: A list of non-empty path segments.
     """
     return [s for s in path.split(separator) if s]
 
@@ -226,9 +226,9 @@ class ArtifactsTrie(object):
       """Collects paths from the trie.
 
       Args:
-          node (TrieNode): current node.
-          current_path (str): path leading to this node.
-          artifacts (dict): dictionary to store artifact paths.
+        node (TrieNode): current node.
+        current_path (str): path leading to this node.
+        artifacts (dict): dictionary to store artifact paths.
       """
       if node.artifacts_names:
         for artifact_name in node.artifacts_names:

--- a/plaso/engine/artifacts_trie.py
+++ b/plaso/engine/artifacts_trie.py
@@ -69,7 +69,7 @@ class ArtifactsTrie(object):
           path_separator=path_separator)
     current_node = current_node.children[path_separator]
 
-    # Handle the case when the input path is equal to the path_separator.
+    # Handle the case when the input path is equal to the path separator.
     if path == path_separator:
       current_node.artifacts_names.append(artifact_name)
       return

--- a/plaso/engine/artifacts_trie.py
+++ b/plaso/engine/artifacts_trie.py
@@ -220,7 +220,7 @@ class ArtifactsTrie(object):
       node (TrieNode): current trie node being traversed.
 
     Returns:
-        dict: dictionary mapping artifact names to their paths.
+      dict: dictionary mapping artifact names to their paths.
     """
     artifacts_paths = {}
     self._collect_paths(node, '', artifacts_paths)

--- a/plaso/engine/artifacts_trie.py
+++ b/plaso/engine/artifacts_trie.py
@@ -25,7 +25,7 @@ class TrieNode(object):
     Args:
       path_separator (Optional[str]): the path separator used in paths stored
           in the Trie, default is '/'.
-      is_root (bool): True if this node is the root node.
+      is_root (Optional[bool]): True if this node is the root node.
     """
     super(TrieNode, self).__init__()
     self.artifacts_names = []

--- a/plaso/engine/artifacts_trie.py
+++ b/plaso/engine/artifacts_trie.py
@@ -66,7 +66,7 @@ class ArtifactsTrie(object):
     if path_separator not in node.children:
       node.children[path_separator] = TrieNode(path_separator=path_separator)
     node = node.children[path_separator]
-    # Handle handle the case when the input path is equal to the path_separator
+    # Handle the case when the input path is equal to the path_separator
     if path == path_separator:
       node.artifacts_names.append(artifact_name)
       return
@@ -97,7 +97,7 @@ class ArtifactsTrie(object):
       return []
 
     sub_root_node = self.root.children[path_separator]
-    # Handle handle the case when the input path is equal to the path_separator
+    # Handle the case when the input path is equal to the path_separator
     if path == path_separator:
       matching_artifacts = set()
       if sub_root_node.artifacts_names:

--- a/plaso/engine/artifacts_trie.py
+++ b/plaso/engine/artifacts_trie.py
@@ -13,10 +13,10 @@ class TrieNode(object):
   """Represents a node in the Trie.
 
   Attributes:
-    children (dict[str, TrieNode]): Child nodes, keyed by path segment.
     artifacts_names (list[str]): Names of artifacts associated with this node.
-    path_separator (str): Path separator used in the Trie.
+    children (dict[str, TrieNode]): Child nodes, keyed by path segment.
     is_root (bool): True if this is the root node.
+    path_separator (str): Path separator used in the Trie.
   """
 
   def __init__(self, path_separator=None, is_root=False):
@@ -28,26 +28,26 @@ class TrieNode(object):
       is_root (bool): True if this node is the root node.
     """
     super(TrieNode, self).__init__()
-    self.children = {}
     self.artifacts_names = []
-    self.path_separator = path_separator
+    self.children = {}
     self.is_root = is_root
+    self.path_separator = path_separator
 
 
 class ArtifactsTrie(object):
   """Trie structure for storing artifact paths.
 
   Attributes:
-    root (TrieNode): Root node of the Trie.
     artifacts_paths (dict[str, list[str]]): Artifact paths for glob expansion,
         keyed by artifact name.
+    root (TrieNode): Root node of the Trie.
   """
 
   def __init__(self):
     """Initializes an artifact trie object."""
     super(ArtifactsTrie, self).__init__()
+    self.artifacts_paths = {}
     self.root = TrieNode(is_root=True)
-    self.artifacts_paths = {}  # Store artifact paths for glob expansion
 
   def AddPath(self, artifact_name, path, path_separator):
     """Adds a path from an artifact definition to the Trie.

--- a/plaso/engine/artifacts_trie.py
+++ b/plaso/engine/artifacts_trie.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+"""Trie structure for storing artifact paths."""
+
+import fnmatch
+import glob
+import os
+
+from plaso.engine import logger
+
+
+class TrieNode(object):
+  """Represents a node in the Trie.
+
+  Attributes:
+    children (dict[str, TrieNode]): Child nodes, keyed by path segment.
+    artifacts_names (list[str]): Names of artifacts associated with this node.
+    path_separator (str): Path separator used in the Trie.
+    is_root (bool): True if this is the root node.
+  """
+
+  def __init__(self, path_separator=None, is_root=False):
+    """Initializes a trie node object.
+
+    Args:
+      path_separator (str): the path separator used in paths stored in
+          the Trie, typically '/' or '\'.
+      is_root (bool): True if this node is the root node.
+    """
+    super(TrieNode, self).__init__()
+    self.children = {}
+    self.artifacts_names = []
+    self.path_separator = path_separator
+    self.is_root = is_root
+
+
+class ArtifactsTrie(object):
+  """Trie structure for storing artifact paths.
+
+  Attributes:
+    root (TrieNode): Root node of the Trie.
+    artifacts_paths (dict[str, list[str]]): Artifact paths for glob expansion,
+        keyed by artifact name.
+  """
+
+  def __init__(self):
+    """Initializes an artifact trie object."""
+    super(ArtifactsTrie, self).__init__()
+    self.root = TrieNode(is_root=True)
+    self.artifacts_paths = {}  # Store artifact paths for glob expansion
+
+  def AddPath(self, artifact_name, path, path_separator):
+    """Adds a path from an artifact definition to the Trie.
+
+    Args:
+      artifact_name (str): name of the artifact.
+      path (str): path from the artifact definition.
+      path_separator (str): path separator.
+    """
+    logger.debug(f'Adding path: "{path:s}" to artifact: "{artifact_name:s}"')
+    self.artifacts_paths.setdefault(artifact_name, []).append(path)
+
+    # Start at the root
+    node = self.root
+    # Add a path separator node if this is a new separator
+    if path_separator not in node.children:
+      node.children[path_separator] = TrieNode(path_separator=path_separator)
+    node = node.children[path_separator]
+    # Handle handle the case when the input path is equal to the path_separator
+    if path == path_separator:
+      node.artifacts_names.append(artifact_name)
+      return
+
+    path_segments = path.strip(path_separator).split(path_separator)
+    for segment in path_segments:
+      # Store the path_separator for each node.
+      if not hasattr(node, 'path_separator'):
+        node.path_separator = path_separator
+
+      if segment not in node.children:
+        node.children[segment] = TrieNode(path_separator)
+      node = node.children[segment]
+    node.artifacts_names.append(artifact_name)
+
+  def GetMatchingArtifacts(self, path, path_separator):
+    """Retrieves the artifact names that match the given path.
+
+    Args:
+        path (str): path to match against the Trie.
+        path_separator (str): path separator.
+
+    Returns:
+      list[str]: artifact names that match the path.
+    """
+    # Start at the root's child that matches the path_separator
+    if path_separator not in self.root.children:
+      return []
+
+    sub_root_node = self.root.children[path_separator]
+    # Handle handle the case when the input path is equal to the path_separator
+    if path == path_separator:
+      matching_artifacts = set()
+      if sub_root_node.artifacts_names:
+        matching_artifacts.update(sub_root_node.artifacts_names)
+      return list(matching_artifacts)
+    path_segments = path.strip(path_separator).split(path_separator)
+    matching_artifacts = set()
+    # Update self.artifacts_paths before starting the search.
+    self.artifacts_paths = self._GetArtifactsPaths(sub_root_node)
+
+    def _search_trie(node, current_path, segments):
+      """Searches the trie for paths matching the given path segments.
+
+      Args:
+        node (TrieNode): current trie node being traversed.
+        current_path (str): path represented by the current node.
+        segments (list[str]): remaining path segments to match.
+      """
+      if node.artifacts_names:
+        for artifact_name in node.artifacts_names:
+          for artifact_path in self.artifacts_paths.get(artifact_name, []):
+            if glob.has_magic(artifact_path):
+              if self._MatchesGlobPattern(
+                      artifact_path, current_path, node.path_separator):
+                matching_artifacts.add(artifact_name)
+            elif os.path.normpath(current_path).strip(os.sep).split(
+                os.sep) == os.path.normpath(artifact_path).strip(
+                    node.path_separator).split(node.path_separator):
+              matching_artifacts.add(artifact_name)
+
+      if not segments:
+        return
+
+      segment = segments[0]
+      remaining_segments = segments[1:]
+
+      # Handle glob characters in the current segment.
+      for child_segment, child_node in node.children.items():
+        # If the child is a glob, see if it matches.
+        if glob.has_magic(child_segment):
+          if self._MatchesGlobPattern(
+                  child_segment, segment, child_node.path_separator):
+            _search_trie(child_node, os.path.join(
+                current_path, segment), remaining_segments)
+            _search_trie(node, os.path.join(
+                current_path, segment), remaining_segments)
+        elif child_segment == segment:
+          # If the child is an exact match, continue traversal.
+          _search_trie(child_node, os.path.join(
+              current_path, segment), remaining_segments)
+
+    _search_trie(sub_root_node, '', path_segments)
+    return list(matching_artifacts)
+
+  def _GetArtifactsPaths(self, node):
+    """Retrieves a mapping of artifact names to their paths.
+
+    Args:
+      node (TrieNode): current trie node being traversed.
+
+    Returns:
+        dict: dictionary mapping artifact names to their paths.
+    """
+    artifacts_paths = {}
+
+    def _collect_paths(node, current_path, artifacts):
+      """Collects paths from the trie.
+
+      Args:
+          node (TrieNode): current node.
+          current_path (str): path leading to this node.
+          artifacts (dict): dictionary to store artifact paths.
+      """
+      if node.artifacts_names:
+        for artifact_name in node.artifacts_names:
+          artifacts.setdefault(artifact_name, []).append(current_path)
+
+      for segment, child_node in node.children.items():
+        # Ensure the path_separator attribute exists.
+        if not hasattr(child_node, 'path_separator'):
+          child_node.path_separator = node.path_separator
+
+        # Construct the next path segment.
+        if current_path == child_node.path_separator:
+          # Means it is the root folder, i.e. `/`
+          next_path = current_path + segment
+        else:
+          next_path = current_path + child_node.path_separator + segment
+
+        _collect_paths(child_node, next_path, artifacts)
+
+    _collect_paths(node, '', artifacts_paths)
+    return artifacts_paths
+
+  def _MatchesGlobPattern(self, glob_pattern, path, path_separator):
+    """Checks if a path matches a given glob pattern.
+
+    Args:
+      glob_pattern: The glob pattern to match against.
+      path: The path to check.
+      path_separator: The path separator used in the glob pattern.
+
+    Returns:
+      True if the path matches the glob pattern, False otherwise.
+    """
+    # Normalize paths using the appropriate separators
+    glob_pattern = glob_pattern.strip(path_separator).split(path_separator)
+    path = path.strip(os.sep).split(os.sep)
+
+    i = 0
+    j = 0
+    while i < len(glob_pattern) and j < len(path):
+      if glob_pattern[i] == '**':
+        # If ** is the last part, it matches everything remaining
+        if i == len(glob_pattern) - 1:
+          return True
+        i += 1  # Move to the next part after **
+        while j < len(path) and not fnmatch.fnmatch(path[j], glob_pattern[i]):
+          j += 1  # Keep advancing in the path until the next part matches
+      elif not fnmatch.fnmatch(path[j], glob_pattern[i]):
+        return False  # Mismatch
+      else:
+        i += 1
+        j += 1
+
+    return i == len(glob_pattern) and j == len(path)

--- a/plaso/engine/artifacts_trie.py
+++ b/plaso/engine/artifacts_trie.py
@@ -151,26 +151,27 @@ class ArtifactsTrie(object):
       # the tree to the path segment from to the tool output as it
       # sanitizes path segments before writing data to disk.
       sanitized_child_segment = path_helper.PathHelper.SanitizePathSegments(
-              [child_segment]).pop()
+          [child_segment]).pop()
+
+      # If the child is an exact match, continue traversal.
       if segment in (child_segment, sanitized_child_segment):
-        # If the child is an exact match, continue traversal.
-        self._SearchTrie(child_node, self._CustomPathJoin(
-            path_separator,
-            current_path, child_segment), remaining_segments, path_separator,
+        custom_path = _CustomPathJoin(
+            path_separator, current_path, child_segment)
+        self._SearchTrie(
+            child_node, custom_path, remaining_segments, path_separator,
             matching_artifacts)
+        
       # If the child is a glob, see if it matches.
       elif glob.has_magic(child_segment):
         if self._MatchesGlobPattern(
                 child_segment, segment, child_node.path_separator):
-          self._SearchTrie(child_node, self._CustomPathJoin(
-              path_separator,
-              current_path, segment), remaining_segments, path_separator,
+          custom_path = _CustomPathJoin(
+              path_separator, current_path, segment)
+          self._SearchTrie(
+              child_node, custom_path, remaining_segments, path_separator,
               matching_artifacts)
           self._SearchTrie(
-              node,
-              self._CustomPathJoin(
-                  path_separator,
-                  current_path, segment), remaining_segments, path_separator,
+              node, custom_path, remaining_segments, path_separator,
               matching_artifacts)
 
   def _ComparePathIfSanitized(

--- a/plaso/engine/artifacts_trie.py
+++ b/plaso/engine/artifacts_trie.py
@@ -61,13 +61,14 @@ class ArtifactsTrie(object):
     path_list = self.artifacts_paths.setdefault(artifact_name, [])
     path_list.append(path)
 
-    # Start at the root
     node = self.root
-    # Add a path separator node if this is a new separator
+    
+    # Add a path separator node if this is a new separator.
     if path_separator not in node.children:
       node.children[path_separator] = TrieNode(path_separator=path_separator)
     node = node.children[path_separator]
-    # Handle the case when the input path is equal to the path_separator
+    
+    # Handle the case when the input path is equal to the path_separator.
     if path == path_separator:
       node.artifacts_names.append(artifact_name)
       return
@@ -93,12 +94,13 @@ class ArtifactsTrie(object):
     Returns:
       list[str]: artifact names that match the path.
     """
-    # Start at the root's child that matches the path_separator
+    # Start at the root's child that matches the path_separator.
     if path_separator not in self.root.children:
       return []
 
     sub_root_node = self.root.children[path_separator]
-    # Handle the case when the input path is equal to the path_separator
+    
+    # Handle the case when the input path is equal to the path_separator.
     if path == path_separator:
       matching_artifacts = set()
       if sub_root_node.artifacts_names:
@@ -121,14 +123,12 @@ class ArtifactsTrie(object):
         for artifact_name in node.artifacts_names:
           for artifact_path in self.artifacts_paths.get(artifact_name, []):
             if self._ComparePathIfSanitized(
-                    current_path,
-                    path_separator,
-                    artifact_path,
-                    node.path_separator):
+                current_path, path_separator, artifact_path,
+                node.path_separator):
               matching_artifacts.add(artifact_name)
             elif glob.has_magic(artifact_path):
               if self._MatchesGlobPattern(
-                      artifact_path, current_path, node.path_separator):
+                  artifact_path, current_path, node.path_separator):
                 matching_artifacts.add(artifact_name)
 
       if not segments:

--- a/plaso/engine/engine.py
+++ b/plaso/engine/engine.py
@@ -195,8 +195,7 @@ class BaseEngine(object):
       filters_helper = artifact_filters.ArtifactDefinitionsFiltersHelper(
           self._artifacts_registry)
       filters_helper.BuildFindSpecs(
-          artifact_filter_names,
-          environment_variables=environment_variables,
+          artifact_filter_names, environment_variables=environment_variables,
           user_accounts=user_accounts,
           enable_artifacts_map=enable_artifacts_map)
 
@@ -275,6 +274,14 @@ class BaseEngine(object):
 
     return session
 
+  def GetArtifactsTrie(self):
+    """Retrieves the artifacts trie.
+
+    Returns:
+      ArtifactsTrie: artifacts trie.
+    """
+    return self._artifacts_trie
+  
   def GetCollectionExcludedFindSpecs(self):
     """Retrieves find specifications to exclude from collection.
 
@@ -399,11 +406,3 @@ class BaseEngine(object):
       status_update_interval (float): status update interval.
     """
     self._status_update_interval = status_update_interval
-
-  def GetArtifactsTrie(self):
-    """Retrieves the artifacts trie.
-
-    Returns:
-        ArtifactsTrie: artifacts trie.
-    """
-    return self._artifacts_trie

--- a/plaso/engine/engine.py
+++ b/plaso/engine/engine.py
@@ -281,7 +281,7 @@ class BaseEngine(object):
       ArtifactsTrie: artifacts trie.
     """
     return self._artifacts_trie
-  
+
   def GetCollectionExcludedFindSpecs(self):
     """Retrieves find specifications to exclude from collection.
 

--- a/plaso/engine/engine.py
+++ b/plaso/engine/engine.py
@@ -41,6 +41,7 @@ class BaseEngine(object):
     self._abort = False
     self._analyzers_profiler = None
     self._artifacts_registry = None
+    self._artifacts_trie = None
     self._excluded_file_system_find_specs = None
     self._included_file_system_find_specs = None
     self._memory_profiler = None
@@ -53,7 +54,6 @@ class BaseEngine(object):
     self._status_update_interval = 0.5
     self._storage_profiler = None
     self._task_queue_profiler = None
-    self._artifacts_trie = None
 
     self.knowledge_base = knowledge_base.KnowledgeBase()
 

--- a/plaso/engine/engine.py
+++ b/plaso/engine/engine.py
@@ -53,6 +53,7 @@ class BaseEngine(object):
     self._status_update_interval = 0.5
     self._storage_profiler = None
     self._task_queue_profiler = None
+    self._artifacts_trie = None
 
     self.knowledge_base = knowledge_base.KnowledgeBase()
 
@@ -166,8 +167,12 @@ class BaseEngine(object):
     self._artifacts_registry = registry
 
   def BuildCollectionFilters(
-      self, environment_variables, user_accounts, artifact_filter_names=None,
-      filter_file_path=None):
+          self,
+          environment_variables,
+          user_accounts,
+          artifact_filter_names=None,
+          filter_file_path=None,
+          enable_artifacts_map=False):
     """Builds collection filters from artifacts or filter file if available.
 
     Args:
@@ -178,6 +183,8 @@ class BaseEngine(object):
           definitions that are used for filtering file system and Windows
           Registry key paths.
       filter_file_path (Optional[str]): path of filter file.
+      enable_artifacts_map (Optional[bool]): True if the artifacts path map
+          should be generated. Defaults to False.
 
     Raises:
       InvalidFilter: if no valid file system find specifications are built.
@@ -191,8 +198,10 @@ class BaseEngine(object):
       filters_helper = artifact_filters.ArtifactDefinitionsFiltersHelper(
           self._artifacts_registry)
       filters_helper.BuildFindSpecs(
-          artifact_filter_names, environment_variables=environment_variables,
-          user_accounts=user_accounts)
+          artifact_filter_names,
+          environment_variables=environment_variables,
+          user_accounts=user_accounts,
+          enable_artifacts_map=enable_artifacts_map)
 
       # If the user selected Windows Registry artifacts we have to ensure
       # the Windows Registry files are parsed.
@@ -200,7 +209,10 @@ class BaseEngine(object):
         filters_helper.BuildFindSpecs(
             self._WINDOWS_REGISTRY_FILES_ARTIFACT_NAMES,
             environment_variables=environment_variables,
-            user_accounts=user_accounts)
+            user_accounts=user_accounts,
+            enable_artifacts_map=enable_artifacts_map,
+            original_registery_artifact_filter_names=(
+                filters_helper.registry_find_specs_artifact_names))
 
       if not filters_helper.file_system_find_specs:
         raise errors.InvalidFilter(
@@ -210,6 +222,8 @@ class BaseEngine(object):
       self._included_file_system_find_specs = (
           filters_helper.file_system_find_specs)
       self._registry_find_specs = filters_helper.registry_find_specs
+
+      self._artifacts_trie = filters_helper.artifacts_trie
 
     elif filter_file_path:
       logger.debug((
@@ -388,3 +402,11 @@ class BaseEngine(object):
       status_update_interval (float): status update interval.
     """
     self._status_update_interval = status_update_interval
+
+  def GetArtifactsTrie(self):
+    """Retrieves the artifacts trie.
+
+    Returns:
+        ArtifactsTrie: artifacts trie.
+    """
+    return self._artifacts_trie

--- a/plaso/engine/engine.py
+++ b/plaso/engine/engine.py
@@ -211,7 +211,7 @@ class BaseEngine(object):
             environment_variables=environment_variables,
             user_accounts=user_accounts,
             enable_artifacts_map=enable_artifacts_map,
-            original_registery_artifact_filter_names=(
+            original_registry_artifact_filter_names=(
                 filters_helper.registry_find_specs_artifact_names))
 
       if not filters_helper.file_system_find_specs:

--- a/plaso/engine/engine.py
+++ b/plaso/engine/engine.py
@@ -167,12 +167,9 @@ class BaseEngine(object):
     self._artifacts_registry = registry
 
   def BuildCollectionFilters(
-          self,
-          environment_variables,
-          user_accounts,
-          artifact_filter_names=None,
-          filter_file_path=None,
-          enable_artifacts_map=False):
+      self, environment_variables, user_accounts,
+      artifact_filter_names=None, filter_file_path=None,
+      enable_artifacts_map=False):
     """Builds collection filters from artifacts or filter file if available.
 
     Args:

--- a/plaso/engine/path_helper.py
+++ b/plaso/engine/path_helper.py
@@ -446,7 +446,7 @@ class PathHelper(object):
       target_directory (str): path of the target directory.
       target_filename (str): name of the target file.
       destination_path (str): destination path for the collected files.
-      
+
     Returns:
       str: normalized path or None.
     """

--- a/plaso/engine/path_helper.py
+++ b/plaso/engine/path_helper.py
@@ -439,18 +439,16 @@ class PathHelper(object):
 
   @classmethod
   def GetRelativePath(
-          cls,
-          target_directory,
-          target_filename,
-          destination_path):
+      cls, target_directory, target_filename, destination_path):
     """Retrieves the relative path from the destination path.
 
     Args:
-        target_directory (str): path of the target directory.
-        target_filename (str): name of the target file.
-        destination_path (str): destination path for the collected files.
+      target_directory (str): path of the target directory.
+      target_filename (str): name of the target file.
+      destination_path (str): destination path for the collected files.
+      
     Returns:
-        str: normalized path or None.
+      str: normalized path or None.
     """
 
     if not destination_path.endswith(os.path.sep):

--- a/plaso/engine/path_helper.py
+++ b/plaso/engine/path_helper.py
@@ -450,7 +450,6 @@ class PathHelper(object):
     Returns:
       str: normalized path or None.
     """
-
     if not destination_path.endswith(os.path.sep):
       destination_path = destination_path + os.path.sep
     target_path = os.path.join(target_directory, target_filename)

--- a/plaso/filters/file_entry.py
+++ b/plaso/filters/file_entry.py
@@ -354,6 +354,7 @@ class FileEntryFilterCollection(object):
     """Initializes a file entry filter collection."""
     super(FileEntryFilterCollection, self).__init__()
     self._filters = []
+    self._artifacts_trie = None
 
   def AddFilter(self, file_entry_filter):
     """Adds a file entry filter to the collection.
@@ -401,3 +402,25 @@ class FileEntryFilterCollection(object):
       output_writer.Write('Filters:\n')
       for file_entry_filter in self._filters:
         file_entry_filter.Print(output_writer)
+
+  def SetArtifactsTrie(self, artifacts_trie):
+    """Sets the artifacts trie.
+
+    Args:
+        artifacts_trie (ArtifactsTrie): artifacts trie.
+    """
+    self._artifacts_trie = artifacts_trie
+
+  def GetMatchingArtifacts(self, path, path_separator):
+    """Retrieves the artifacts that match the given path.
+
+    Args:
+        path (str): The path of the extracted file.
+        path_separator (str): The path separator.
+
+    Returns:
+        list[str]: A list of artifact names that match the path.
+    """
+    if self._artifacts_trie:
+      return self._artifacts_trie.GetMatchingArtifacts(path, path_separator)
+    return []

--- a/plaso/filters/file_entry.py
+++ b/plaso/filters/file_entry.py
@@ -378,7 +378,7 @@ class FileEntryFilterCollection(object):
       return []
 
     return self._artifacts_trie.GetMatchingArtifacts(path, path_separator)
-  
+
   def HasFilters(self):
     """Determines if filters are defined.
 

--- a/plaso/filters/file_entry.py
+++ b/plaso/filters/file_entry.py
@@ -353,8 +353,8 @@ class FileEntryFilterCollection(object):
   def __init__(self):
     """Initializes a file entry filter collection."""
     super(FileEntryFilterCollection, self).__init__()
-    self._filters = []
     self._artifacts_trie = None
+    self._filters = []
 
   def AddFilter(self, file_entry_filter):
     """Adds a file entry filter to the collection.
@@ -364,6 +364,21 @@ class FileEntryFilterCollection(object):
     """
     self._filters.append(file_entry_filter)
 
+  def GetMatchingArtifacts(self, path, path_separator):
+    """Retrieves the artifacts that match the given path.
+
+    Args:
+      path (str): The path of the extracted file.
+      path_separator (str): The path separator.
+
+    Returns:
+      list[str]: A list of artifact names that match the path.
+    """
+    if not self._artifacts_trie:
+      return []
+
+    return self._artifacts_trie.GetMatchingArtifacts(path, path_separator)
+  
   def HasFilters(self):
     """Determines if filters are defined.
 
@@ -407,20 +422,6 @@ class FileEntryFilterCollection(object):
     """Sets the artifacts trie.
 
     Args:
-        artifacts_trie (ArtifactsTrie): artifacts trie.
+      artifacts_trie (ArtifactsTrie): artifacts trie.
     """
     self._artifacts_trie = artifacts_trie
-
-  def GetMatchingArtifacts(self, path, path_separator):
-    """Retrieves the artifacts that match the given path.
-
-    Args:
-        path (str): The path of the extracted file.
-        path_separator (str): The path separator.
-
-    Returns:
-        list[str]: A list of artifact names that match the path.
-    """
-    if self._artifacts_trie:
-      return self._artifacts_trie.GetMatchingArtifacts(path, path_separator)
-    return []

--- a/test_data/artifacts/artifacts_filters.yaml
+++ b/test_data/artifacts/artifacts_filters.yaml
@@ -110,3 +110,18 @@ sources:
     separator: '\'
 labels: [System]
 supported_os: [Windows]
+---
+name: WindowsSystemRegistryFiles
+doc: Windows system Registry files.
+sources:
+- type: FILE
+  attributes:
+    paths:
+    - '%%environ_systemdrive%%\System Volume Information\Syscache.hve'
+    - '%%environ_systemroot%%\System32\config\SAM'
+    - '%%environ_systemroot%%\System32\config\SECURITY'
+    - '%%environ_systemroot%%\System32\config\SOFTWARE'
+    - '%%environ_systemroot%%\System32\config\SYSTEM'
+    separator: '\'
+supported_os: [Windows]
+urls: ['https://artifacts-kb.readthedocs.io/en/latest/sources/windows/RegistryFiles.html']

--- a/tests/cli/image_export_tool.py
+++ b/tests/cli/image_export_tool.py
@@ -699,9 +699,8 @@ class ImageExportToolTest(test_lib.CLIToolTestCase):
       # Verify that no files were extracted.
       # Only artifacts_map.json and hashes.json should exist.
       self.assertEqual(
-          sorted(os.listdir(temp_directory)), sorted(
-              ['hashes.json', 'artifacts_map.json'])
-      )
+          sorted(os.listdir(temp_directory)),
+          sorted(['hashes.json', 'artifacts_map.json']))
 
       # Verify that the trie has no matching paths for image.qcow2.
       self.assertIsNotNone(test_tool._filter_collection._artifacts_trie)
@@ -711,8 +710,7 @@ class ImageExportToolTest(test_lib.CLIToolTestCase):
 
       # Verify that artifacts_map.json is created but empty
       artifacts_map_file_path = os.path.join(
-          temp_directory, "artifacts_map.json"
-      )
+          temp_directory, "artifacts_map.json")
       with open(
           artifacts_map_file_path, "r", encoding="utf-8"
       ) as file_object:

--- a/tests/cli/image_export_tool.py
+++ b/tests/cli/image_export_tool.py
@@ -641,8 +641,11 @@ class ImageExportToolTest(test_lib.CLIToolTestCase):
           os.path.join(temp_directory, 'hashes.json'),
           os.path.join(temp_directory, 'artifacts_map.json')])
       expected_json_data = {
-          'TestFiles3': ['a_directory/another_file', 'a_directory/a_file'],
-          'TestFiles4': ['a_directory/another_file', 'passwords.txt']
+          'TestFiles3': [
+              f'a_directory{os.sep}another_file',
+              f'a_directory{os.sep}a_file'],
+          'TestFiles4':
+              [f'a_directory{os.sep}another_file', 'passwords.txt']
       }
 
       extracted_files = self._RecursiveList(temp_directory)
@@ -699,7 +702,8 @@ class ImageExportToolTest(test_lib.CLIToolTestCase):
       # Verify that no files were extracted.
       # Only artifacts_map.json and hashes.json should exist.
       self.assertEqual(
-          os.listdir(temp_directory), ['hashes.json', 'artifacts_map.json']
+          sorted(os.listdir(temp_directory)), sorted(
+              ['hashes.json', 'artifacts_map.json'])
       )
 
       # Verify that the trie has no matching paths for image.qcow2.

--- a/tests/cli/image_export_tool.py
+++ b/tests/cli/image_export_tool.py
@@ -596,8 +596,7 @@ class ImageExportToolTest(test_lib.CLIToolTestCase):
       self.assertEqual(json_data, expected_json_data)
 
   def testProcessSourceEnableArtifactsMap(self):
-    """Tests the ProcessSource function with a artifacts filter file and
-    enable_artifacts_map flag.
+    """Tests the ProcessSource function with atrifacts map enabled.
 
     This test uses plaso/test_data/image.qcow2 which has directories matching
     artifact filters: [TestGroupExport, TestFiles3, TestFiles4,

--- a/tests/cli/image_export_tool.py
+++ b/tests/cli/image_export_tool.py
@@ -644,11 +644,9 @@ class ImageExportToolTest(test_lib.CLIToolTestCase):
               f'a_directory{os.sep}another_file',
               f'a_directory{os.sep}a_file'],
           'TestFiles4':
-              [f'a_directory{os.sep}another_file', 'passwords.txt']
-      }
+              [f'a_directory{os.sep}another_file', 'passwords.txt']}
 
       extracted_files = self._RecursiveList(temp_directory)
-
       self.assertEqual(sorted(extracted_files), expected_extracted_files)
 
       # Verify content of artifacts_map.json

--- a/tests/cli/image_export_tool.py
+++ b/tests/cli/image_export_tool.py
@@ -710,7 +710,7 @@ class ImageExportToolTest(test_lib.CLIToolTestCase):
       self.assertIsNotNone(test_tool._filter_collection._artifacts_trie)
       self.assertNotIn('a_directory',
                        test_tool._filter_collection._artifacts_trie.root
-                       .children['/'].children)
+                       .children[os.sep].children)
 
       # Verify that artifacts_map.json is created but empty
       artifacts_map_file_path = os.path.join(

--- a/tests/cli/image_export_tool.py
+++ b/tests/cli/image_export_tool.py
@@ -780,11 +780,11 @@ class ImageExportToolTest(test_lib.CLIToolTestCase):
       test_tool.ProcessSource()
 
       output = output_writer.ReadOutput()
+      error_msg = ', '.join(test_tool._SOURCE_TYPES_TO_PREPROCESS)
       self.assertEqual(
           output,
-          ('Input must be in '
-           f'{list(test_tool._SOURCE_TYPES_TO_PREPROCESS)} '
-           'the "file" type is not supported.\n')
+          (f'Input must be in "{error_msg}" '
+           'the type: "file" is not supported.\n')
       )
 
 

--- a/tests/engine/artifact_filters.py
+++ b/tests/engine/artifact_filters.py
@@ -338,67 +338,61 @@ class ArtifactDefinitionsFiltersHelperTest(shared_test_lib.BaseTestCase):
     # Test that paths are added to artifacts trie.
     self.assertIn(os.sep, test_filter_file.artifacts_trie.root.children)
     path_trie_node = test_filter_file.artifacts_trie.root.children[os.sep]
+    path_trie_node_children = path_trie_node.children
     self.assertEqual(
         path_trie_node.artifacts_names, [])
-    self.assertEqual(len(path_trie_node.children), 5)
-    self.assertIn('Windows', path_trie_node.children)
-    self.assertIn('test_data', path_trie_node.children)
-    self.assertIn('home', path_trie_node.children)
-    self.assertIn('Users', path_trie_node.children)
-    self.assertIn('homes', path_trie_node.children)
+    self.assertEqual(len(path_trie_node_children), 5)
+    self.assertIn('Windows', path_trie_node_children)
+    self.assertIn('test_data', path_trie_node_children)
+    self.assertIn('home', path_trie_node_children)
+    self.assertIn('Users', path_trie_node_children)
+    self.assertIn('homes', path_trie_node_children)
 
     self.assertEqual(
-        path_trie_node.children['Windows'].artifacts_names, [])
+        path_trie_node_children['Windows'].artifacts_names, [])
     self.assertIn(
-        'test_data', path_trie_node.children['Windows'].children)
+        'test_data', path_trie_node_children['Windows'].children)
 
+    test_data_children = path_trie_node_children['test_data'].children
     self.assertEqual(
-        path_trie_node.children['test_data'].artifacts_names, [])
-    self.assertEqual(len(path_trie_node.children['test_data'].children), 1)
-    self.assertIn('*', path_trie_node.children['test_data'].children)
+        path_trie_node_children['test_data'].artifacts_names, [])
+    self.assertEqual(len(test_data_children), 1)
+    self.assertIn('*', test_data_children)
 
+    star_children = test_data_children['*'].children
     self.assertEqual(
-        path_trie_node.children['test_data']
-        .children['*'].artifacts_names,
+        test_data_children['*'].artifacts_names,
         [artifact_name])
-    
     self.assertEqual(
-        len(path_trie_node.children['test_data'].children['*'].children), 1)
+        len(star_children), 1)
     self.assertIn(
-        '*', path_trie_node.children['test_data'].children['*'].children)
+        '*', star_children)
 
     self.assertEqual(
-        path_trie_node.children['test_data']
-        .children['*'].children['*'].artifacts_names,
+        star_children['*'].artifacts_names,
         [artifact_name]
     )
     self.assertEqual(
-        len(
-            path_trie_node.children['test_data']
-            .children['*'].children['*'].children
-        ),
-        1
-    )
+        len(star_children['*'].children), 1)
     self.assertIn(
         '*',
-        path_trie_node.children['test_data'].children['*']
-        .children['*'].children
+        star_children['*'].children
     )
 
     self.assertEqual(
-        path_trie_node.children['home'].artifacts_names, [])
+        path_trie_node_children['home'].artifacts_names, [])
     self.assertIn(
-        'testuser2', path_trie_node.children['home'].children)
+        'testuser2', path_trie_node_children['home'].children)
 
     self.assertEqual(
-        path_trie_node.children['Users'].artifacts_names, [])
+        path_trie_node_children['Users'].artifacts_names, [])
     self.assertIn(
-        'testuser2', path_trie_node.children['Users'].children)
+        'testuser2', path_trie_node_children['Users'].children)
 
     self.assertEqual(
-        path_trie_node.children['homes'].artifacts_names, [])
+        path_trie_node_children['homes'].artifacts_names, [])
     self.assertIn(
-        'testuser1', path_trie_node.children['homes'].children)
+        'testuser1', path_trie_node_children['homes'].children)
 
   def testBuildFindSpecsFromRegistrySourceKey(self):
     """Tests the _BuildFindSpecsFromRegistrySourceKey function on Windows
@@ -420,10 +414,12 @@ class ArtifactDefinitionsFiltersHelperTest(shared_test_lib.BaseTestCase):
         'HKEY_LOCAL_MACHINE', 'System', 'ControlSet.*', 'Control', '.*', '.*',
         '.*', '.*', '.*', '.*', '.*', '.*', '.*', '.*']
 
+    first_find_spec = find_specs[0]
+    last_find_spec = find_specs[-1]
     self.assertEqual(
-        find_specs[0]._key_path_segments, first_expected_key_path_segments)
+        first_find_spec._key_path_segments, first_expected_key_path_segments)
     self.assertEqual(
-        find_specs[-1]._key_path_segments, last_expected_key_path_segments)
+        last_find_spec._key_path_segments, last_expected_key_path_segments)
 
     # Test CurrentControlSet
     key_path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control'

--- a/tests/engine/artifact_filters.py
+++ b/tests/engine/artifact_filters.py
@@ -221,8 +221,7 @@ class ArtifactDefinitionsFiltersHelperTest(shared_test_lib.BaseTestCase):
         separator,
         environment_variable,
         test_user_accounts,
-        enable_artifacts_map=True
-    )
+        enable_artifacts_map=True)
 
     # Should build 1 find_spec.
     self.assertEqual(len(find_specs), 1)
@@ -244,8 +243,7 @@ class ArtifactDefinitionsFiltersHelperTest(shared_test_lib.BaseTestCase):
         separator,
         environment_variable,
         test_user_accounts,
-        enable_artifacts_map=True
-    )
+        enable_artifacts_map=True)
 
     # Glob expansion should by default recurse ten levels.
     self.assertEqual(len(find_specs), 10)
@@ -277,8 +275,7 @@ class ArtifactDefinitionsFiltersHelperTest(shared_test_lib.BaseTestCase):
         separator,
         environment_variable,
         test_user_accounts,
-        enable_artifacts_map=True
-    )
+        enable_artifacts_map=True)
 
     # 6 find specs should be created for testuser1 and testuser2.
     self.assertEqual(len(find_specs), 6)
@@ -307,8 +304,7 @@ class ArtifactDefinitionsFiltersHelperTest(shared_test_lib.BaseTestCase):
         separator,
         environment_variable,
         test_user_accounts,
-        enable_artifacts_map=True
-    )
+        enable_artifacts_map=True)
 
     # 8 find specs should be created for testuser1 and testuser2.
     self.assertEqual(len(find_specs), 8)
@@ -327,8 +323,7 @@ class ArtifactDefinitionsFiltersHelperTest(shared_test_lib.BaseTestCase):
         separator,
         environment_variable,
         test_user_accounts,
-        enable_artifacts_map=True
-    )
+        enable_artifacts_map=True)
 
     # 16 find specs should be created for testuser1 and testuser2.
     self.assertEqual(len(find_specs), 16)
@@ -365,8 +360,8 @@ class ArtifactDefinitionsFiltersHelperTest(shared_test_lib.BaseTestCase):
     self.assertEqual(
         path_trie_node.children['test_data']
         .children['*'].artifacts_names,
-        [artifact_name]
-    )
+        [artifact_name])
+    
     self.assertEqual(
         len(path_trie_node.children['test_data'].children['*'].children), 1)
     self.assertIn(

--- a/tests/engine/artifacts_trie.py
+++ b/tests/engine/artifacts_trie.py
@@ -15,9 +15,7 @@ class TrieNodeTest(unittest.TestCase):
     self.assertIsNotNone(node)
     self.assertEqual(node.children, {})
     self.assertEqual(node.artifacts_names, [])
-    self.assertIsNone(node.path_separator)
-
-  # You can add more tests for TrieNode if needed, but it's a simple class.
+    self.assertEqual(node.path_separator, '/')
 
 
 class ArtifactsTrieTest(unittest.TestCase):

--- a/tests/engine/artifacts_trie.py
+++ b/tests/engine/artifacts_trie.py
@@ -33,26 +33,22 @@ class ArtifactsTrieTest(unittest.TestCase):
     root = self.trie.root
     self.assertIn('/', root.children)
     self.assertIn('path', root.children['/'].children)
-    self.assertIn('to', root.children['/'].children['path'].children)
+    path_children = root.children['/'].children['path'].children
+    self.assertIn('to', path_children)
+    to_children = path_children['to'].children
     self.assertIn(
-        'file.txt', root.children['/'].children['path'].children['to'].children)
+        'file.txt', to_children)
     self.assertIn(
         'another.txt',
-        root.children['/'].children['path'].children['to'].children
+        to_children
     )
     self.assertEqual(
-        root.children['/']
-        .children['path']
-        .children['to']
-        .children['file.txt']
+        to_children['file.txt']
         .artifacts_names,
         ['artifact1'],
     )
     self.assertEqual(
-        root.children['/']
-        .children['path']
-        .children['to']
-        .children['another.txt']
+        to_children['another.txt']
         .artifacts_names,
         ['artifact2']
     )
@@ -65,24 +61,20 @@ class ArtifactsTrieTest(unittest.TestCase):
     root = self.trie.root
     self.assertIn('/', root.children)
     self.assertIn('path', root.children['/'].children)
-    self.assertIn('to', root.children['/'].children['path'].children)
+    path_children = root.children['/'].children['path'].children
+    self.assertIn('to', path_children)
+    to_children = path_children['to'].children
     self.assertIn(
-        '*.txt', root.children['/'].children['path'].children['to'].children)
+        '*.txt', to_children)
     self.assertIn(
-        'dir**', root.children['/'].children['path'].children['to'].children)
+        'dir**', to_children)
     self.assertEqual(
-        root.children['/']
-        .children['path']
-        .children['to']
-        .children['*.txt']
+        to_children['*.txt']
         .artifacts_names,
         ['artifact1']
     )
     self.assertEqual(
-        root.children['/']
-        .children['path']
-        .children['to']
-        .children['dir**']
+        to_children['dir**']
         .artifacts_names,
         ['artifact2']
     )

--- a/tests/engine/artifacts_trie.py
+++ b/tests/engine/artifacts_trie.py
@@ -273,6 +273,27 @@ class ArtifactsTrieTest(unittest.TestCase):
     matches = self.trie.GetMatchingArtifacts('/path/to/file.txt', '/')
     self.assertNotIn('artifact1', matches)
 
+  def test_get_matching_artifacts_sanitized_paths(self):
+    """Tests GetMatchingArtifacts with sanitized paths."""
+    self.trie.AddPath('artifact1', '/path/to/file\x00\x01.txt', '/')
+    self.trie.AddPath('artifact2', '/another/path/fo:r?/file.txt', '/')
+
+    # Test path with dirty characters that would be sanitized.
+    matches = self.trie.GetMatchingArtifacts(
+        '/path/to/file__.txt', '/')
+    self.assertIn('artifact1', matches)
+
+    # Test with a different path that sanitizes to the same value.
+    matches = self.trie.GetMatchingArtifacts(
+        '/another/path/fo_r_/file.txt', '/')
+    self.assertIn('artifact2', matches)
+
+    # Negative test with non-matching sanitized path.
+    matches = self.trie.GetMatchingArtifacts(
+        '/nonexistent/path/fo_r_/file.txt', '/')
+    self.assertNotIn('artifact1', matches)
+    self.assertNotIn('artifact2', matches)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/engine/artifacts_trie.py
+++ b/tests/engine/artifacts_trie.py
@@ -1,0 +1,275 @@
+# -*- coding: utf-8 -*-
+"""Tests for the artifacts trie."""
+
+import unittest
+
+from plaso.engine import artifacts_trie
+
+
+class TrieNodeTest(unittest.TestCase):
+  """Tests for the TrieNode object."""
+
+  def test_initialization(self):
+    """Test that the node can be initialized."""
+    node = artifacts_trie.TrieNode()
+    self.assertIsNotNone(node)
+    self.assertEqual(node.children, {})
+    self.assertEqual(node.artifacts_names, [])
+    self.assertIsNone(node.path_separator)
+
+  # You can add more tests for TrieNode if needed, but it's a simple class.
+
+
+class ArtifactsTrieTest(unittest.TestCase):
+  """Tests for the artifactsTrie object."""
+
+  def setUp(self):
+    """Setup a trie for testing."""
+    self.trie = artifacts_trie.ArtifactsTrie()
+
+  def test_add_path(self):
+    """Tests the AddPath function."""
+    self.trie.AddPath('artifact1', '/path/to/file.txt', '/')
+    self.trie.AddPath('artifact2', '/path/to/another.txt', '/')
+
+    root = self.trie.root
+    self.assertIn('/', root.children)
+    self.assertIn('path', root.children['/'].children)
+    self.assertIn('to', root.children['/'].children['path'].children)
+    self.assertIn(
+        'file.txt', root.children['/'].children['path'].children['to'].children)
+    self.assertIn(
+        'another.txt',
+        root.children['/'].children['path'].children['to'].children
+    )
+    self.assertEqual(
+        root.children['/']
+        .children['path']
+        .children['to']
+        .children['file.txt']
+        .artifacts_names,
+        ['artifact1'],
+    )
+    self.assertEqual(
+        root.children['/']
+        .children['path']
+        .children['to']
+        .children['another.txt']
+        .artifacts_names,
+        ['artifact2']
+    )
+
+  def test_add_path_with_glob(self):
+    """Tests the AddPath function with glob patterns."""
+    self.trie.AddPath('artifact1', '/path/to/*.txt', '/')
+    self.trie.AddPath('artifact2', '/path/to/dir**', '/')
+
+    root = self.trie.root
+    self.assertIn('/', root.children)
+    self.assertIn('path', root.children['/'].children)
+    self.assertIn('to', root.children['/'].children['path'].children)
+    self.assertIn(
+        '*.txt', root.children['/'].children['path'].children['to'].children)
+    self.assertIn(
+        'dir**', root.children['/'].children['path'].children['to'].children)
+    self.assertEqual(
+        root.children['/']
+        .children['path']
+        .children['to']
+        .children['*.txt']
+        .artifacts_names,
+        ['artifact1']
+    )
+    self.assertEqual(
+        root.children['/']
+        .children['path']
+        .children['to']
+        .children['dir**']
+        .artifacts_names,
+        ['artifact2']
+    )
+
+  def test_get_matching_artifacts_no_glob(self):
+    """Tests GetMatchingArtifacts without glob."""
+    self.trie.AddPath('artifact1', '/path/to/file.txt', '/')
+    self.trie.AddPath('artifact2', '/path/to/another.txt', '/')
+
+    matches = self.trie.GetMatchingArtifacts('/path/to/file.txt', '/')
+    self.assertIn('artifact1', matches)
+    self.assertNotIn('artifact2', matches)
+
+  def test_get_matching_artifacts_with_glob(self):
+    """Tests GetMatchingArtifacts with glob patterns."""
+    self.trie.AddPath('artifact1', '/path/to/*.txt', '/')
+    self.trie.AddPath('artifact2', '/path/**/file.txt', '/')
+    # The trie structure will have these paths and children
+    # root
+    #  |
+    #  /
+    #  |
+    #  path
+    #   |
+    #  to, **
+    #   |   |
+    #  *.txt  file.txt
+
+    matches = self.trie.GetMatchingArtifacts('/path/to/file.txt', '/')
+    self.assertIn('artifact1', matches)
+    self.assertIn('artifact2', matches)
+
+    matches = self.trie.GetMatchingArtifacts('/path/to/dir/file.txt', '/')
+    self.assertIn('artifact2', matches)
+    self.assertNotIn('artifact1', matches)
+
+  def test_get_matching_artifacts_with_multiple_globs(self):
+    """Tests GetMatchingArtifacts with multiple consecutive glob patterns."""
+    self.trie.AddPath('artifact1', '/**/**/file.txt', '/')
+    self.trie.AddPath('artifact2', '/**/**/another.txt', '/')
+
+    # The trie structure will have these paths and children
+    # root
+    #  |
+    #  /
+    #  |
+    #  **
+    #   |
+    #  **, file.txt, another.txt
+
+    matches = self.trie.GetMatchingArtifacts(
+        '/path/to/dir/subdir/file.txt', '/')
+    self.assertIn('artifact1', matches)
+    self.assertNotIn('artifact2', matches)
+
+    matches = self.trie.GetMatchingArtifacts(
+        '/path/to/dir/subdir/another.txt', '/')
+    self.assertIn('artifact2', matches)
+    self.assertNotIn('artifact1', matches)
+
+  def test_get_matching_artifacts_single_asterisk(self):
+    """Tests GetMatchingArtifacts with single asterisk glob patterns."""
+    self.trie.AddPath('artifact1', '/path/to/*/file.txt', '/')
+    self.trie.AddPath('artifact2', '/path/*/data/*.txt', '/')
+    self.trie.AddPath(
+        'artifact3', '/home/*/.jupyter/jupyter_notebook_config.py', '/')
+
+    matches = self.trie.GetMatchingArtifacts('/path/to/dir/file.txt', '/')
+    self.assertIn('artifact1', matches)
+    self.assertNotIn('artifact2', matches)
+
+    matches = self.trie.GetMatchingArtifacts(
+        '/path/dir/data/test.txt', '/')
+    self.assertNotIn('artifact1', matches)
+    self.assertIn('artifact2', matches)
+
+    matches = self.trie.GetMatchingArtifacts(
+        '/home/dummyuser/.jupyter/jupyter_notebook_config.py', '/')
+    self.assertNotIn('artifact1', matches)
+    self.assertNotIn('artifact2', matches)
+    self.assertIn('artifact3', matches)
+
+  def test_get_matching_artifacts_windows_paths(self):
+    """Tests GetMatchingArtifacts with Windows paths."""
+    self.trie.AddPath('artifact1', '\\Windows\\System32\\*.dll', '\\')
+    self.trie.AddPath('artifact2', '\\Users\\**\\AppData\\*', '\\')
+
+    matches = self.trie.GetMatchingArtifacts(
+        '\\Windows\\System32\\kernel32.dll', '\\')
+    self.assertIn('artifact1', matches)
+    self.assertNotIn('artifact2', matches)
+
+    matches = self.trie.GetMatchingArtifacts(
+        '\\Users\\test\\AppData\\Local', '\\')
+    self.assertIn('artifact2', matches)
+    self.assertNotIn('artifact1', matches)
+
+  def test_get_matching_artifacts_negative_cases(self):
+    """Tests GetMatchingArtifacts with non-matching cases."""
+    self.trie.AddPath('artifact1', '/path/to/file.txt', '/')
+    self.trie.AddPath('artifact2', '/path/to/*.txt', '/')
+    self.trie.AddPath('artifact3', '/path/**/file.txt', '/')
+
+    matches = self.trie.GetMatchingArtifacts('/path/to/other.txt', '/')
+    self.assertNotIn('artifact1', matches)
+    self.assertNotIn('artifact3', matches)
+
+    matches = self.trie.GetMatchingArtifacts('/path/dir/file.txt', '/')
+    self.assertNotIn('artifact1', matches)
+    self.assertNotIn('artifact2', matches)
+
+    matches = self.trie.GetMatchingArtifacts('/path/to/dir/test/fi*.txt', '/')
+    self.assertNotIn('artifact1', matches)
+    self.assertNotIn('artifact2', matches)
+
+  def test_add_path_with_mixed_separators(self):
+    """Tests the AddPath function with mixed path separators."""
+    self.trie.AddPath('artifact1', '/mixed/path/style', '/')
+    self.trie.AddPath('artifact2', '\\another\\mixed\\style', '\\')
+
+    root = self.trie.root
+    self.assertIn('/', root.children)
+    self.assertIn('mixed', root.children['/'].children)
+
+    self.assertIn('\\', root.children)
+    self.assertIn('another', root.children['\\'].children)
+
+  def test_get_matching_artifacts_mixed_separators(self):
+    """Tests GetMatchingArtifacts with mixed path separators."""
+    self.trie.AddPath('artifact1', '/mixed/path/style', '/')
+    self.trie.AddPath('artifact2', '\\another\\mixed\\style', '\\')
+
+    matches = self.trie.GetMatchingArtifacts('/mixed/path/style', '/')
+    self.assertIn('artifact1', matches)
+
+    matches = self.trie.GetMatchingArtifacts('\\another\\mixed\\style', '\\')
+    self.assertIn('artifact2', matches)
+
+  def test_get_matching_artifacts_same_path_different_artifacts(self):
+    """Tests GetMatchingArtifacts with same path for different artifacts."""
+    self.trie.AddPath('artifact1', '/same/path/file.txt', '/')
+    self.trie.AddPath('artifact2', '/same/path/file.txt', '/')
+
+    matches = self.trie.GetMatchingArtifacts('/same/path/file.txt', '/')
+    self.assertIn('artifact1', matches)
+    self.assertIn('artifact2', matches)
+
+  def test_get_matching_artifacts_empty_path(self):
+    """Tests GetMatchingArtifacts with an empty path."""
+    self.trie.AddPath('artifact1', '/path/to/file.txt', '/')
+
+    matches = self.trie.GetMatchingArtifacts('', '/')
+    self.assertEqual(len(matches), 0)
+
+  def test_get_matching_artifacts_root_path(self):
+    """Tests GetMatchingArtifacts with root path."""
+    self.trie.AddPath('artifact1', '/', '/')
+
+    matches = self.trie.GetMatchingArtifacts('/', '/')
+    self.assertIn('artifact1', matches)
+
+  def test_get_matching_artifacts_nonexistent_path(self):
+    """Tests GetMatchingArtifacts with a nonexistent path."""
+    self.trie.AddPath('artifact1', '/path/to/file.txt', '/')
+
+    matches = self.trie.GetMatchingArtifacts('/nonexistent/path', '/')
+    self.assertEqual(len(matches), 0)
+
+  def test_get_matching_artifacts_case_sensitivity(self):
+    """Tests GetMatchingArtifacts with different case sensitivity."""
+    self.trie.AddPath('artifact1', '/path/to/file.txt', '/')
+
+    matches = self.trie.GetMatchingArtifacts('/Path/To/File.TXT', '/')
+    self.assertNotIn('artifact1', matches)
+
+  def test_get_matching_artifacts_special_characters(self):
+    """Tests GetMatchingArtifacts with special characters in path."""
+    self.trie.AddPath('artifact1', '/path/to/file[0-9].txt', '/')
+
+    matches = self.trie.GetMatchingArtifacts('/path/to/file1.txt', '/')
+    self.assertIn('artifact1', matches)
+
+    matches = self.trie.GetMatchingArtifacts('/path/to/file.txt', '/')
+    self.assertNotIn('artifact1', matches)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/engine/artifacts_trie.py
+++ b/tests/engine/artifacts_trie.py
@@ -202,8 +202,9 @@ class ArtifactsTrieTest(unittest.TestCase):
 
   def test_add_path_with_mixed_separators(self):
     """Tests the AddPath function with mixed path separators."""
-    self.trie.AddPath('artifact1', '/mixed/path/style', '/')
-    self.trie.AddPath('artifact2', '\\another\\mixed\\style', '\\')
+    self.trie.AddPath('artifact1', '/mixed/path/style_s', '/')
+    self.trie.AddPath(
+        'artifact2', '\\another\\mixed path\\style to-match_it', '\\')
 
     root = self.trie.root
     self.assertIn('/', root.children)
@@ -214,13 +215,15 @@ class ArtifactsTrieTest(unittest.TestCase):
 
   def test_get_matching_artifacts_mixed_separators(self):
     """Tests GetMatchingArtifacts with mixed path separators."""
-    self.trie.AddPath('artifact1', '/mixed/path/style', '/')
-    self.trie.AddPath('artifact2', '\\another\\mixed\\style', '\\')
+    self.trie.AddPath('artifact1', '/mixed/path/style_s', '/')
+    self.trie.AddPath(
+        'artifact2', '\\another\\mixed path\\style to-match_it', '\\')
 
-    matches = self.trie.GetMatchingArtifacts('/mixed/path/style', '/')
+    matches = self.trie.GetMatchingArtifacts('/mixed/path/style_s', '/')
     self.assertIn('artifact1', matches)
 
-    matches = self.trie.GetMatchingArtifacts('\\another\\mixed\\style', '\\')
+    matches = self.trie.GetMatchingArtifacts(
+        '\\another\\mixed path\\style to-match_it', '\\')
     self.assertIn('artifact2', matches)
 
   def test_get_matching_artifacts_same_path_different_artifacts(self):

--- a/tests/engine/engine.py
+++ b/tests/engine/engine.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Tests the engine."""
 
+import os
 import unittest
 
 from dfvfs.helpers import fake_file_system_builder
@@ -11,8 +12,10 @@ from dfvfs.path import path_spec
 from dfvfs.resolver import context
 from dfvfs.vfs import file_system as dfvfs_file_system
 
+from plaso.containers import artifacts as containers_artifacts
 from plaso.engine import configurations
 from plaso.engine import engine
+from plaso.lib import errors
 from plaso.storage.fake import writer as fake_writer
 
 from tests import test_lib as shared_test_lib
@@ -93,7 +96,115 @@ class BaseEngineTest(shared_test_lib.BaseTestCase):
 
     # TODO: add test that raises BadConfigOption
 
-  # TODO: add tests for BuildCollectionFilters.
+  def testBuildCollectionFilters(self):
+    """Tests the BuildCollectionFilters function."""
+    test_artifacts_path = shared_test_lib.GetTestFilePath(['artifacts'])
+    self._SkipIfPathNotExists(test_artifacts_path)
+
+    test_engine = TestEngine()
+    test_engine.BuildArtifactsRegistry(test_artifacts_path, None)
+
+    # Test with artifact_filter_names
+    artifact_filter_names = ['TestFiles', 'TestFiles2']
+    environment_variables = [
+        containers_artifacts.EnvironmentVariableArtifact(
+            case_sensitive=False, name='systemdrive', value='C:'
+        )
+    ]
+    test_user_accounts = [
+        containers_artifacts.UserAccountArtifact(
+            identifier='1000',
+            path_separator='\\',
+            user_directory='C:\\Users\\testuser1',
+            username='testuser1',
+        ),
+        containers_artifacts.UserAccountArtifact(
+            identifier='1001',
+            path_separator='\\',
+            user_directory='%%environ_systemdrive%%\\Users\\testuser2',
+            username='testuser2',
+        ),
+    ]
+
+    # Pass artifact_filter_names to CreateSession
+    session = test_engine.CreateSession(
+        artifact_filter_names=artifact_filter_names)
+    test_engine.BuildCollectionFilters(
+        environment_variables,
+        test_user_accounts,
+        artifact_filter_names=session.artifact_filters,
+        enable_artifacts_map=True
+    )
+
+    self.assertIsNotNone(test_engine._artifacts_trie)
+    # Verify content of the artifacts trie
+    self.assertIn(os.sep, test_engine._artifacts_trie.root.children)
+    trie_root = test_engine._artifacts_trie.root.children[os.sep]
+    self.assertIn(
+        'test_data',
+        trie_root.children)
+    self.assertIn(
+        '*.evtx',
+        trie_root.children['test_data'].children)
+    self.assertIn(
+        'Users',
+        trie_root.children)
+    self.assertIn(
+        'testuser1',
+        trie_root.children['Users'].children)
+    self.assertIn(
+        'testuser2',
+        trie_root.children['Users'].children)
+    self.assertIn(
+        'Documents',
+        trie_root.children['Users'].children['testuser1'].children)
+    self.assertIn(
+        'Documents',
+        trie_root.children['Users'].children['testuser2'].children)
+    self.assertIn(
+        'WindowsPowerShell',
+        trie_root.children['Users'].children['testuser1']
+        .children['Documents'].children)
+    self.assertIn(
+        'WindowsPowerShell',
+        trie_root.children['Users'].children['testuser2']
+        .children['Documents'].children)
+    self.assertIn(
+        'profile.ps1',
+        trie_root.children['Users'].children['testuser1']
+        .children['Documents'].children['WindowsPowerShell'].children)
+    self.assertIn(
+        'profile.ps1',
+        trie_root.children['Users'].children['testuser2']
+        .children['Documents'].children['WindowsPowerShell'].children)
+
+    # Test with filter_file_path
+    test_filter_file_path = self._GetTestFilePath(
+        ['end_to_end', 'filter_file2.yaml'])
+    self._SkipIfPathNotExists(test_filter_file_path)
+
+    test_engine.BuildCollectionFilters(
+        environment_variables,
+        test_user_accounts,
+        filter_file_path=test_filter_file_path,
+        enable_artifacts_map=True
+    )
+
+    self.assertIsNotNone(test_engine._included_file_system_find_specs)
+    self.assertIsNotNone(test_engine._excluded_file_system_find_specs)
+
+    # Test specific file paths from filter file.
+    included_find_specs = test_engine.GetCollectionIncludedFindSpecs()
+    self.assertGreater(len(included_find_specs), 0)
+
+    # Test with invalid filter
+    with self.assertRaises(errors.InvalidFilter):
+      test_engine.BuildCollectionFilters(
+          environment_variables,
+          test_user_accounts,
+          artifact_filter_names=['NonExistentArtifact'],
+          enable_artifacts_map=True
+      )
 
   def testCreateSession(self):
     """Tests the CreateSession function."""
@@ -116,8 +227,12 @@ class BaseEngineTest(shared_test_lib.BaseTestCase):
         parent=os_path_spec)
 
     resolver_context = context.Context()
-    test_file_system, test_mount_point = test_engine.GetSourceFileSystem(
-        source_path_spec, resolver_context=resolver_context)
+    (
+        test_file_system,
+        test_mount_point,
+    ) = test_engine.GetSourceFileSystem(
+        source_path_spec, resolver_context=resolver_context
+    )
 
     self.assertIsNotNone(test_file_system)
     self.assertIsInstance(test_file_system, dfvfs_file_system.FileSystem)
@@ -149,11 +264,12 @@ class BaseEngineTest(shared_test_lib.BaseTestCase):
     storage_writer.Open()
 
     source_configurations = test_engine.PreprocessSource(
-        [source_path_spec], storage_writer)
+        [source_path_spec], storage_writer
+    )
 
     self.assertEqual(len(source_configurations), 1)
-    self.assertEqual(source_configurations[0].operating_system, 'Windows NT')
+    self.assertEqual(source_configurations[0].operating_system, "Windows NT")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
   unittest.main()

--- a/tests/engine/engine.py
+++ b/tests/engine/engine.py
@@ -138,8 +138,9 @@ class BaseEngineTest(shared_test_lib.BaseTestCase):
 
     self.assertIsNotNone(test_engine._artifacts_trie)
     # Verify content of the artifacts trie
-    self.assertIn(os.sep, test_engine._artifacts_trie.root.children)
-    trie_root = test_engine._artifacts_trie.root.children[os.sep]
+    artifacts_trie_root_children = test_engine._artifacts_trie.root.children
+    self.assertIn(os.sep, artifacts_trie_root_children)
+    trie_root = artifacts_trie_root_children[os.sep]
     self.assertIn(
         'test_data',
         trie_root.children)
@@ -149,34 +150,35 @@ class BaseEngineTest(shared_test_lib.BaseTestCase):
     self.assertIn(
         'Users',
         trie_root.children)
+    users_child = trie_root.children['Users']
     self.assertIn(
         'testuser1',
-        trie_root.children['Users'].children)
+        users_child.children)
     self.assertIn(
         'testuser2',
-        trie_root.children['Users'].children)
+        users_child.children)
+    testuser1_child = users_child.children['testuser1']
+    testuser2_child = users_child.children['testuser2']
     self.assertIn(
         'Documents',
-        trie_root.children['Users'].children['testuser1'].children)
+        testuser1_child.children)
     self.assertIn(
         'Documents',
-        trie_root.children['Users'].children['testuser2'].children)
+        testuser2_child.children)
+    documents_child_user1 = testuser1_child.children['Documents']
+    documents_child_user2 = testuser2_child.children['Documents']
     self.assertIn(
         'WindowsPowerShell',
-        trie_root.children['Users'].children['testuser1']
-        .children['Documents'].children)
+        documents_child_user1.children)
     self.assertIn(
         'WindowsPowerShell',
-        trie_root.children['Users'].children['testuser2']
-        .children['Documents'].children)
+        documents_child_user2.children)
     self.assertIn(
         'profile.ps1',
-        trie_root.children['Users'].children['testuser1']
-        .children['Documents'].children['WindowsPowerShell'].children)
+        documents_child_user1.children['WindowsPowerShell'].children)
     self.assertIn(
         'profile.ps1',
-        trie_root.children['Users'].children['testuser2']
-        .children['Documents'].children['WindowsPowerShell'].children)
+        documents_child_user2.children['WindowsPowerShell'].children)
 
     # Test with filter_file_path
     test_filter_file_path = self._GetTestFilePath(

--- a/tests/engine/path_helper.py
+++ b/tests/engine/path_helper.py
@@ -440,7 +440,7 @@ class PathHelperTest(shared_test_lib.BaseTestCase):
     self.assertEqual(sanitized_path_segments, expected_sanitized_segments)
 
     # Test with a path segment containing the path separator.
-    path_segments = [f'test{os.sep}dir', 'file.txt']
+    path_segments = [f'test{os.path.sep}dir', 'file.txt']
     expected_sanitized_segments = ['test_dir', 'file.txt']
     sanitized_path_segments = path_helper.PathHelper.SanitizePathSegments(
         path_segments)
@@ -463,36 +463,36 @@ class PathHelperTest(shared_test_lib.BaseTestCase):
   def testGetRelativePath(self):
     """Tests the GetRelativePath function."""
     # Test with normal paths.
-    target_directory = '/home/user/output'
+    target_directory = '/home/user/output'.replace('/', os.path.sep)
     target_filename = 'file.txt'
-    destination_path = '/home/user/output/'
+    destination_path = '/home/user/output/'.replace('/', os.path.sep)
     expected_relative_path = 'file.txt'
     relative_path = path_helper.PathHelper.GetRelativePath(
         target_directory, target_filename, destination_path)
     self.assertEqual(relative_path, expected_relative_path)
 
     # Test with subdirectory.
-    target_directory = '/home/user/output/subdir'
+    target_directory = '/home/user/output/subdir'.replace('/', os.path.sep)
     target_filename = 'image.dd'
-    destination_path = '/home/user/output/'
+    destination_path = '/home/user/output/'.replace('/', os.path.sep)
     expected_relative_path = os.path.join('subdir', 'image.dd')
     relative_path = path_helper.PathHelper.GetRelativePath(
         target_directory, target_filename, destination_path)
     self.assertEqual(relative_path, expected_relative_path)
 
     # Test with a relative destination path.
-    target_directory = 'output/subdir'
+    target_directory = 'output/subdir'.replace('/', os.path.sep)
     target_filename = 'file.txt'
-    destination_path = 'output' + os.sep
+    destination_path = 'output' + os.path.sep
     expected_relative_path = os.path.join('subdir', 'file.txt')
     relative_path = path_helper.PathHelper.GetRelativePath(
         target_directory, target_filename, destination_path)
     self.assertEqual(relative_path, expected_relative_path)
 
     # Test with no match.
-    target_directory = '/home/user/output/subdir'
+    target_directory = '/home/user/output/subdir'.replace('/', os.path.sep)
     target_filename = 'image.E01'
-    destination_path = '/another/directory/'
+    destination_path = '/another/directory/'.replace('/', os.path.sep)
     relative_path = path_helper.PathHelper.GetRelativePath(
         target_directory, target_filename, destination_path)
     self.assertIsNone(relative_path)
@@ -502,27 +502,27 @@ class PathHelperTest(shared_test_lib.BaseTestCase):
     self.assertIsNone(relative_path)
 
     # Test with only destination path ending with separator.
-    target_directory = '/home/user/output/subdir'
+    target_directory = '/home/user/output/subdir'.replace('/', os.path.sep)
     target_filename = 'data.txt'
-    destination_path = '/home/user/output/'
+    destination_path = '/home/user/output/'.replace('/', os.path.sep)
     expected_relative_path = os.path.join('subdir', 'data.txt')
     relative_path = path_helper.PathHelper.GetRelativePath(
         target_directory, target_filename, destination_path)
     self.assertEqual(relative_path, expected_relative_path)
 
     # Test with only destination path not ending with separator.
-    target_directory = '/home/user/output/subdir'
+    target_directory = '/home/user/output/subdir'.replace('/', os.path.sep)
     target_filename = 'file.txt'
-    destination_path = '/home/user/output'
+    destination_path = '/home/user/output'.replace('/', os.path.sep)
     expected_relative_path = os.path.join('subdir', 'file.txt')
     relative_path = path_helper.PathHelper.GetRelativePath(
         target_directory, target_filename, destination_path)
     self.assertEqual(relative_path, expected_relative_path)
 
     # Test with target directory being root.
-    target_directory = '/'
+    target_directory = '/'.replace('/', os.path.sep)
     target_filename = 'file.txt'
-    destination_path = '/'
+    destination_path = '/'.replace('/', os.path.sep)
     expected_relative_path = 'file.txt'
     relative_path = path_helper.PathHelper.GetRelativePath(
         target_directory, target_filename, destination_path)

--- a/tests/filters/file_entry.py
+++ b/tests/filters/file_entry.py
@@ -2,12 +2,14 @@
 # -*- coding: utf-8 -*-
 """Tests for the file entry filters."""
 
+import os
 import unittest
 
 from dfvfs.lib import definitions as dfvfs_definitions
 from dfvfs.path import factory as path_spec_factory
 from dfvfs.resolver import resolver as path_spec_resolver
 
+from plaso.engine import artifacts_trie
 from plaso.filters import file_entry as file_entry_filters
 from plaso.lib import specification
 
@@ -377,6 +379,38 @@ class FileEntryFilterCollectionTest(shared_test_lib.BaseTestCase):
     file_entry_filter = file_entry_filters.NamesFileEntryFilter(['name'])
     test_filter_collection.AddFilter(file_entry_filter)
     self.assertTrue(test_filter_collection.HasFilters())
+
+  def testSetArtifactsTrie(self):
+    """Tests the SetArtifactsTrie function."""
+    test_filter_collection = file_entry_filters.FileEntryFilterCollection()
+    trie = artifacts_trie.ArtifactsTrie()
+    test_filter_collection.SetArtifactsTrie(trie)
+    self.assertEqual(test_filter_collection._artifacts_trie, trie)
+
+  def testGetMatchingArtifacts(self):
+    """Tests the GetMatchingArtifacts function."""
+    test_filter_collection = file_entry_filters.FileEntryFilterCollection()
+    trie = artifacts_trie.ArtifactsTrie()
+    trie.AddPath('artifact1', '/path/to/file.txt', os.sep)
+    trie.AddPath('artifact2', '/path/to/dir/', os.sep)
+    test_filter_collection.SetArtifactsTrie(trie)
+
+    # Test matching a file.
+    matches = test_filter_collection.GetMatchingArtifacts(
+        '/path/to/file.txt', os.sep)
+    self.assertIn('artifact1', matches)
+    self.assertNotIn('artifact2', matches)
+
+    # Test matching a directory.
+    matches = test_filter_collection.GetMatchingArtifacts(
+        '/path/to/dir', os.sep)
+    self.assertIn('artifact2', matches)
+    self.assertNotIn('artifact1', matches)
+
+    # Test non-matching path.
+    matches = test_filter_collection.GetMatchingArtifacts(
+        '/nonexistent/path', os.sep)
+    self.assertEqual(matches, [])
 
   # TODO: add test for Matches.
   # TODO: add test for Print.

--- a/tests/filters/file_entry.py
+++ b/tests/filters/file_entry.py
@@ -391,25 +391,27 @@ class FileEntryFilterCollectionTest(shared_test_lib.BaseTestCase):
     """Tests the GetMatchingArtifacts function."""
     test_filter_collection = file_entry_filters.FileEntryFilterCollection()
     trie = artifacts_trie.ArtifactsTrie()
-    trie.AddPath('artifact1', '/path/to/file.txt', os.sep)
-    trie.AddPath('artifact2', '/path/to/dir/', os.sep)
+    trie.AddPath(
+        'artifact1', f'{os.sep}path{os.sep}to{os.sep}file.txt', os.sep)
+    trie.AddPath(
+        'artifact2', f'{os.sep}path{os.sep}to{os.sep}dir{os.sep}', os.sep)
     test_filter_collection.SetArtifactsTrie(trie)
 
     # Test matching a file.
     matches = test_filter_collection.GetMatchingArtifacts(
-        '/path/to/file.txt', os.sep)
+        f'{os.sep}path{os.sep}to{os.sep}file.txt', os.sep)
     self.assertIn('artifact1', matches)
     self.assertNotIn('artifact2', matches)
 
     # Test matching a directory.
     matches = test_filter_collection.GetMatchingArtifacts(
-        '/path/to/dir', os.sep)
+        f'{os.sep}path{os.sep}to{os.sep}dir', os.sep)
     self.assertIn('artifact2', matches)
     self.assertNotIn('artifact1', matches)
 
     # Test non-matching path.
     matches = test_filter_collection.GetMatchingArtifacts(
-        '/nonexistent/path', os.sep)
+        f'{os.sep}nonexistent{os.sep}path', os.sep)
     self.assertEqual(matches, [])
 
   # TODO: add test for Matches.


### PR DESCRIPTION
## Feature: Map Extracted Files to Artifact Definitions in image_export.py



## Description:
This PR adds an optional feature to Plaso's image_export.py tool to generate a JSON file mapping extracted files to the artifact definitions that led to their extraction. This mapping provides valuable context about the extracted files.

#### Functionality:

The new `--enable_artifacts_map` flag activates this feature. When enabled, the tool creates an `artifacts_map.json` file in the output directory. This file contains a dictionary where:

Keys: Artifact definition names (e.g., `JupyterConfigFile`, `SshdConfigFile`, `WindowsEnvironmentVariableComSpec`).
Values: Lists of extracted file paths (relative to the output directory) that matched the corresponding artifact definition.

```
plaso/scripts/image_export.py --artifact_filters JupyterConfigFile,SshdConfigFile \
--write /home/user/tmp --enable_artifacts_map --logfile /home/user/tmp/log.log \
--volumes all --partitions all /home/user/artifact_disk.dd
```
This command would produce an `artifacts_map.json` file similar to:
```
{
  "SshdConfigFile": ["etc/ssh/sshd_config"],
  "JupyterConfigFile": ["home/dummyuser/.jupyter/jupyter_notebook_config.py"]
}
```
This output indicates that the files `etc/ssh/sshd_config` and `home/dummyuser/.jupyter/jupyter_notebook_config.py` were extracted because they matched the `SshdConfigFile` and `JupyterConfigFile` artifact definitions, respectively.

##### Registry Artifacts:

For artifacts that rely on Windows Registry keys or values (e.g., `WindowsEnvironmentVariableComSpec`), the tool automatically extracts the relevant registry hive files (e.g., `SYSTEM`, `SOFTWARE`, `NTUSER.DAT`). The `artifacts_map.json` will map these hive files to both:

The artifact that directly triggered the hive's extraction (e.g., `WindowsSystemRegistryFiles`).
Any artifacts that rely on data within those hives (e.g., `WindowsEnvironmentVariableComSpec`).

Example with Registry Artifacts:
If you run `image_export.py` with `--artifact_filters WindowsEnvironmentVariableComSpec`, the `artifacts_map.json` might contain:
```
{
  "WindowsSystemRegistryFiles": [
    "System Volume Information/Syscache.hve",
    "Windows/System32/config/SAM",
    "Windows/System32/config/SECURITY",
    "Windows/System32/config/SOFTWARE",
    "Windows/System32/config/SYSTEM"
  ],
  "WindowsEnvironmentVariableComSpec": [
    "System Volume Information/Syscache.hve",
    "Users/Warren/AppData/Local/Microsoft/Windows/UsrClass.dat",
    "Users/Warren/NTUSER.DAT",
    "Windows/ServiceProfiles/LocalService/NTUSER.DAT",
    "Windows/ServiceProfiles/NetworkService/NTUSER.DAT",
    "Windows/System32/config/SAM",
    "Windows/System32/config/SECURITY",
    "Windows/System32/config/SOFTWARE",
    "Windows/System32/config/SYSTEM"
  ],
  "WindowsUserRegistryFiles": [
    "Users/Warren/AppData/Local/Microsoft/Windows/UsrClass.dat",
    "Users/Warren/NTUSER.DAT",
    "Windows/ServiceProfiles/LocalService/NTUSER.DAT",
    "Windows/ServiceProfiles/NetworkService/NTUSER.DAT"
  ]
}
```

This shows that the `SYSTEM`, `SOFTWARE`, and other hive files were extracted because of both `WindowsSystemRegistryFiles` and `WindowsEnvironmentVariableComSpec`, the mapped paths will be relative to the provided output path under the `--write` argument.

##### Technical Details:

The core of this feature is the ArtifactsTrie class, which stores artifact definition paths in a Trie (prefix tree) data structure.

###### Artifacts Trie Structure

- Root Node: A special node that doesn't represent a path segment but has children for each unique path separator in the definitions.
- Path Separator Nodes: Children of the root, representing path separators (e.g., /, \).
- Other Nodes: Each node represents a path segment from an artifact definition.
- Glob Handling: Glob patterns (like * and **) are stored as literal node keys.
- Artifact Names: Nodes corresponding to the end of a valid artifact path store a list of associated artifact names in their artifacts_names attribute.
Example Trie:

```
Root
├── / (path separator)
│   ├── Users
│   │   └── **
│   │       └── Downloads
│   │           └── *.pdf (artifacts_names: ["PDFDownloads"])
│   └── Windows
│       └── System32
│           └── config
│               └── SAM (artifacts_names: ["WindowsSAMRegistry"])
└── \ (path separator)
    └── Users
        └── *\
            └── AppData
                └── Local
                    └── test.ini (artifacts_names: ["LocalAppDataFiles"])
```
###### Matching Logic

Paths are normalized to use os.sep as the separator.
The `GetMatchingArtifacts` method traverses the Trie based on input path segments, using `fnmatch.fnmatch` for glob matching. `**` is handled recursively to match zero or more directory levels.

##### Source Type Handling
When the input  to the tool is:
- Directory: A `dfvfs.FileSystem` object of type `OS` is created, with a `dfvfs.FileSystemSearcher` using the input directory as the mount point. The tool extracts files matching the FindSpec's criteria within this directory.
- File: `ExtractPathSpecs` yields the input file path directly without searching, as it's assumed that a user-provided file path should be extracted.

Added safeguard check to exit and print if input is file, this tool can handle images, block devices and hierarchy of directories from the evidence system
