### PR TITLE
Factorize common code in Pinfo

### DIFF
--- a/plaso/cli/pinfo_tool.py
+++ b/plaso/cli/pinfo_tool.py
@@ -262,139 +262,58 @@ class PinfoTool(tools.CLITool, tool_options.StorageFileOptions):
     compare_storage_counters = self._CalculateStorageCounters(
         compare_storage_reader)
 
-    # Compare number of events.
-    parsers_counter = storage_counters.get('parsers', collections.Counter())
-    compare_parsers_counter = compare_storage_counters.get(
-        'parsers', collections.Counter())
-    differences = self._CompareCounter(parsers_counter, compare_parsers_counter)
+    counters = [
+      (
+        'parsers', False,
+        'Events generated per parser',
+        ['Parser (plugin) name', 'Number of events']),
+      (
+        'extraction_warnings_by_parser_chain', False,
+        'Extraction warnings generated per parser',
+        ['Parser (plugin) name', 'Number of warnings']),
+      (
+        'extraction_warnings_by_path_spec', True,
+        'Pathspecs with most extraction warnings',
+        ['Number of warnings', 'Pathspec']),
+      (
+        'recovery_warnings_by_parser_chain', False,
+        'Recovery warnings generated per parser',
+        ['Parser (plugin) name', 'Number of warnings']),
+      (
+        'recovery_warnings_by_path_spec', True,
+        'Pathspecs with most recovery warnings',
+        ['Number of warnings', 'Pathspec']),
+      (
+        'timelining_warnings_by_parser_chain', False,
+        'Timelining warnings generated per parser',
+        ['Parser (plugin) name', 'Number of warnings']),
+      (
+        'timelining_warnings_by_path_spec', True,
+        'Pathspecs with most timelining warnings',
+        ['Number of warnings', 'Pathspec']),
+      (
+        'event_labels', False,
+        'Event tags generated per label',
+        ['Label', 'Number of event tags']),
+      (
+        'analysis_reports', False,
+        'Reports generated per plugin',
+         ['Plugin name', 'Number of reports']),
+    ]
 
-    if differences:
-      stores_are_identical = False
+    for (counter_type, reverse, title, column_names) in counters:
+      storage_counter = storage_counters.get(
+        counter_type, collections.Counter())
+      compare_storage_counter = compare_storage_counters.get(
+        counter_type, collections.Counter())
+      differences = self._CompareCounter(
+        storage_counter, compare_storage_counter)
 
-      self._PrintCounterDifferences(
-          differences,
-          column_names=['Parser (plugin) name', 'Number of events'],
-          title='Events generated per parser')
+      if differences:
+        stores_are_identical = False
 
