### PR TITLE
Fix typo in macOS data formatter

### DIFF
--- a/plaso/data/formatters/macos.yaml
+++ b/plaso/data/formatters/macos.yaml
@@ -369,7 +369,7 @@ message:
 short_message:
 - 'Body: {body}'
 short_source: 'Launchd'
-source: 'MacOS Laucnhd'
+source: 'MacOS Launchd'
 ---
 type: 'conditional'
 data_type: 'macos:lsquarantine:entry'


### PR DESCRIPTION
## One line description of pull request

Fixes a typo in the macOS data formatter.

## Description:

(nothing else, really)

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated.
* [ ] Test data has a Plaso compatible license. If the test data was not authored by you (the contributor), make sure to mention its orginal source in ACKNOWLEDGEMENTS.
* [ ] Reviewer assigned.
* [ ] Automated checks (GitHub Actions, AppVeyor) pass.
