### PR TITLE
remove dependency on old standalone "mock"

### DIFF
--- a/config/linux/gift_copr_install.sh
+++ b/config/linux/gift_copr_install.sh
@@ -76,7 +76,6 @@ PYTHON3_DEPENDENCIES="libbde-python3
 
 # Additional dependencies for running tests, alphabetized, one per line.
 TEST_DEPENDENCIES="python3-fakeredis
-                   python3-mock
                    python3-setuptools";
 
 # Additional dependencies for development, alphabetized, one per line.

--- a/config/linux/ubuntu_install_plaso.sh
+++ b/config/linux/ubuntu_install_plaso.sh
@@ -83,7 +83,6 @@ PYTHON_DEPENDENCIES="libbde-python3
 
 # Additional dependencies for running tests, alphabetized, one per line.
 TEST_DEPENDENCIES="python3-fakeredis
-                   python3-mock
                    python3-setuptools";
 
 # Additional dependencies for development, alphabetized, one per line.

--- a/docs/sources/developer/Developers-Guide.md
+++ b/docs/sources/developer/Developers-Guide.md
@@ -78,7 +78,7 @@ If your code requires adding a new dependency please check out these instruction
 1. Join the development mailing list: [log2timeline-dev@googlegroups.com](https://groups.google.com/forum/#%21forum/log2timeline-dev)
 and [Slack channel](https://github.com/open-source-dfir/slack), we recommend
 using the same account as step 1
-1. Install the required development tools like pylint and python-mock
+1. Install the required development tools like pylint
 1. Make sure to run all the tests in the Plaso codebase, and that they
 successfully complete in your development environment
 1. Make sure your development environment is set up correctly so that you can develop

--- a/docs/sources/developer/Developing-Fedora.md
+++ b/docs/sources/developer/Developing-Fedora.md
@@ -31,4 +31,3 @@ If you intend to do development on Plaso you'll also need to install some
 development tools:
 
 * PyLint 1.9.x
-* Python Mock

--- a/docs/sources/developer/Developing-MacOS.md
+++ b/docs/sources/developer/Developing-MacOS.md
@@ -40,4 +40,3 @@ dependencies regularly.**
 If you intend to do development on plaso you'll also need to install some development tools:
 
 * PyLint 1.9.x
-* Python Mock

--- a/docs/sources/developer/Developing-Ubuntu.md
+++ b/docs/sources/developer/Developing-Ubuntu.md
@@ -53,13 +53,6 @@ If you intend to do development on Plaso you'll also need to install some
 development tools:
 
 * PyLint
-* Python Mock
 
 ### PyLint
 Currently plaso development uses PyLint version 2.6.x.
-
-### Python Mock
-To install Python Mock run:
-```bash
-sudo apt-get install python-mock
-```

--- a/docs/sources/developer/Developing-Windows.md
+++ b/docs/sources/developer/Developing-Windows.md
@@ -58,5 +58,4 @@ C:\Python3\python.exe C:\plaso-build\plaso\plaso\frontend\pinfo.py timeline.plas
 If you intend to do development on Plaso you'll also need to install the
 following development tools:
 
-* mock
 * pylint

--- a/test_dependencies.ini
+++ b/test_dependencies.ini
@@ -5,9 +5,3 @@ maximum_version: 2.21.3
 is_optional: true
 rpm_name: python3-fakeredis
 version_property: __version__
-
-[mock]
-dpkg_name: python3-mock
-minimum_version: 2.0.0
-rpm_name: python3-mock
-version_property: __version__

--- a/tests/cli/status_view.py
+++ b/tests/cli/status_view.py
@@ -4,8 +4,7 @@
 
 import sys
 import unittest
-
-import mock
+from unittest import mock
 
 from dfvfs.lib import definitions as dfvfs_definitions
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ setenv =
   PYTHONPATH = {toxinidir}
 deps =
   fakeredis >= 1.4.1,< 2.21.3
-  mock >= 2.0.0
   coverage: coverage
   wheel:
     build
@@ -44,7 +43,6 @@ setenv =
   PYTHONPATH = {toxinidir}
 deps =
   fakeredis >= 1.4.1,< 2.21.3
-  mock >= 2.0.0
   pylint >= 3.3.0, < 3.4.0
   setuptools >= 65
   yamllint >= 1.26.0


### PR DESCRIPTION
this codebase already uses the newer "unittest.mock" from the standard library everywhere else

* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required 

--> it's actually the reverse here