### PR TITLE
remove unused dependency on "six"

### DIFF
--- a/dependencies.ini
+++ b/dependencies.ini
@@ -428,12 +428,6 @@ minimum_version: 2.18.0
 rpm_name: python3-requests
 version_property: __version__
 
-[six]
-dpkg_name: python3-six
-minimum_version: 1.1.0
-rpm_name: python3-six
-version_property: __version__
-
 [urllib3]
 skip_requires: true
 dpkg_name: python3-urllib3

--- a/plaso/dependencies.py
+++ b/plaso/dependencies.py
@@ -71,7 +71,6 @@ PYTHON_DEPENDENCIES = {
     'pyvslvm': ('get_version()', '20160109', None, True),
     'redis': ('__version__', '3.4', None, False),
     'requests': ('__version__', '2.18.0', None, True),
-    'six': ('__version__', '1.1.0', None, True),
     'urllib3': ('__version__', '1.21.1', None, True),
     'xattr': ('__version__', '0.7.2', None, False),
     'xlsxwriter': ('__version__', '0.9.3', None, True),

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,6 @@ pytz
 pyzmq >= 2.1.11
 redis >= 3.4
 requests >= 2.18.0
-six >= 1.1.0
 xattr >= 0.7.2 ; platform_system != "Windows"
 yara-python >= 3.4.0
 zstd >= 1.3.0.2


### PR DESCRIPTION
Hi !

Six was a comatibility layer used to have a billingual Python 2+3 codebase

https://wiki.debian.org/Python3-six-removal