### PR TITLE
Added RADAR Diagnosed Applications Windows Registry plugin

### DIFF
--- a/plaso/data/formatters/windows.yaml
+++ b/plaso/data/formatters/windows.yaml
@@ -462,6 +462,16 @@ short_source: 'REG'
 source: 'Registry Key'
 ---
 type: 'conditional'
+data_type: 'windows:registry:diagnosed_applications'
+message:
+- 'Process Name: {process_name}'
+- 'Last Detection Time: {last_detection_time}'
+- 'Origin: {key_path}'
+short_message: 'Process Name: {process_name}'
+short_source: 'REG'
+source: 'Registry Key'
+---
+type: 'conditional'
 data_type: 'windows:registry:explorer:programcache'
 message:
 - 'Key: {key_path}'

--- a/plaso/data/timeliner.yaml
+++ b/plaso/data/timeliner.yaml
@@ -1603,6 +1603,12 @@ attribute_mappings:
   description: 'Content Modification Time'
 place_holder_event: true
 ---
+data_type: 'windows:registry:diagnosed_applications'
+attribute_mappings:
+- name: 'last_written_time'
+  description: 'Content Modification Time'
+place_holder_event: false
+---
 data_type: 'windows:registry:explorer:programcache'
 attribute_mappings:
 - name: 'last_written_time'

--- a/plaso/data/timeliner.yaml
+++ b/plaso/data/timeliner.yaml
@@ -1605,6 +1605,8 @@ place_holder_event: true
 ---
 data_type: 'windows:registry:diagnosed_applications'
 attribute_mappings:
+- name: 'last_detection_time'
+  description: 'Last Detection Time'
 - name: 'last_written_time'
   description: 'Content Modification Time'
 place_holder_event: false

--- a/plaso/parsers/winreg_plugins/__init__.py
+++ b/plaso/parsers/winreg_plugins/__init__.py
@@ -6,6 +6,7 @@ from plaso.parsers.winreg_plugins import bagmru
 from plaso.parsers.winreg_plugins import bam
 from plaso.parsers.winreg_plugins import ccleaner
 from plaso.parsers.winreg_plugins import default
+from plaso.parsers.winreg_plugins import diagnosed_applications
 from plaso.parsers.winreg_plugins import lfu
 from plaso.parsers.winreg_plugins import motherboard_info
 from plaso.parsers.winreg_plugins import mountpoints

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -2,7 +2,7 @@
 """Plug-in to collect evidence of execution from RADAR HeapLeakDetection
 Diagnosed Applications."""
 
-import os
+from os.path import dirname
 
 from dfdatetime import filetime as dfdatetime_filetime
 from dfdatetime import semantic_time as dfdatetime_semantic_time