-    # Compare extraction warnings by parser chain.
-    warnings_counter = storage_counters.get(
-        'extraction_warnings_by_parser_chain', collections.Counter())
-    compare_warnings_counter = compare_storage_counters.get(
-        'extraction_warnings_by_parser_chain', collections.Counter())
-    differences = self._CompareCounter(
-        warnings_counter, compare_warnings_counter)
-
-    if differences:
-      stores_are_identical = False
-
-      self._PrintCounterDifferences(
-          differences,
-          column_names=['Parser (plugin) name', 'Number of warnings'],
-          title='Extraction warnings generated per parser')
-
-    # Compare extraction warnings by path specification
-    warnings_counter = storage_counters.get(
-        'extraction_warnings_by_path_spec', collections.Counter())
-    compare_warnings_counter = compare_storage_counters.get(
-        'extraction_warnings_by_path_spec', collections.Counter())
-    differences = self._CompareCounter(
-        warnings_counter, compare_warnings_counter)
-
-    if differences:
-      stores_are_identical = False
-
-      self._PrintCounterDifferences(
-          differences, column_names=['Number of warnings', 'Pathspec'],
-          reverse=True, title='Pathspecs with most extraction warnings')
-
-    # Compare recovery warnings by parser chain.
-    warnings_counter = storage_counters.get(
-        'recovery_warnings_by_parser_chain', collections.Counter())
-    compare_warnings_counter = compare_storage_counters.get(
-        'recovery_warnings_by_parser_chain', collections.Counter())
-    differences = self._CompareCounter(
-        warnings_counter, compare_warnings_counter)
-
-    if differences:
-      stores_are_identical = False
-
-      self._PrintCounterDifferences(
-          differences,
-          column_names=['Parser (plugin) name', 'Number of warnings'],
-          title='Recovery warnings generated per parser')
-
-    # Compare recovery warnings by path specification
-    warnings_counter = storage_counters.get(
-        'recovery_warnings_by_path_spec', collections.Counter())
-    compare_warnings_counter = compare_storage_counters.get(
-        'recovery_warnings_by_path_spec', collections.Counter())
-    differences = self._CompareCounter(
-        warnings_counter, compare_warnings_counter)
-
-    if differences:
-      stores_are_identical = False
-
-      self._PrintCounterDifferences(
-          differences, column_names=['Number of warnings', 'Pathspec'],
-          reverse=True, title='Pathspecs with most recovery warnings')
-
-    # Compare timelining warnings by parser chain.
-    warnings_counter = storage_counters.get(
-        'timelining_warnings_by_parser_chain', collections.Counter())
-    compare_warnings_counter = compare_storage_counters.get(
-        'timelining_warnings_by_parser_chain', collections.Counter())
-    differences = self._CompareCounter(
-        warnings_counter, compare_warnings_counter)
-
-    if differences:
-      stores_are_identical = False
-
-      self._PrintCounterDifferences(
-          differences,
-          column_names=['Parser (plugin) name', 'Number of warnings'],
-          title='Timelining warnings generated per parser')
-
-    # Compare timelining warnings by path specification.
-    warnings_counter = storage_counters.get(
-        'timelining_warnings_by_path_spec', collections.Counter())
-    compare_warnings_counter = compare_storage_counters.get(
-        'timelining_warnings_by_path_spec', collections.Counter())
-    differences = self._CompareCounter(
-        warnings_counter, compare_warnings_counter)
-
-    if differences:
-      stores_are_identical = False
-
-      self._PrintCounterDifferences(
-          differences, column_names=['Number of warnings', 'Pathspec'],
-          reverse=True, title='Pathspecs with most timelining warnings')
-
-    # Compare event labels.
-    labels_counter = storage_counters.get('event_labels', collections.Counter())
-    compare_labels_counter = compare_storage_counters.get(
-        'event_labels', collections.Counter())
-    differences = self._CompareCounter(labels_counter, compare_labels_counter)
-
-    if differences:
-      stores_are_identical = False
-
-      self._PrintCounterDifferences(
-          differences, column_names=['Label', 'Number of event tags'],
-          title='Event tags generated per label')
-
-    # Compare analysis reports.
-    reports_counter = storage_counters.get(
-        'analysis_reports', collections.Counter())
-    compare_reports_counter = compare_storage_counters.get(
-        'analysis_reports', collections.Counter())
-    differences = self._CompareCounter(reports_counter, compare_reports_counter)
-
-    if differences:
-      stores_are_identical = False
-
-      self._PrintCounterDifferences(
-          differences, column_names=['Plugin name', 'Number of reports'],
-          title='Reports generated per plugin')
+        self._PrintCounterDifferences(
+          differences, reverse=reverse, column_names=column_names, title=title)
 
     return stores_are_identical
 

--- a/plaso/cli/pinfo_tool.py
+++ b/plaso/cli/pinfo_tool.py
@@ -120,7 +120,6 @@ class PinfoTool(tools.CLITool, tool_options.StorageFileOptions):
     # TODO: determine analysis report counter from actual stored analysis
     # reports or remove.
     analysis_reports_counter = collections.Counter()
-    analysis_reports_counter_error = False
 
     event_labels_counter = {}
     if storage_reader.HasAttributeContainers('event_label_count'):
@@ -130,7 +129,6 @@ class PinfoTool(tools.CLITool, tool_options.StorageFileOptions):
               'event_label_count')}
 
     event_labels_counter = collections.Counter(event_labels_counter)
-    event_labels_counter_error = False
 
     parsers_counter = {}
     if storage_reader.HasAttributeContainers('parser_count'):
