### PR TITLE
Added support for Firefox 118+ download end time

### DIFF
--- a/plaso/parsers/sqlite_plugins/firefox_downloads.py
+++ b/plaso/parsers/sqlite_plugins/firefox_downloads.py
@@ -195,15 +195,14 @@ class Firefox118DownloadsPlugin(interface.SQLitePlugin):
       'moz_annos': frozenset([
           'id', 'place_id', 'anno_attribute_id', 'content', 'flags',
           'expiration', 'type', 'dateAdded', 'lastModified']),
-      'moz_places': frozenset([
-          'id', 'title', 'url', 'last_visit_date'])}
+      'moz_places': frozenset(['id', 'title', 'url', 'last_visit_date'])}
 
   QUERIES = [
       (('SELECT annos1.content, annos2.flags, annos2.expiration, annos2.type, '
         'annos2.dateAdded, annos2.lastModified, annos2.content as dest_fpath, '
         'places.url, places.title, places.last_visit_date '
-        'from moz_annos annos1, moz_annos annos2, moz_places places '
-        'WHERE annos1.anno_attribute_id == annos2.anno_attribute_id+1 '
+        'FROM moz_annos annos1, moz_annos annos2, moz_places places '
+        'WHERE annos1.anno_attribute_id == (annos2.anno_attribute_id + 1) '
         'AND annos1.place_id == annos2.place_id '
         'AND annos1.place_id == places.id'),
        'ParseDownloadsRow')]
@@ -260,16 +259,24 @@ class Firefox118DownloadsPlugin(interface.SQLitePlugin):
 
     content = self._GetRowValue(query_hash, row, 'content')
     content_data = json.loads(content)
+    # Content consists of a JSON object similar to:
+    # {
+    #   'state': 1,
+    #   'deleted': False,
+    #   'endTime': 1689722333589,
+    #   'fileSize': 66383750
+    # }
 
     event_data = Firefox118DownloadEventData()
 
     event_data.deleted = content_data.get('deleted', None)
     event_data.download_state = content_data.get('state', None)
+
     end_time = content_data.get('endTime', None)
     if end_time is not None:
       event_data.end_time = dfdatetime_posix_time.PosixTimeInMilliseconds(
-          timestamp=end_time
-      )
+          timestamp=end_time)
+
     event_data.expiration = self._GetRowValue(query_hash, row, 'expiration')
     event_data.flags = self._GetRowValue(query_hash, row, 'flags')
     event_data.full_path = self._GetRowValue(query_hash, row, 'dest_fpath')

--- a/tests/parsers/sqlite_plugins/firefox_downloads.py
+++ b/tests/parsers/sqlite_plugins/firefox_downloads.py
@@ -65,21 +65,19 @@ class FirefoxDownloadsPluginTest(test_lib.SQLitePluginTestCase):
     expected_event_values = {
         'data_type': 'firefox:downloads:download',
         'download_state': 1,
+        'end_time': '2023-07-18T23:20:29.974+00:00',
         'full_path': (
-            'file:///C:/Users/factdevteam/'
-            'Downloads/VSCodeUserSetup-x64-1.80.1.exe'
-        ),
+            'file:///C:/Users/factdevteam/Downloads/'
+            'VSCodeUserSetup-x64-1.80.1.exe'),
         'name': 'VSCodeUserSetup-x64-1.80.1.exe',
         'received_bytes': 93176792,
         'start_time': '2023-07-18T23:20:28.452000+00:00',
-        'end_time': '2023-07-18T23:20:29.974+00:00',
         'total_bytes': 93176792,
         'type': 3,
         'url': (
-            'https://az764295.vo.msecnd.net/stable/74f6148eb9ea00507ec'
-            '113ec51c489d6ffb4b771/VSCodeUserSetup-x64-1.80.1.exe'
-        ),
-    }
+            'https://az764295.vo.msecnd.net/stable/'
+            '74f6148eb9ea00507ec113ec51c489d6ffb4b771/'
+            'VSCodeUserSetup-x64-1.80.1.exe')}
 
     event_data = storage_writer.GetAttributeContainerByIndex('event_data', 2)
     self.CheckEventData(event_data, expected_event_values)


### PR DESCRIPTION
## One line description of pull request

The Firefox 118+ downloads parser set `end_time` to the wrong data type, preventing timelining from working correctly with it. This fixes it.

## Description:

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated.
* [x] Test data has a Plaso compatible license. If the test data was not authored by you (the contributor), make sure to mention its orginal source in ACKNOWLEDGEMENTS.
* [x] Reviewer assigned.
* [ ] Automated checks (GitHub Actions, AppVeyor) pass.
