### PR TITLE
Added data type counter

### DIFF
--- a/plaso/cli/pinfo_tool.py
+++ b/plaso/cli/pinfo_tool.py
@@ -127,6 +127,18 @@ class PinfoTool(tools.CLITool, tool_options.StorageFileOptions):
         analysis_reports_counter = collections.Counter()
         analysis_reports_counter_error = False
 
+        data_types_counter = {}
+        if storage_reader.HasAttributeContainers("data_type_count"):
+            data_types_counter = {
+                data_type_count.name: data_type_count.number_of_events
+                for data_type_count in storage_reader.GetAttributeContainers(
+                    "data_type_count"
+                )
+            }
+
+        data_types_counter = collections.Counter(data_types_counter)
+        data_types_counter_error = False
+
         event_labels_counter = {}
         if storage_reader.HasAttributeContainers("event_label_count"):
             event_labels_counter = {
@@ -213,6 +225,9 @@ class PinfoTool(tools.CLITool, tool_options.StorageFileOptions):
         if not analysis_reports_counter_error:
             storage_counters["analysis_reports"] = analysis_reports_counter
 
+        if not data_types_counter_error:
+            storage_counters["data_types"] = data_types_counter
+
         if not event_labels_counter_error:
             storage_counters["event_labels"] = event_labels_counter
 
@@ -292,6 +307,24 @@ class PinfoTool(tools.CLITool, tool_options.StorageFileOptions):
         compare_storage_counters = self._CalculateStorageCounters(
             compare_storage_reader
         )
+
+        # Compare number of events by data type.
+        data_types_counter = storage_counters.get("data_types", collections.Counter())
+        compare_data_types_counter = compare_storage_counters.get(
+            "data_types", collections.Counter()
+        )
+        differences = self._CompareCounter(
+            data_types_counter, compare_data_types_counter
+        )
+
+        if differences:
+            stores_are_identical = False
+
+            self._PrintCounterDifferences(
+                differences,
+                column_names=["Data type name", "Number of events"],
+                title="Events generated per data type",
+            )
 
         # Compare number of events.
         parsers_counter = storage_counters.get("parsers", collections.Counter())
@@ -796,6 +829,56 @@ class PinfoTool(tools.CLITool, tool_options.StorageFileOptions):
         table_view.Write(self._output_writer)
         self._output_writer.Write("\n")
 
+    def _PrintDataTypesCounter(self, data_types_counter, session_identifier=None):
+        """Prints the data types counter
+
+        Args:
+          data_types_counter (collections.Counter): number of events per data type.
+          session_identifier (Optional[str]): session identifier, formatted as
+              a UUID.
+        """
+        if self._output_format == "json":
+            if session_identifier:
+                self._output_writer.Write(", ")
+
+            json_string = json.dumps(data_types_counter)
+            self._output_writer.Write(f'"data_types": {json_string:s}')
+
+        elif self._output_format in ("markdown", "text"):
+            if self._output_format == "text" and not data_types_counter:
+                if not session_identifier:
+                    self._output_writer.Write("\nNo events stored.\n")
+
+            else:
+                title = "Events generated per data type"
+                if session_identifier:
+                    title = f"{title:s}: {session_identifier:s}"
+                    title_level = 4
+                else:
+                    title_level = 2
+
+                if not data_types_counter:
+                    if not session_identifier:
+                        heading_start = "#" * title_level
+                        self._output_writer.Write(
+                            f"{heading_start:s} {title:s}\n\nN/A\n\n"
+                        )
+                else:
+                    table_view = views.ViewsFactory.GetTableView(
+                        self._views_format_type,
+                        column_names=["Data type name", "Number of events"],
+                        title=title,
+                        title_level=title_level,
+                    )
+
+                    for key, value in sorted(data_types_counter.items()):
+                        if key != "total":
+                            table_view.AddRow([key, value])
+
+                    table_view.AddRow(["Total", data_types_counter["total"]])
+
+                    table_view.Write(self._output_writer)
+
     def _PrintEventLabelsCounter(self, event_labels_counter, session_identifier=None):
         """Prints the event labels counter.
 
@@ -1260,6 +1343,18 @@ class PinfoTool(tools.CLITool, tool_options.StorageFileOptions):
         section_written = False
 
         if self._sections == "all" or "events" in self._sections:
+            data_types = storage_counters.get("data_types", collections.Counter())
+
+            # FIXME: This should be mandatory but the test file must be re-generated.
+            if data_types:
+                self._PrintDataTypesCounter(data_types)
+                section_written = True
+
+                if self._output_format == "json" and section_written:
+                    self._output_writer.Write(", ")
+
+                section_written = False
+
             parsers = storage_counters.get("parsers", collections.Counter())
 
             self._PrintParsersCounter(parsers)

--- a/plaso/containers/counts.py
+++ b/plaso/containers/counts.py
@@ -4,6 +4,31 @@ from acstore.containers import interface
 from acstore.containers import manager
 
 
+class DataTypeCount(interface.AttributeContainer):
+    """Data type count attribute container.
+
+    Attributes:
+      name (str): name of the data type.
+      number_of_events (int): number of events generated with this data type.
+    """
+
+    CONTAINER_TYPE = "data_type_count"
+
+    SCHEMA = {"name": "str", "number_of_events": "int"}
+
+    def __init__(self, name=None, number_of_events=None):
+        """Initializes a data type count attribute container.
+
+        Args:
+          name (Optional[str]): name of the data type.
+          number_of_events (Optional[int]): number of events generated with this
+              data type.
+        """
+        super().__init__()
+        self.name = name
+        self.number_of_events = number_of_events
+
+
 class EventLabelCount(interface.AttributeContainer):
     """Event label count attribute container.
 
@@ -56,5 +81,5 @@ class ParserCount(interface.AttributeContainer):
 
 
 manager.AttributeContainersManager.RegisterAttributeContainers(
-    [EventLabelCount, ParserCount]
+    [DataTypeCount, EventLabelCount, ParserCount]
 )

--- a/plaso/engine/timeliner.py
+++ b/plaso/engine/timeliner.py
@@ -445,7 +445,7 @@ class EventDataTimeliner:
         ):
             return
 