@@ -140,7 +138,6 @@ class PinfoTool(tools.CLITool, tool_options.StorageFileOptions):
               'parser_count')}
 
     parsers_counter = collections.Counter(parsers_counter)
-    parsers_counter_error = False
 
     storage_counters = {}
 
@@ -191,14 +188,9 @@ class PinfoTool(tools.CLITool, tool_options.StorageFileOptions):
     storage_counters['timelining_warnings_by_parser_chain'] = (
         timelining_warnings_by_parser_chain)
 
-    if not analysis_reports_counter_error:
-      storage_counters['analysis_reports'] = analysis_reports_counter
-
-    if not event_labels_counter_error:
-      storage_counters['event_labels'] = event_labels_counter
-
-    if not parsers_counter_error:
-      storage_counters['parsers'] = parsers_counter
+    storage_counters['analysis_reports'] = analysis_reports_counter
+    storage_counters['event_labels'] = event_labels_counter
+    storage_counters['parsers'] = parsers_counter
 
     return storage_counters
 

--- a/tests/cli/pinfo_tool.py
+++ b/tests/cli/pinfo_tool.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Tests for the pinfo CLI tool."""
 
+import collections
 import json
 import unittest
 
@@ -30,7 +31,45 @@ Parser (plugin) name : Number of events
 Storage files are different.
 """
 
-  # TODO: add test for _CalculateStorageCounters.
+  def testCalculateStorageCounters(self):
+    """Tests the _CalculateStorageCounters function."""
+    test_file_path = self._GetTestFilePath(['psort_test.plaso'])
+    self._SkipIfPathNotExists(test_file_path)
+
+    output_writer = test_lib.TestOutputWriter(encoding='utf-8')
+    test_tool = pinfo_tool.PinfoTool(output_writer=output_writer)
+
+    storage_reader = test_tool._GetStorageReader(test_file_path)
+
+    expected_output = {
+      'analysis_reports': collections.Counter(),
+      'event_labels': collections.Counter({
+        'total': 8,
+        'repeated': 4,
+        'exit1': 2,
+        'exit2': 2,
+      }),
+      'extraction_warnings_by_parser_chain': collections.Counter({
+        'text/syslog_traditional': 2,
+      }),
+      'extraction_warnings_by_path_spec': collections.Counter({
+        'type: OS, location: /tmp/test/test_data/syslog\n': 2,
+      }),
+      'parsers': collections.Counter({
+        'total': 38,
+        'syslog_traditional': 32,
+        'filestat': 6,
+      }),
+      'recovery_warnings_by_parser_chain': collections.Counter(),
+      'recovery_warnings_by_path_spec': collections.Counter(),
+      'timelining_warnings_by_parser_chain': collections.Counter(),
+      'timelining_warnings_by_path_spec': collections.Counter(),
+    }
+
+    output = test_tool._CalculateStorageCounters(storage_reader)
+
+    self.assertEqual(output, expected_output)
+
   # TODO: add test for _CompareStores.
 
   def testGenerateAnalysisResultsReportAsJSON(self):


### PR DESCRIPTION
## One line description of pull request

Factorizes duplicated code in Pinfo. 

## Description:

In `plaso/cli/pinfo_tool.py`, both methods `_CalculateStorageCounters()` and `_CompareStores()` have duplicated codes that only varies in data but not in behavior. Like any duplicated code, modifying one path implies to also modify all the other paths. This is error prone and it hurts extensibility.

This merge request, factorize those code and provides a test basis for said methods. Also, it cuts the code footprint by half. The behavior should be identical and printing differences in storage preserves the same order.

## Additional Context

I'm working on adding a new "data type counter" into the storage file. I already have a working patch but it hurts me to add another duplicated code in those paths. So, this is kinda of a "pre-requisite" patch.

Concerning this MR itself, I have a few questions (mostly regarding tests):
- I've named the test function for `_CompareStores`, `testPrivateCompareStores` since `testCompareStores` already exists. Is this name fine?
- I'm not entirely convinced by those "mocks" in `testPrivateCompareStores`. Is this how you would approach it or do you prefer checking it from an actual file instead?
- The `counters` list in `_CompareStores` sounds like something that should goes into class attribute, so we have a "single source of truth" (both in code and tests). What do you think about it?

Regards,
