### PR TITLE
fix: add newsyslog header/footer support to Santa log parser

### DIFF
--- a/plaso/parsers/text_plugins/santa.py
+++ b/plaso/parsers/text_plugins/santa.py
@@ -335,6 +335,13 @@ class SantaTextPlugin(interface.TextPlugin):
       pyparsing.Literal('EXIT').set_results_name('action') +
       _PID + _PID_VERSION + _PPID + _UID + _GID + _END_OF_LINE)
 
+  # Newsyslog header/footer format:
+  # MMM DD HH:MM:SS hostname newsyslog[PID]: message
+  _NEWSYSLOG_LINE = (
+      pyparsing.Regex(
+          r'[A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\S+\s+'
+          r'newsyslog\[\d+\]:\s+.*') + _END_OF_LINE)
+
   _QUOTA_EXCEEDED_LINE = (
       _DATE_TIME_BLOCK + pyparsing.Literal((
           '*** LOG MESSAGE QUOTA EXCEEDED - SOME MESSAGES FROM THIS PROCESS '
@@ -344,6 +351,7 @@ class SantaTextPlugin(interface.TextPlugin):
       ('execution_line', _EXECUTION_LINE),
       ('file_system_event_line', _FILE_OPERATION_LINE),
       ('mount_line', _DISK_MOUNT_LINE),
+      ('newsyslog_line', _NEWSYSLOG_LINE),
       ('process_exit_line', _PROCESS_EXIT_LINE),
       ('quota_exceeded_line', _QUOTA_EXCEEDED_LINE),
       ('unmount_line', _DISK_UNMOUNT_LINE)]
@@ -364,6 +372,10 @@ class SantaTextPlugin(interface.TextPlugin):
     Raises:
       ParseError: if the structure cannot be parsed.
     """
+    if key == 'newsyslog_line':
+      # Skip newsyslog header/footer lines
+      return
+
     if key == 'quota_exceeded_line':
       # skip this line
       return

--- a/test_data/santa_newsyslog.log
+++ b/test_data/santa_newsyslog.log
@@ -1,0 +1,4 @@
+Mar 31 06:30:02 hostname newsyslog[10904]: logfile turned over due to size>25000K
+[2023-03-31T06:29:57.423Z] I santad: action=EXIT|pid=10897|pidversion=2243287|ppid=1|uid=262|gid=262
+[2023-04-12T22:18:02.588Z] I santad: action=EXEC|decision=ALLOW|reason=CERT|sha256=abc123def456|cert_sha256=def789ghi012|cert_cn=Software Signing|pid=12345|pidversion=3456789|ppid=1|uid=0|user=root|gid=0|group=wheel|mode=M|path=/usr/bin/test
+Apr 12 22:33:30 hostname newsyslog[58079]: logfile turned over due to size>40000K

--- a/tests/parsers/text_plugins/santa.py
+++ b/tests/parsers/text_plugins/santa.py
@@ -182,5 +182,61 @@ class SantaTextPluginTest(test_lib.TextPluginTestCase):
     self.CheckEventData(event_data, expected_event_values)
 
 
+  def testProcessWithNewsyslogHeaders(self):
+    """Tests the Process function with newsyslog headers and footers."""
+    plugin = santa.SantaTextPlugin()
+    storage_writer = self._ParseTextFileWithPlugin(
+        ['santa_newsyslog.log'], plugin)
+
+    # Should only parse the 2 valid Santa log lines, skipping newsyslog lines
+    number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
+        'event_data')
+    self.assertEqual(number_of_event_data, 2)
+
+    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+        'extraction_warning')
+    self.assertEqual(number_of_warnings, 0)
+
+    number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+        'recovery_warning')
+    self.assertEqual(number_of_warnings, 0)
+
+    # Test EXIT event
+    expected_event_values = {
+        'action': 'EXIT',
+        'data_type': 'santa:process_exit',
+        'exit_time': '2023-03-31T06:29:57.423+00:00',
+        'gid': '262',
+        'pid': '10897',
+        'pid_version': '2243287',
+        'ppid': '1',
+        'uid': '262'}
+
+    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 0)
+    self.CheckEventData(event_data, expected_event_values)
+
+    # Test EXEC event
+    expected_event_values = {
+        'action': 'EXEC',
+        'certificate_common_name': 'Software Signing',
+        'certificate_hash': 'def789ghi012',
+        'data_type': 'santa:execution',
+        'decision': 'ALLOW',
+        'gid': '0',
+        'group': 'wheel',
+        'last_run_time': '2023-04-12T22:18:02.588+00:00',
+        'mode': 'M',
+        'pid': '12345',
+        'pid_version': '3456789',
+        'ppid': '1',
+        'process_hash': 'abc123def456',
+        'process_path': '/usr/bin/test',
+        'reason': 'CERT',
+        'uid': '0',
+        'user': 'root'}
+
+    event_data = storage_writer.GetAttributeContainerByIndex('event_data', 1)
+    self.CheckEventData(event_data, expected_event_values)
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
## Summary
- Handle newsyslog rotation headers/footers in Santa logs
- Skip newsyslog metadata lines gracefully
- Maintain parsing of actual Santa log entries

Fixes #4599

## Test plan
- [x] Created test_data/santa_newsyslog.log with mixed entries
- [x] Validates newsyslog line detection and skipping
- [x] Confirms Santa events still parsed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>