-        data_type_name = getattr(event_data, 'data_type', None)
+        data_type_name = getattr(event_data, "data_type", None)
 
         parser_name = None
         parser_chain = getattr(event_data, "_parser_chain", None)

--- a/plaso/engine/timeliner.py
+++ b/plaso/engine/timeliner.py
@@ -20,6 +20,7 @@ class EventDataTimeliner:
     """The event data timeliner.
 
     Attributes:
+      data_types_counter (collections.Counter): number of events per data types.
       number_of_produced_events (int): number of produced events.
       parsers_counter (collections.Counter): number of events per parser or
           parser plugin.
@@ -54,6 +55,7 @@ class EventDataTimeliner:
         self._preferred_year = preferred_year
         self._time_zone_per_path_spec = None
 
+        self.data_types_counter = collections.Counter()
         self.number_of_produced_events = 0
         self.parsers_counter = collections.Counter()
 
@@ -443,6 +445,8 @@ class EventDataTimeliner:
         ):
             return
 
+        data_type_name = getattr(event_data, 'data_type', None)
+
         parser_name = None
         parser_chain = getattr(event_data, "_parser_chain", None)
         if parser_chain:
@@ -476,6 +480,10 @@ class EventDataTimeliner:
 
                 number_of_events += 1
 
+                if data_type_name:
+                    self.data_types_counter[data_type_name] += 1
+                self.data_types_counter["total"] += 1
+
                 if parser_name:
                     self.parsers_counter[parser_name] += 1
                 self.parsers_counter["total"] += 1
@@ -494,6 +502,10 @@ class EventDataTimeliner:
                 definitions.TIME_DESCRIPTION_NOT_A_TIME,
             )
             storage_writer.AddAttributeContainer(event)
+
+            if data_type_name:
+                self.data_types_counter[data_type_name] += 1
+            self.data_types_counter["total"] += 1
 
             if parser_name:
                 self.parsers_counter[parser_name] += 1

--- a/plaso/multi_process/extraction_engine.py
+++ b/plaso/multi_process/extraction_engine.py
@@ -171,6 +171,7 @@ class ExtractionMultiProcessEngine(task_engine.TaskMultiProcessEngine):
             worker_timeout = definitions.DEFAULT_WORKER_TIMEOUT
 
         super().__init__()
+        self._data_types_counter = collections.Counter()
         self._enable_sigsegv_handler = False
         self._event_data_timeliner = None
         self._extraction_worker = None
@@ -863,6 +864,14 @@ class ExtractionMultiProcessEngine(task_engine.TaskMultiProcessEngine):
         self._number_of_produced_events = 0
         self._number_of_produced_sources = 0
 
+        stored_data_types_counter = collections.Counter(
+            {
+                data_type_count.name: data_type_count
+                for data_type_count in storage_writer.GetAttributeContainers(
+                    "data_type_count"
+                )
+            }
+        )
         stored_parsers_counter = collections.Counter(
             {
                 parser_count.name: parser_count
@@ -881,6 +890,15 @@ class ExtractionMultiProcessEngine(task_engine.TaskMultiProcessEngine):
             self._status = definitions.STATUS_INDICATOR_ABORTED
         else:
             self._status = definitions.STATUS_INDICATOR_COMPLETED
+
+        for key, value in self._event_data_timeliner.data_types_counter.items():
+            data_type_count = stored_data_types_counter.get(key, None)
+            if data_type_count:
+                data_type_count.number_of_events += value
+                storage_writer.UpdateAttributeContainer(data_type_count)
+            else:
+                data_type_count = counts.DataTypeCount(name=key, number_of_events=value)
+                storage_writer.AddAttributeContainer(data_type_count)
 
         for key, value in self._event_data_timeliner.parsers_counter.items():
             parser_count = stored_parsers_counter.get(key)

--- a/plaso/single_process/extraction_engine.py
+++ b/plaso/single_process/extraction_engine.py
@@ -40,6 +40,7 @@ class SingleProcessEngine(engine.BaseEngine):
         """
         super().__init__()
         self._current_display_name = ""
