### PR TITLE
Added missing initialization of status_reasons in GCP log parser

### DIFF
--- a/plaso/parsers/jsonl_plugins/gcp_log.py
+++ b/plaso/parsers/jsonl_plugins/gcp_log.py
@@ -109,6 +109,7 @@ class GCPLogEventData(events.EventData):
     self.source_images = None
     self.status_code = None
     self.status_message = None
+    self.status_reasons = None
     self.text_payload = None
     self.user_agent = None
 


### PR DESCRIPTION
## One line description of pull request

Add missing `status_reasons` declaration in  `GCPLogEventData` constructor.

## Description:

Commit [e0e5b1e96ec36a84dec3ed6ccb8](https://github.com/log2timeline/plaso/commit/e0e5b1e96ec36a84dec3ed6ccb8ff46f9fd64774) introduced new attributes in `GCPLogEventData`. However, the attribute `status_reasons` is missing declaration in constructor. Because of this, it becomes "optional" and might or might not appear in the final event data. This could lead to inconsistent results downstream for tools expecting this attribute (whenever it is empty or not).

Note that I caught this by comparing data types produced by `./utils/export_event_data.py` and the actual commit. Without this changes, I get:

```
gcp:log:entry
  caller_ip
  container
  data_type
  dcsa_emails
  dcsa_scopes
  delegation_chain
  event_subtype
  event_type
  filename
  firewall_rules
  firewall_source_ranges
  gcloud_command_identity
  gcloud_command_partial
  log_name
  message
  method_name
  permissions
  policy_deltas
  principal_email
  principal_subject
  recorded_time
  request_account_identifier
  request_address
  request_description
  request_direction
  request_email
  request_member
  request_metadata
  request_name
  request_target_tags
  resource_labels
  resource_name
  service_account_delegation
  service_account_display_name
  service_account_key_name
  service_name
  severity
  source_images
  status_code
  status_message
  text_payload
  user_agent
```

With the change:

```
gcp:log:entry
  caller_ip
  container
  data_type
  dcsa_emails
  dcsa_scopes
  delegation_chain
  event_subtype
  event_type
  filename
  firewall_rules
  firewall_source_ranges
  gcloud_command_identity
  gcloud_command_partial
  log_name
  message
  method_name
  permissions
  policy_deltas
  principal_email
  principal_subject
  recorded_time
  request_account_identifier
  request_address
  request_description
  request_direction
  request_email
  request_member
  request_metadata
  request_name
  request_target_tags
  resource_labels
  resource_name
  service_account_delegation
  service_account_display_name
  service_account_key_name
  service_name
  severity
  source_images
  status_code
  status_message
  status_reasons
  text_payload
  user_agent
```

Note that this process of comparison takes some times (when upgrading Plaso). Maybe there should be some kind of hook to automatically detect discrepancy between the documentation (pydoc) and the data type actually built. This might be related to #4956

@roshanmaskey does it look good to you?