@@ -50,7 +50,7 @@ class DiagnosedApplicationsPlugin(
       'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\RADAR\\HeapLeakDetection\\'
       'DiagnosedApplications')])
   _DEFINITION_FILE = os.path.join(
-    os.path.dirname(__file__), 'filetime.yaml')
+    dirname(__file__), 'filetime.yaml')
 
   def _ParseFiletime(self, byte_stream):
     """Parses a FILETIME date and time value from a byte stream.

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -2,7 +2,14 @@
 """Plug-in to collect evidence of execution from RADAR 
 HeapLeakDetection Diagnosed Applications."""
 
+import os
+
+from dfdatetime import filetime as dfdatetime_filetime
+from dfdatetime import semantic_time as dfdatetime_semantic_time
+
 from plaso.containers import events
+from plaso.lib import dtfabric_helper
+from plaso.lib import errors
 from plaso.parsers import winreg_parser
 from plaso.parsers.winreg_plugins import interface
 
@@ -31,7 +38,8 @@ class WindowsRegistryDiagnosedApplicationsEventData(events.EventData):
     self.last_written_time = None
 
 
-class DiagnosedApplicationsPlugin(interface.WindowsRegistryPlugin):
+class DiagnosedApplicationsPlugin(
+    interface.WindowsRegistryPlugin, dtfabric_helper.DtFabricHelper):
   """Plug-in to collect information about the Motherboard and BIOS."""
 
   NAME = 'diagnosed_applications'
@@ -41,6 +49,38 @@ class DiagnosedApplicationsPlugin(interface.WindowsRegistryPlugin):
     interface.WindowsRegistryKeyPathFilter(
       'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\RADAR\\HeapLeakDetection\\'
       'DiagnosedApplications')])
+  _DEFINITION_FILE = os.path.join(
+    os.path.dirname(__file__), 'filetime.yaml')
+
+  def _ParseFiletime(self, byte_stream):
+    """Parses a FILETIME date and time value from a byte stream.
+
+    Args:
+      byte_stream (bytes): byte stream.
+
+    Returns:
+      dfdatetime.DateTimeValues: a FILETIME date and time values or a semantic
+        date and time values if the FILETIME date and time value is not set.
+
+    Raises:
+      ParseError: if the FILETIME could not be parsed.
+    """
+    filetime_map = self._GetDataTypeMap('filetime')
+
+    try:
+      filetime = self._ReadStructureFromByteStream(
+          byte_stream, 0, filetime_map)
+    except (ValueError, errors.ParseError) as exception:
+      raise errors.ParseError(
+          f'Unable to parse FILETIME value with error: {exception!s}')
+
+    if filetime == 0:
+      return dfdatetime_semantic_time.NotSet()
+
+    try:
+      return dfdatetime_filetime.Filetime(timestamp=filetime)
+    except ValueError:
+      raise errors.ParseError(f'Invalid FILETIME value: 0x{filetime:08x}')
 
   def ExtractEvents(self, parser_mediator, registry_key, **kwargs):
     """Extracts events from a Windows Registry key.
