### PR TITLE
fix: add IPv6 zone index support to IIS parser

### DIFF
--- a/plaso/parsers/text_plugins/iis.py
+++ b/plaso/parsers/text_plugins/iis.py
@@ -93,9 +93,15 @@ class WinIISTextPlugin(interface.TextPlugin):
   _FOUR_DIGITS = pyparsing.Word(pyparsing.nums, exact=4).set_parse_action(
       lambda tokens: int(tokens[0], 10))
 
+  # IPv6 address with optional zone index (e.g., fe80::1%3 or fe80::1%eth0)
+  # Zone index format: % followed by alphanumeric characters
+  _IPV6_WITH_ZONE = pyparsing.Combine(
+      pyparsing.pyparsing_common.ipv6_address +
+      pyparsing.Optional('%' + pyparsing.Word(pyparsing.alphanums)))
+
   _IP_ADDRESS = (
       pyparsing.pyparsing_common.ipv4_address |
-      pyparsing.pyparsing_common.ipv6_address | _BLANK)
+      _IPV6_WITH_ZONE | _BLANK)
 
   PORT = pyparsing.Word(pyparsing.nums, max=6).set_parse_action(
       lambda tokens: int(tokens[0], 10)) | _BLANK

--- a/test_data/iis_ipv6_zone.log
+++ b/test_data/iis_ipv6_zone.log
@@ -1,0 +1,7 @@
+#Software: Microsoft Internet Information Services 10.0
+#Version: 1.0
+#Date: 2021-08-07 00:00:01
+#Fields: date time s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(User-Agent) cs(Referer) sc-status sc-substatus sc-win32-status time-taken
+2022-01-01 00:01:24 fe80::1ff:fe23:4567:890a%3 POST /powershell clientApplication=ActiveMonitor;PSVersion=5.1.14393.4467 444  random\ranuser1 ::1 Microsoft+WinRM+Client - 200 0 0 15
+2022-01-02 00:01:25 ::1 GET /api/test - 443  testuser fe80::abcd:ef01:2345:6789%eth0 Mozilla/5.0 - 200 0 0 20
+2022-01-03 00:01:26 2001:db8::1%2 POST /endpoint - 443  admin 192.168.1.100 curl/7.68.0 - 404 0 0 10


### PR DESCRIPTION
## Summary
- Add support for IPv6 addresses with zone index (e.g., fe80::1%3)
- Extends IIS parser to handle zone identifiers in IPv6 addresses
- Maintains backward compatibility with IPv4 and standard IPv6

Fixes #4903

## Test plan
- [x] Added test_data/iis_ipv6_zone.log with 3 test cases
- [x] Tested IPv6 with numeric zone IDs (%3, %2)
- [x] Tested IPv6 with alphanumeric zone IDs (%eth0)
- [x] Verified backward compatibility with IPv4/standard IPv6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>