### PR TITLE
Corrected shebangs in utility/test scripts

### DIFF
--- a/tests/engine/artifact_filters.py
+++ b/tests/engine/artifact_filters.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Tests for the artifacts file filter functions."""
 

--- a/tests/parsers/text_plugins/android_logcat.py
+++ b/tests/parsers/text_plugins/android_logcat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Tests for Android logcat text parser plugin."""
 

--- a/tests/parsers/text_plugins/apache_access.py
+++ b/tests/parsers/text_plugins/apache_access.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Tests for Apache access log text parser plugin."""
 

--- a/tests/parsers/text_plugins/aws_elb_access.py
+++ b/tests/parsers/text_plugins/aws_elb_access.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Tests for the AWS ELB access log text parser plugin."""
 

--- a/tests/parsers/text_plugins/confluence_access.py
+++ b/tests/parsers/text_plugins/confluence_access.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Tests for Confluence access log text parser plugin."""
 

--- a/tests/parsers/text_plugins/santa.py
+++ b/tests/parsers/text_plugins/santa.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Tests for Santa log text parser plugin."""
 

--- a/tests/parsers/winpca.py
+++ b/tests/parsers/winpca.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Tests for Program Compatibility Assistant (PCA) log parsers."""
 

--- a/utils/export_event_data.py
+++ b/utils/export_event_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Script to extract the event data attribute containers schema."""
 

--- a/utils/export_supported_formats.py
+++ b/utils/export_supported_formats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Script to extract information about the supported data formats."""
 

--- a/utils/generate_windows_time_zones.py
+++ b/utils/generate_windows_time_zones.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Script to generate Windows time zone name to Python mappings."""
 


### PR DESCRIPTION
## One line description of pull request

Fixes shebangs to search python from the environment instead of hardcoded paths.

## Description:

The shebangs are incorrectly set in some scripts. When running those scripts in a virtual environment, the Python from the host system is used instead of the one from the virtualenv itself. 