+        self._data_types_counter = None
         self._event_data_timeliner = None
         self._extraction_worker = None
         self._file_system_cache = []
@@ -579,6 +580,14 @@ class SingleProcessEngine(engine.BaseEngine):
 
         self._StartStatusUpdateThread()
 
+        self._data_types_counter = collections.Counter(
+            {
+                data_type_count.name: data_type_count
+                for data_type_count in self._storage_writer.GetAttributeContainers(
+                    "data_type_count"
+                )
+            }
+        )
         self._parsers_counter = collections.Counter(
             {
                 parser_count.name: parser_count
@@ -587,7 +596,6 @@ class SingleProcessEngine(engine.BaseEngine):
                 )
             }
         )
-
         try:
             self._ProcessSource(parser_mediator, file_system_path_specs)
 
@@ -612,6 +620,16 @@ class SingleProcessEngine(engine.BaseEngine):
 
             self._StopProfiling()
             parser_mediator.StopProfiling()
+
+        for key, value in self._event_data_timeliner.data_types_counter.items():
+            data_type_count = self._data_types_counter.get(key, None)
+            if data_type_count:
+                data_type_count.number_of_events += value
+                self._storage_writer.UpdateAttributeContainer(data_type_count)
+            else:
+                data_type_count = counts.DataTypeCount(name=key, number_of_events=value)
+                self._data_types_counter[key] = data_type_count
+                self._storage_writer.AddAttributeContainer(data_type_count)
 
         for key, value in self._event_data_timeliner.parsers_counter.items():
             parser_count = self._parsers_counter.get(key)


### PR DESCRIPTION
## One line description of pull request

Add a new `data_type_count` attribute container for data types into the storage file.

## Description:

(Note that this MR is part of #5016)

Data type can be used as en Event Filter expression in `psort.py`. However, there is no way, without any _a posteriori_ knowledge, to know what actual values can be used in the expression. Adding data type counter into the storage file and printing them with pinfo will allow user to do it.

With the patch, the `text` output format, the output looks like:

```
$ ./plaso/scripts/pinfo.py 20251126T082737-apache_access.log.plaso --output_format text

************************** Plaso Storage Information ***************************
            Filename : 20251126T082737-apache_access.log.plaso
      Format version : 20230327
Serialization format : json
--------------------------------------------------------------------------------

*********************************** Sessions ***********************************
66268194-c93d-4f0d-9667-2c6caefe3d4a : 2025-11-26T07:27:37.930296+00:00
--------------------------------------------------------------------------------

******************************** Event sources *********************************
Total : 1
--------------------------------------------------------------------------------

************************ Events generated per data type ************************
         Data type name : Number of events
--------------------------------------------------------------------------------
apache:access_log:entry : 14
                fs:stat : 3
                  Total : 17
--------------------------------------------------------------------------------

************************* Events generated per parser **************************
Parser (plugin) name : Number of events
--------------------------------------------------------------------------------
       apache_access : 14
            filestat : 3
               Total : 17
--------------------------------------------------------------------------------

No events labels stored.

******************* Extraction warnings generated per parser *******************
Parser (plugin) name : Number of warnings
--------------------------------------------------------------------------------
  text/apache_access : 1
--------------------------------------------------------------------------------

************** Path specifications with most extraction warnings ***************
Number of warnings : Pathspec
--------------------------------------------------------------------------------
                 1 : type: OS, location:
                     /plaso/test_data/apache_access.log
--------------------------------------------------------------------------------

No analysis reports stored.
```

The `markdown` format:

```
# Plaso Storage Information

<table>
<tr><th nowrap style="text-align:left;vertical-align:top">Filename</th><td>20251126T082737-apache_access.log.plaso</td></tr>
<tr><th nowrap style="text-align:left;vertical-align:top">Format version</th><td>20230327</td></tr>
<tr><th nowrap style="text-align:left;vertical-align:top">Serialization format</th><td>json</td></tr>
</table>

## Sessions

<table>
<tr><th nowrap style="text-align:left;vertical-align:top">66268194-c93d-4f0d-9667-2c6caefe3d4a</th><td>2025-11-26T07:27:37.930296+00:00</td></tr>
</table>

## Event sources

<table>
<tr><th nowrap style="text-align:left;vertical-align:top">Total</th><td>1</td></tr>
</table>

## Events generated per data type

Data type name | Number of events
--- | ---
apache:access_log:entry | 14
fs:stat | 3
Total | 17

## Events generated per parser

Parser (plugin) name | Number of events
--- | ---
apache_access | 14
filestat | 3
Total | 17

## Event tags generated per label

N/A

### Extraction warnings generated per parser

Parser (plugin) name | Number of warnings
--- | ---
text/apache_access | 1

### Path specifications with most extraction warnings

Number of warnings | Pathspec
--- | ---
1 | type: OS, location: /plaso/test_data/apache_access.log
```

And the `json` (pretty-printed with `jq`):

```json
{
   ...
  "storage_counters": {
    "data_types": {
      "fs:stat": 3,
      "total": 17,
      "apache:access_log:entry": 14
    },
    "parsers": {
      "filestat": 3,
      "total": 17,
      "apache_access": 14
    },
    "event_labels": {},
    "warnings_by_parser": {
      "text/apache_access": 1
    },
    "warnings_by_path_spec": {
      "type: OS, location: /plaso/test_data/apache_access.log\n": 1
    },
    "analysis_reports": {}
  }
}
```

The MR has currently no test but I'm willing to work on it if you agree with the changes. Note that the **storage file format version must be updated** as the schema changed. Also, I would rather rewrite some part of this MR if #5014 get merged.

Thanks

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated.
* [x] Test data has a Plaso compatible license. If the test data was not authored by you (the contributor), make sure to mention its orginal source in ACKNOWLEDGEMENTS.
* [x] Reviewer assigned.
* [x] Automated checks (GitHub Actions, AppVeyor) pass.