@@ -52,16 +92,13 @@ class DiagnosedApplicationsPlugin(interface.WindowsRegistryPlugin):
     """
     for subkey in registry_key.GetSubkeys():
       event_data = WindowsRegistryDiagnosedApplicationsEventData()
+
       event_data.process_name = subkey.name
-      
-      try:
-        event_data.last_detection_time = self._ParseFiletime(
-          subkey.GetValueByName('LastDetectionTime')
-        )
-      except errors.ParseError as exception:
-        warning = f'unable to parse LastDetectionTime: {exception!s}'
-        parser_mediator.ProduceExtractionWarning(warning)
-      
+      event_data.last_detection_time = self._ParseFiletime(
+        subkey.GetValueByName(
+          "LastDetectionTime"
+        ).data
+      )
       event_data.key_path = subkey.path
       event_data.last_written_time = subkey.last_written_time
   

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -2,7 +2,7 @@
 """Plug-in to collect evidence of execution from RADAR HeapLeakDetection
 Diagnosed Applications."""
 
-from os.path import dirname
+from os.path import dirname, join
 
 from dfdatetime import filetime as dfdatetime_filetime
 from dfdatetime import semantic_time as dfdatetime_semantic_time

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -49,7 +49,7 @@ class DiagnosedApplicationsPlugin(
     interface.WindowsRegistryKeyPathFilter(
       'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\RADAR\\HeapLeakDetection\\'
       'DiagnosedApplications')])
-  _DEFINITION_FILE = os.path.join(
+  _DEFINITION_FILE = join(
     dirname(__file__), 'filetime.yaml')
 
   def _ParseFiletime(self, byte_stream):

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -39,7 +39,7 @@ class DiagnosedApplicationsPlugin(interface.WindowsRegistryPlugin):
 
   FILTERS = frozenset([
     interface.WindowsRegistryKeyPathFilter(
-      'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\RADAR\\HeapLeakDetection\\
+      'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\RADAR\\HeapLeakDetection\\'
       'DiagnosedApplications')])
 
   def ExtractEvents(self, parser_mediator, registry_key, **kwargs):

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""Plug-in to collect evidence of execution from RADAR 
+HeapLeakDetection Diagnosed Applications."""
+
+from plaso.containers import events
+from plaso.parsers import winreg_parser
+from plaso.parsers.winreg_plugins import interface
+
+
+class WindowsRegistryDiagnosedApplicationsEventData(events.EventData):
+  """Windows Motherboard Info event data attribute container.
+
+  Attributes:
+    process_name (str): Name of the process diagnosed by RADAR.
+    last_detection_time (dfdatetime.DateTimeValues): process last
+        detected by RADAR date and time.
+    key_path (str): Windows Registry key path.
+    last_written_time (dfdatetime.DateTimeValues): entry last written date
+        and time.
+  """
+
+  DATA_TYPE = 'windows:registry:diagnosed_applications'
+
+  def __init__(self):
+    """Initializes event data."""
+    super(WindowsRegistryMotherboardInfoEventData, self).__init__(
+        data_type=self.DATA_TYPE)
+    self.process_name = None
+    self.last_detection_time = None
+    self.key_path = None
+    self.last_written_time = None
+
+
+class DiagnosedApplicationsPlugin(interface.WindowsRegistryPlugin):
+  """Plug-in to collect information about the Motherboard and BIOS."""
+
+  NAME = 'diagnosed_applications'
+  DATA_FORMAT = 'Diagnosed Applications Registry data'
+
+  FILTERS = frozenset([
+    interface.WindowsRegistryKeyPathFilter(
+      'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\RADAR\\HeapLeakDetection\\
+      'DiagnosedApplications')])
+
+  def ExtractEvents(self, parser_mediator, registry_key, **kwargs):
+    """Extracts events from a Windows Registry key.
+
+    Args:
+      parser_mediator (ParserMediator): mediates interactions between parsers
+          and other components, such as storage and dfVFS.
+      registry_key (dfwinreg.WinRegistryKey): Windows Registry key.
+    """
+    for subkey in registry_key.GetSubkeys():
+      event_data = WindowsRegistryDiagnosedApplicationsEventData()
+      event_data.process_name = subkey.name
+      
+      try:
+        event_data.last_detection_time = self._ParseFiletime(
+          subkey.GetValueByName('LastDetectionTime')
+        )
+      except errors.ParseError as exception:
+        warning = f'unable to parse LastDetectionTime: {exception!s}'
+        parser_mediator.ProduceExtractionWarning(warning)
+      
+      event_data.key_path = subkey.path
+      event_data.last_written_time = subkey.last_written_time
+  
+      parser_mediator.ProduceEventData(event_data)
+
+
+winreg_parser.WinRegistryParser.RegisterPlugin(DiagnosedApplicationsPlugin)

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -8,7 +8,7 @@ from plaso.parsers.winreg_plugins import interface
 
 
 class WindowsRegistryDiagnosedApplicationsEventData(events.EventData):
-  """Windows Motherboard Info event data attribute container.
+  """Windows Diagnosed Application event data attribute container.
 
   Attributes:
     process_name (str): Name of the process diagnosed by RADAR.

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -53,7 +53,6 @@ class DiagnosedApplicationsPlugin(interface.WindowsRegistryPlugin):
     for subkey in registry_key.GetSubkeys():
       event_data = WindowsRegistryDiagnosedApplicationsEventData()
       event_data.process_name = subkey.name
