### PR TITLE
Changes to include name in AMCacheFileEventData

### DIFF
--- a/plaso/parsers/winreg_plugins/amcache.py
+++ b/plaso/parsers/winreg_plugins/amcache.py
@@ -28,6 +28,7 @@ class AMCacheFileEventData(events.EventData):
         (31457280 bytes) of file, preceded by "0000").
     file_modification_time (dfdatetime.DateTimeValues): file entry last
         modification date and time.
+    file_name (str): name of the file.
     file_reference (str): file system file reference, for example 9-1 (MFT
         entry - sequence number).
     file_size (int): size of file in bytes.
@@ -58,6 +59,7 @@ class AMCacheFileEventData(events.EventData):
     self.file_identifier = None
     self.file_modification_time = None
     self.file_reference = None
+    self.file_name = None
     self.file_size = None
     self.file_version = None
     self.full_path = None
@@ -123,6 +125,7 @@ class AMCachePlugin(interface.WindowsRegistryPlugin):
   _APPLICATION_SUB_KEY_VALUES = {
       'FileId': 'file_identifier',
       'LowerCaseLongPath': 'full_path',
+      'Name': 'file_name',
       'ProductName': 'product_name',
       'ProductVersion': 'file_version',
       'ProgramId': 'program_identifier',

--- a/tests/parsers/winreg_plugins/amcache.py
+++ b/tests/parsers/winreg_plugins/amcache.py
@@ -120,6 +120,7 @@ class AMCachePluginTest(test_lib.RegistryPluginTestCase):
         'file_creation_time': None,
         'file_identifier': '000075c5a97f521f760e32a4a9639a653eed862e9c61',
         'file_modification_time': None,
+        'file_name': 'svchost.exe',
         'full_path': 'c:\\windows\\system32\\svchost.exe',
         'installation_time': None,
         'last_written_time': None,


### PR DESCRIPTION
## One line description of pull request

This adds the `Name` field of `Root\InventoryApplicationFile\%NAME%|%IDENTIFIER%` AmCache entries to produced events.

## Description:


## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms to the
[Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated.
* [x] Test data has a Plaso compatible license. If the test data was not authored by you (the contributor), make sure to mention its orginal source in ACKNOWLEDGEMENTS.
* [x] Reviewer assigned.
* [x] Automated checks (GitHub Actions, AppVeyor) pass.
