### PR TITLE
Add missing f-string in ListTimeZones

### DIFF
--- a/plaso/cli/tools.py
+++ b/plaso/cli/tools.py
@@ -356,7 +356,7 @@ class CLITool(object):
         utc_offset_string = f'+{utc_offset:s}'
       else:
         _, _, utc_offset = local_date_string.rpartition('-')
-        utc_offset_string = '-{utc_offset:s}'
+        utc_offset_string = f'-{utc_offset:s}'
 
       table_view.AddRow([time_zone_name, utc_offset_string])
 


### PR DESCRIPTION
## One line description of pull request
Add missing f-string to ListTimeZones formatted output


## Description:

When you run log2timeline --timezone list the formatted output shows "-{utf_offset:s}" for
all Time zones with a negative UTC offset.

**Related issue (if applicable):** N/A

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated.
* [x] Test data has a Plaso compatible license. If the test data was not authored by you (the contributor), make sure to mention its orginal source in ACKNOWLEDGEMENTS.
* [x] Reviewer assigned.
* [x] Automated checks (GitHub Actions, AppVeyor) pass.