-      print(subkey.GetValueByName('LastDetectionTime'))
       
       try:
         event_data.last_detection_time = self._ParseFiletime(

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -23,7 +23,7 @@ class WindowsRegistryDiagnosedApplicationsEventData(events.EventData):
 
   def __init__(self):
     """Initializes event data."""
-    super(WindowsRegistryMotherboardInfoEventData, self).__init__(
+    super(WindowsRegistryDiagnosedApplicationsEventData, self).__init__(
         data_type=self.DATA_TYPE)
     self.process_name = None
     self.last_detection_time = None

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -101,7 +101,7 @@ class DiagnosedApplicationsPlugin(
       )
       event_data.key_path = subkey.path
       event_data.last_written_time = subkey.last_written_time
-  
+      
       parser_mediator.ProduceEventData(event_data)
 
 

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Plug-in to collect evidence of execution from RADAR 
-HeapLeakDetection Diagnosed Applications."""
+"""Plug-in to collect evidence of execution from RADAR HeapLeakDetection
+Diagnosed Applications."""
 
 import os
 

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -53,6 +53,7 @@ class DiagnosedApplicationsPlugin(interface.WindowsRegistryPlugin):
     for subkey in registry_key.GetSubkeys():
       event_data = WindowsRegistryDiagnosedApplicationsEventData()
       event_data.process_name = subkey.name
+      print(subkey.GetValueByName('LastDetectionTime'))
       
       try:
         event_data.last_detection_time = self._ParseFiletime(

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -101,7 +101,6 @@ class DiagnosedApplicationsPlugin(
       )
       event_data.key_path = subkey.path
       event_data.last_written_time = subkey.last_written_time
-      
       parser_mediator.ProduceEventData(event_data)
 
 

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -57,7 +57,7 @@ class DiagnosedApplicationsPlugin(
 
     Returns:
       dfdatetime.DateTimeValues: a FILETIME date and time values or a semantic
-        date and time values if the FILETIME date and time value is not set.
+          date and time values if the FILETIME date and time value is not set.
 
     Raises:
       ParseError: if the FILETIME could not be parsed.

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -1,5 +1,4 @@
-"""Plug-in to collect evidence of execution from RADAR HeapLeakDetection
-Diagnosed Applications."""
+"""Windows Registry plugin to parse the RADAR Diagnosed Applications key."""
 
 from os.path import dirname, join
 
@@ -13,43 +12,42 @@ from plaso.parsers import winreg_parser
 from plaso.parsers.winreg_plugins import interface
 
 
-class WindowsRegistryDiagnosedApplicationsEventData(events.EventData):
-  """Windows Diagnosed Application event data attribute container.
+class DiagnosedApplicationsEventData(events.EventData):
+  """RADAR Diagnosed Application event data attribute container.
 
   Attributes:
-    process_name (str): Name of the process diagnosed by RADAR.
+    key_path (str): Windows Registry key path.
     last_detection_time (dfdatetime.DateTimeValues): process last
         detected by RADAR date and time.
-    key_path (str): Windows Registry key path.
     last_written_time (dfdatetime.DateTimeValues): entry last written date
         and time.
+    process_name (str): Name of the process diagnosed by RADAR.
   """
 
   DATA_TYPE = 'windows:registry:diagnosed_applications'
 
   def __init__(self):
     """Initializes event data."""
-    super().__init__(
-        data_type=self.DATA_TYPE)
-    self.process_name = None
-    self.last_detection_time = None
+    super().__init__(data_type=self.DATA_TYPE)
     self.key_path = None
+    self.last_detection_time = None
     self.last_written_time = None
+    self.process_name = None
 
 
 class DiagnosedApplicationsPlugin(
     interface.WindowsRegistryPlugin, dtfabric_helper.DtFabricHelper):
-  """Plug-in to collect information about the Motherboard and BIOS."""
+  """RADAR Diagnosed Applications Windows Registry plugin."""
 
   NAME = 'diagnosed_applications'
   DATA_FORMAT = 'Diagnosed Applications Registry data'
 
   FILTERS = frozenset([
-    interface.WindowsRegistryKeyPathFilter(
-      'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\RADAR\\HeapLeakDetection\\'
-      'DiagnosedApplications')])
-  _DEFINITION_FILE = join(
-    dirname(__file__), 'filetime.yaml')
+      interface.WindowsRegistryKeyPathFilter(
+          'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\RADAR\\HeapLeakDetection\\'
+          'DiagnosedApplications')])
+
+  _DEFINITION_FILE = join(dirname(__file__), 'filetime.yaml')
 
   def _ParseFiletime(self, byte_stream):
     """Parses a FILETIME date and time value from a byte stream.
@@ -90,16 +88,15 @@ class DiagnosedApplicationsPlugin(
       registry_key (dfwinreg.WinRegistryKey): Windows Registry key.
     """
     for subkey in registry_key.GetSubkeys():
-      event_data = WindowsRegistryDiagnosedApplicationsEventData()
+      last_detection_value = subkey.GetValueByName('LastDetectionTime')
+      date_time = self._ParseFiletime(last_detection_value.data)
 
