### PR TITLE
fix: correct registry value parsing for Amcache plugin parameters

### DIFF
--- a/plaso/parsers/winreg_plugins/amcache.py
+++ b/plaso/parsers/winreg_plugins/amcache.py
@@ -120,7 +120,10 @@ class AMCachePlugin(interface.WindowsRegistryPlugin):
       'ProductVersion': 'file_version',
       'ProgramId': 'program_identifier',
       'Publisher': 'company_name',
-      'Size': 'file_size'}
+      'Size': 'file_size',
+      'FileId': 'sha1',
+      'Language': 'language_code',
+      'Version': 'file_version'}
 
   _FILE_REFERENCE_KEY_VALUES = {
       '0': 'product_name',
@@ -216,6 +219,10 @@ class AMCachePlugin(interface.WindowsRegistryPlugin):
       if value:
         value_data = self._GetValueDataAsObject(
             parser_mediator, application_sub_key.path, value_name, value)
+
+        if attribute_name == 'sha1' and value_data.startswith('0000'):
+            # Strip off the 4 leading zero's from the sha1 hash.
+            value_data = value_data[4:]
 
         setattr(event_data, attribute_name, value_data)
 

--- a/tests/parsers/winreg_plugins/amcache.py
+++ b/tests/parsers/winreg_plugins/amcache.py
@@ -120,7 +120,16 @@ class AMCachePluginTest(test_lib.RegistryPluginTestCase):
         'installation_time': None,
         'last_written_time': None,
         'link_time': '1997-01-10T22:26:24+00:00',
-        'msi_installation_time': None}
+        'msi_installation_time': None,
+        'sha1': '75c5a97f521f760e32a4a9639a653eed862e9c61',
+        'file_size': 53744,
+        'language_code': 1033,
+        'file_version': '10.0.18362.1 (winbuild.160101.0800)',
+        'company_name': 'microsoft corporation',
+        'file_description': None,
+        'file_reference': None,
+        'product_name': 'microsoft® windows® operating system',
+        'program_identifier': '0000f519feec486de87ed73cb92d3cac802400000000'}
 
     event_data = storage_writer.GetAttributeContainerByIndex('event_data', 135)
     self.CheckEventData(event_data, expected_event_values)


### PR DESCRIPTION
## Description:

Updated the plugin to correctly read registry values for the following parameters of the windows:registry:amcache data type
- sha1
- file_size
- language_code
- file_version
- company_name
- product_name
- program_identifier

Updated Test File.

This fix addresses issues caused by changes in the Amcache hive structure from Windows 7 to Windows 10.

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated.
* [ ] Test data has a Plaso compatible license. If the test data was not authored by you (the contributor), make sure to mention its orginal source in ACKNOWLEDGEMENTS.
* [x] Reviewer assigned.
* [ ] Automated checks (GitHub Actions, AppVeyor) pass.