-      event_data.process_name = subkey.name
-      event_data.last_detection_time = self._ParseFiletime(
-        subkey.GetValueByName(
-          "LastDetectionTime"
-        ).data
-      )
+      event_data = DiagnosedApplicationsEventData()
       event_data.key_path = subkey.path
+      event_data.last_detection_time = date_time
       event_data.last_written_time = subkey.last_written_time
+      event_data.process_name = subkey.name
+
       parser_mediator.ProduceEventData(event_data)
 
 

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Plug-in to collect evidence of execution from RADAR HeapLeakDetection
 Diagnosed Applications."""
 
@@ -30,7 +29,7 @@ class WindowsRegistryDiagnosedApplicationsEventData(events.EventData):
 
   def __init__(self):
     """Initializes event data."""
-    super(WindowsRegistryDiagnosedApplicationsEventData, self).__init__(
+    super().__init__(
         data_type=self.DATA_TYPE)
     self.process_name = None
     self.last_detection_time = None

--- a/plaso/parsers/winreg_plugins/diagnosed_applications.py
+++ b/plaso/parsers/winreg_plugins/diagnosed_applications.py
@@ -1,6 +1,6 @@
 """Windows Registry plugin to parse the RADAR Diagnosed Applications key."""
 
-from os.path import dirname, join
+import os
 
 from dfdatetime import filetime as dfdatetime_filetime
 from dfdatetime import semantic_time as dfdatetime_semantic_time
@@ -47,7 +47,7 @@ class DiagnosedApplicationsPlugin(
           'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\RADAR\\HeapLeakDetection\\'
           'DiagnosedApplications')])
 
-  _DEFINITION_FILE = join(dirname(__file__), 'filetime.yaml')
+  _DEFINITION_FILE = os.path.join(os.path.dirname(__file__), 'filetime.yaml')
 
   def _ParseFiletime(self, byte_stream):
     """Parses a FILETIME date and time value from a byte stream.

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -32,7 +32,7 @@ class WindowsRegistryDiagnosedApplicationsPluginTest(
         'DiagnosedApplications\\chrome.exe'
     )
 
-    value_data = int(filetime.timestamp).encode('utf_16_le')
+    value_data = filetime.timestamp.encode('utf_16_le')
     registry_value = dfwinreg_fake.FakeWinRegistryValue(
       'LastDetectionTime', data=value_data,
       data_type=dfwinreg_definitions.REG_QWORD)

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -32,7 +32,8 @@ class WindowsRegistryDiagnosedApplicationsPluginTest(
         'DiagnosedApplications\\chrome.exe'
     )
 
-    value_data = f"{filetime.timestamp}".encode('utf_16_le')
+    value_data = "1db78823a40721d".encode('utf_16_le')
+    print(value_data)
     registry_value = dfwinreg_fake.FakeWinRegistryValue(
       'LastDetectionTime', data=value_data,
       data_type=dfwinreg_definitions.REG_QWORD)

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -41,7 +41,7 @@ class WindowsRegistryDiagnosedApplicationsPluginTest(
     return registry_key
 
   def testProcessValue(self):
-    """Tests the Process function for BAM data."""
+    """Tests the Process function for Diagnosed Applications data."""
     test_file_entry = test_lib.TestFileEntry('SOFTWARE')
     registry_key = self._CreateTestKey()
     plugin = diagnosed_applications.DiagnosedApplicationsPlugin()

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -32,7 +32,7 @@ class WindowsRegistryDiagnosedApplicationsPluginTest(
         'DiagnosedApplications\\chrome.exe'
     )
 
-    value_data = int(filetime.timestamp)
+    value_data = int(filetime.timestamp).encode('utf_16_le')
     registry_value = dfwinreg_fake.FakeWinRegistryValue(
       'LastDetectionTime', data=value_data,
       data_type=dfwinreg_definitions.REG_QWORD)

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -32,13 +32,12 @@ class WindowsRegistryDiagnosedApplicationsPluginTest(
         'DiagnosedApplications\\chrome.exe'
     )
 
-    value_data = "1db78823a40721d"
+    value_data = int(filetime.timestamp)
     print(value_data)
     registry_value = dfwinreg_fake.FakeWinRegistryValue(
       'LastDetectionTime', data=value_data,
       data_type=dfwinreg_definitions.REG_QWORD)
     registry_key.AddValue(registry_value)
-    print(str(registry_key.GetValueByName('LastDetectionTime')))
 
     return registry_key
 

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -17,28 +17,6 @@ class WindowsRegistryDiagnosedApplicationsPluginTest(
     test_lib.RegistryPluginTestCase):
   """Tests for the Diagnosed Applications Windows Registry plugin."""
 
-  def _CreateTestKey(self):
-    """Creates Registry keys and values for testing.
-    Returns:
-      dfwinreg.WinRegistryKey: a Windows Registry key.
-    """
-    filetime = dfdatetime_filetime.Filetime()
-    filetime.CopyFromDateTimeString('2024-08-28 09:23:49.002031')
-    self.registry_key = dfwinreg_fake.FakeWinRegistryKey(
-      'chrome.exe',
-      key_path_prefix='HKEY_LOCAL_MACHINE\\SOFTWARE',
-      last_written_time=filetime.timestamp,
-      relative_key_path='Microsoft\\RADAR\\HeapLeakDetection\\'
-        'DiagnosedApplications\\chrome.exe'
-    )
-
-    registry_value = dfwinreg_fake.FakeWinRegistryValue(
-      'LastDetectionTime',
-      data=b'\xac\xbcu\xbe<u\xcc\x01',
-      data_type=dfwinreg_definitions.REG_QWORD
-    )
-    self.registry_key.AddValue(registry_value)
-
   def testProcessValue(self):
     """Tests the Process function for Diagnosed Applications data."""
     test_file_entry = self._GetTestFileEntry(['SOFTWARE'])

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -20,7 +20,8 @@ class WindowsRegistryDiagnosedApplicationsPluginTest(
   def testProcessValue(self):
     """Tests the Process function for Diagnosed Applications data."""
     test_file_entry = self._GetTestFileEntry(['SOFTWARE'])
-    key_path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\RADAR\\HeapLeakDetection\\DiagnosedApplications'
+    key_path = ('HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\RADAR\\'
+                'HeapLeakDetection\\DiagnosedApplications')
 
     win_registry = self._GetWinRegistryFromFileEntry(test_file_entry)
     registry_key = win_registry.GetKeyByPath(key_path)

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -32,7 +32,7 @@ class WindowsRegistryDiagnosedApplicationsPluginTest(
         'DiagnosedApplications\\chrome.exe'
     )
 
-    value_data = (int(filetime.timestamp)).to_bytes(8, byteorder='little')
+    value_data = b"\x01\xDB\x78\x82\x3A\x40\x72\x1D"
     print(value_data)
     registry_value = dfwinreg_fake.FakeWinRegistryValue(
       'LastDetectionTime', data=value_data,
@@ -63,7 +63,7 @@ class WindowsRegistryDiagnosedApplicationsPluginTest(
 
     expected_event_values = {
       'process_name': 'chrome.exe',
-      'last_detection_time': '2024-08-28T09:23:49.0020310+00:00',
+      'last_detection_time': '2025-02-06T10:31:05.594524+02:00',
       'data_type': 'windows:registry:diagnosed_applications',
       'key_path': (
           'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\RADAR\\HeapLeakDetection'

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -4,10 +4,6 @@
 
 import unittest
 
-from dfdatetime import filetime as dfdatetime_filetime
-from dfwinreg import definitions as dfwinreg_definitions
-from dfwinreg import fake as dfwinreg_fake
-
 from plaso.parsers.winreg_plugins import diagnosed_applications
 
 from tests.parsers.winreg_plugins import test_lib

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -38,7 +38,7 @@ class WindowsRegistryDiagnosedApplicationsPluginTest(
       'LastDetectionTime', data=value_data,
       data_type=dfwinreg_definitions.REG_QWORD)
     registry_key.AddValue(registry_value)
-    print(registry_key.GetValueByName('LastDetectionTime'))
+    print(str(registry_key.GetValueByName('LastDetectionTime')))
 
     return registry_key
 

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -32,7 +32,7 @@ class WindowsRegistryDiagnosedApplicationsPluginTest(
         'DiagnosedApplications\\chrome.exe'
     )
 
-    value_data = filetime.timestamp.encode('utf_16_le')
+    value_data = f"{filetime.timestamp}".encode('utf_16_le')
     registry_value = dfwinreg_fake.FakeWinRegistryValue(
       'LastDetectionTime', data=value_data,
       data_type=dfwinreg_definitions.REG_QWORD)

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -32,7 +32,7 @@ class WindowsRegistryDiagnosedApplicationsPluginTest(
         'DiagnosedApplications\\chrome.exe'
     )
 
-    value_data = int(filetime.timestamp)
+    value_data = (int(filetime.timestamp)).to_bytes(8, byteorder='little')
     print(value_data)
     registry_value = dfwinreg_fake.FakeWinRegistryValue(
       'LastDetectionTime', data=value_data,

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -32,7 +32,7 @@ class WindowsRegistryDiagnosedApplicationsPluginTest(
         'DiagnosedApplications\\chrome.exe'
     )
 
-    value_data = filetime.timestamp
+    value_data = int(filetime.timestamp)
     registry_value = dfwinreg_fake.FakeWinRegistryValue(
       'LastDetectionTime', data=value_data,
       data_type=dfwinreg_definitions.REG_QWORD)

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -32,12 +32,13 @@ class WindowsRegistryDiagnosedApplicationsPluginTest(
         'DiagnosedApplications\\chrome.exe'
     )
 
-    value_data = "1db78823a40721d".encode('utf_16_le')
+    value_data = "1db78823a40721d"
     print(value_data)
     registry_value = dfwinreg_fake.FakeWinRegistryValue(
       'LastDetectionTime', data=value_data,
       data_type=dfwinreg_definitions.REG_QWORD)
     registry_key.AddValue(registry_value)
+    print(registry_key.GetValueByName('LastDetectionTime'))
 
     return registry_key
 

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the Diagnosed Applications Windows Registry plugin."""
+
+import unittest
+
+from dfdatetime import filetime as dfdatetime_filetime
+from dfwinreg import definitions as dfwinreg_definitions
+from dfwinreg import fake as dfwinreg_fake
+
+from plaso.parsers.winreg_plugins import diagnosed_applications
+
+from tests.parsers.winreg_plugins import test_lib
+
+
+class WindowsRegistryDiagnosedApplicationsPluginTest(
+    test_lib.RegistryPluginTestCase):
+  """Tests for the Diagnosed Applications Windows Registry plugin."""
+
+  def _CreateTestKey(self):
+    """Creates Registry keys and values for testing.
+    Returns:
+      dfwinreg.WinRegistryKey: a Windows Registry key.
+    """
+    filetime = dfdatetime_filetime.Filetime()
+    filetime.CopyFromDateTimeString('2024-08-28 09:23:49.002031')
+    registry_key = dfwinreg_fake.FakeWinRegistryKey(
+      'chrome.exe',
+      key_path_prefix='HKEY_LOCAL_MACHINE\\SOFTWARE',
+      last_written_time=filetime.timestamp,
+      relative_key_path='Microsoft\\RADAR\\HeapLeakDetection\\'
+        'DiagnosedApplications\\chrome.exe'
+    )
+
+    value_data = filetime.timestamp
+    registry_value = dfwinreg_fake.FakeWinRegistryValue(
+      'LastDetectionTime', data=value_data,
+      data_type=dfwinreg_definitions.REG_QWORD)
+    registry_key.AddValue(registry_value)
+
+    return registry_key
+
+  def testProcessValue(self):
+    """Tests the Process function for BAM data."""
+    test_file_entry = test_lib.TestFileEntry('SOFTWARE')
+    registry_key = self._CreateTestKey()
+    plugin = diagnosed_applications.DiagnosedApplicationsPlugin()
+    storage_writer = self._ParseKeyWithPlugin(
+        registry_key, plugin, file_entry=test_file_entry)
+
+    number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
+        'event_data')
+    self.assertEqual(number_of_event_data, 1)
+
+    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+        'extraction_warning')
+    self.assertEqual(number_of_warnings, 0)
+
+    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+        'recovery_warning')
+    self.assertEqual(number_of_warnings, 0)
+
+    expected_event_values = {
+      'process_name': 'chrome.exe',
+      'last_detection_time': '2024-08-28T09:23:49.0020310+00:00',
+      'data_type': 'windows:registry:diagnosed_applications',
+      'key_path': (
+          'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\RADAR\\HeapLeakDetection'
+          '\\DiagnosedApplications\\chrome.exe'),
+      'last_written_time': '2024-08-28T09:23:49.0020310+00:00'}
+
+    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 0)
+    self.CheckEventData(event_data, expected_event_values)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """Tests for the Diagnosed Applications Windows Registry plugin."""
 
 import unittest

--- a/tests/parsers/winreg_plugins/diagnosed_applications.py
+++ b/tests/parsers/winreg_plugins/diagnosed_applications.py
@@ -15,16 +15,16 @@ class WindowsRegistryDiagnosedApplicationsPluginTest(
   def testProcessValue(self):
     """Tests the Process function for Diagnosed Applications data."""
     test_file_entry = self._GetTestFileEntry(['SOFTWARE'])
-    key_path = ('HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\RADAR\\'
-                'HeapLeakDetection\\DiagnosedApplications')
+
+    key_path = (
+        'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\RADAR\\HeapLeakDetection\\'
+        'DiagnosedApplications')
 
     win_registry = self._GetWinRegistryFromFileEntry(test_file_entry)
     registry_key = win_registry.GetKeyByPath(key_path)
     plugin = diagnosed_applications.DiagnosedApplicationsPlugin()
     storage_writer = self._ParseKeyWithPlugin(
-      registry_key=registry_key,
-      plugin=plugin
-    )
+        registry_key=registry_key, plugin=plugin)
 
     number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
         'event_data')
@@ -39,14 +39,13 @@ class WindowsRegistryDiagnosedApplicationsPluginTest(
     self.assertEqual(number_of_warnings, 0)
 
     expected_event_values = {
-      'process_name': 'TrustedInstaller.exe',
-      'last_detection_time': '2011-09-17T13:21:44.0776364+00:00',
-      'data_type': 'windows:registry:diagnosed_applications',
-      'key_path': (
-          'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\RADAR\\HeapLeakDetection'
-          '\\DiagnosedApplications\\TrustedInstaller.exe'),
-      'last_written_time': '2011-09-17T13:21:44.0776364+00:00'
-    }
+        'data_type': 'windows:registry:diagnosed_applications',
+        'key_path': (
+            'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\RADAR\\'
+            'HeapLeakDetection\\DiagnosedApplications\\TrustedInstaller.exe'),
+        'last_detection_time': '2011-09-17T13:21:44.0776364+00:00',
+        'last_written_time': '2011-09-17T13:21:44.0776364+00:00',
+        'process_name': 'TrustedInstaller.exe'}
 
     event_data = storage_writer.GetAttributeContainerByIndex('event_data', 0)
     self.CheckEventData(event_data, expected_event_values)


### PR DESCRIPTION
## RADAR - Evidence of Execution


## Description
A subkey is generated for each process that exceeds the 'HeapLeakDetection' threshold within the scan interval under 'HKLM\Software\Microsoft\RADAR\HeapLeakDetection\DiagnosedApplications'.

Further explanations can be found in the references (it would be redundant to repeat that).

## References
https://harelsegev.github.io/posts/the-mystery-of-the-heapleakdetection-registry-key/
https://github.com/MHaggis/HeapLeakDetection
https://www.youtube.com/watch?v=edJa_SLVqOo

## Checklist:
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated.
* [x] Test data has a Plaso compatible license. If the test data was not authored by you (the contributor), make sure to mention its orginal source in ACKNOWLEDGEMENTS.
* [x] Reviewer assigned.
* [ ] Automated checks (GitHub Actions, AppVeyor) pass.
