### PR TITLE
Changes to systemd journal parser to handle corrupt and binary data

### DIFF
--- a/plaso/parsers/systemd_journal.py
+++ b/plaso/parsers/systemd_journal.py
@@ -286,30 +286,8 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
 
         return entry_object_offsets
 
-    def _DecodeFieldData(self, parser_mediator, byte_data):
-        """Decodes journal field data as UTF-8.
-
-        Produces an extraction warning when the data contains invalid UTF-8,
-        which is replaced rather than raising.
-
-        Args:
-          parser_mediator (ParserMediator): parser mediator.
-          byte_data (bytes): journal field data to decode.
-
-        Returns:
-          str: data decoded as UTF-8, with invalid bytes replaced.
-        """
-        try:
-            return byte_data.decode("utf-8")
-        except UnicodeDecodeError:
-            parser_mediator.ProduceExtractionWarning(
-                "Unable to decode journal field data as UTF-8, replaced invalid "
-                "characters"
-            )
-            return byte_data.decode("utf-8", errors="replace")
-
-    def _SplitFieldData(self, parser_mediator, field_data):
-        """Splits journal field data into a key and value.
+    def _ParseKeyValuePair(self, parser_mediator, field_data):
+        """Parses a key value pair.
 
         Args:
           parser_mediator (ParserMediator): parser mediator.
@@ -320,11 +298,27 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
           tuple[str, str]: key and value decoded as UTF-8, with invalid bytes
               replaced rather than raising.
         """
-        key, _, value = field_data.partition(b"=")
-        return (
-            self._DecodeFieldData(parser_mediator, key),
-            self._DecodeFieldData(parser_mediator, value),
-        )
+        key_data, _, value_data = field_data.partition(b"=")
+
+        try:
+            key = key_data.decode("utf-8")
+        except UnicodeDecodeError:
+            parser_mediator.ProduceExtractionWarning(
+                "Unable to decode journal field key as UTF-8. Unsupported code points "
+                "are escaped."
+            )
+            key = key_data.decode("utf-8", errors="backslashreplace")
+
+        try:
+            value = value_data.decode("utf-8")
+        except UnicodeDecodeError:
+            parser_mediator.ProduceExtractionWarning(
+                f"Unable to decode journal field with key: {key:s} value as UTF-8. "
+                f"Unsupported code points are escaped."
+            )
+            value = value_data.decode("utf-8", errors="backslashreplace")
+
+        return key, value
 
     def _ParseJournalEntry(self, parser_mediator, file_object, file_offset):
         """Parses a journal entry.
@@ -363,8 +357,8 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
                 )
             except (ValueError, errors.ParseError) as exception:
                 raise errors.ParseError(
-                    f"Unable to parse entry item at offset: 0x{file_offset:08x} "
-                    f"with error: {exception!s}"
+                    f"Unable to parse entry item at offset: 0x{file_offset:08x} with "
+                    f"error: {exception!s}"
                 )
 
             file_offset += entry_item_data_size
@@ -377,7 +371,7 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
                 )
 
             field_data = self._ParseDataObject(file_object, entry_item.object_offset)
-            key, value = self._SplitFieldData(parser_mediator, field_data)
+            key, value = self._ParseKeyValuePair(parser_mediator, field_data)
             fields[key] = value
 
         return fields

--- a/plaso/parsers/systemd_journal.py
+++ b/plaso/parsers/systemd_journal.py
@@ -286,11 +286,33 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
 
         return entry_object_offsets
 
-    @staticmethod
-    def _SplitFieldData(field_data):
+    def _DecodeFieldData(self, parser_mediator, byte_data):
+        """Decodes journal field data as UTF-8.
+
+        Produces an extraction warning when the data contains invalid UTF-8,
+        which is replaced rather than raising.
+
+        Args:
+          parser_mediator (ParserMediator): parser mediator.
+          byte_data (bytes): journal field data to decode.
+
+        Returns:
+          str: data decoded as UTF-8, with invalid bytes replaced.
+        """
+        try:
+            return byte_data.decode("utf-8")
+        except UnicodeDecodeError:
+            parser_mediator.ProduceExtractionWarning(
+                "Unable to decode journal field data as UTF-8, replaced invalid "
+                "characters"
+            )
+            return byte_data.decode("utf-8", errors="replace")
+
+    def _SplitFieldData(self, parser_mediator, field_data):
         """Splits journal field data into a key and value.
 
         Args:
+          parser_mediator (ParserMediator): parser mediator.
           field_data (bytes): journal field data, which is "key=value" where the
               value can contain arbitrary binary (non-UTF-8) data.
 
@@ -300,16 +322,17 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
         """
         key, _, value = field_data.partition(b"=")
         return (
-            key.decode("utf-8", errors="replace"),
-            value.decode("utf-8", errors="replace"),
+            self._DecodeFieldData(parser_mediator, key),
+            self._DecodeFieldData(parser_mediator, value),
         )
 
-    def _ParseJournalEntry(self, file_object, file_offset):
+    def _ParseJournalEntry(self, parser_mediator, file_object, file_offset):
         """Parses a journal entry.
 
         This method will generate an event per ENTRY object.
 
         Args:
+          parser_mediator (ParserMediator): parser mediator.
           file_object (dfvfs.FileIO): a file-like object.
           file_offset (int): offset of the entry object relative to the start
               of the file-like object.
@@ -354,7 +377,7 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
                 )
 
             field_data = self._ParseDataObject(file_object, entry_item.object_offset)
-            key, value = self._SplitFieldData(field_data)
+            key, value = self._SplitFieldData(parser_mediator, field_data)
             fields[key] = value
 
         return fields
@@ -416,7 +439,9 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
                 continue
 
             try:
-                fields = self._ParseJournalEntry(file_object, entry_object_offset)
+                fields = self._ParseJournalEntry(
+                    parser_mediator, file_object, entry_object_offset
+                )
             except errors.ParseError as exception:
                 parser_mediator.ProduceExtractionWarning(
                     f"Unable to parse journal entry at offset: "

--- a/plaso/parsers/systemd_journal.py
+++ b/plaso/parsers/systemd_journal.py
@@ -141,7 +141,7 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
         if data_object.object_flags & self._OBJECT_COMPRESSED_FLAG_XZ:
             try:
                 data = lzma.decompress(data)
-            except (lzma.LZMAError, EOFError) as exception:
+            except (EOFError, lzma.LZMAError) as exception:
                 raise errors.ParseError(
                     f"Unable to decompress XZ at offset: 0x{data_offset:08x} with "
                     f"error: {exception!s}"
@@ -164,7 +164,7 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
                 data = lz4_block.decompress(
                     data[8:], uncompressed_size=uncompressed_size
                 )
-            except (lz4_block.LZ4BlockError, ValueError) as exception:
+            except (ValueError, lz4_block.LZ4BlockError) as exception:
                 raise errors.ParseError(
                     f"Unable to decompress LZ4 at offset: 0x{data_offset:08x} with "
                     f"error: {exception!s}"

--- a/plaso/parsers/systemd_journal.py
+++ b/plaso/parsers/systemd_journal.py
@@ -139,7 +139,13 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
         data = file_object.read(data_size)
 
         if data_object.object_flags & self._OBJECT_COMPRESSED_FLAG_XZ:
-            data = lzma.decompress(data)
+            try:
+                data = lzma.decompress(data)
+            except (lzma.LZMAError, EOFError) as exception:
+                raise errors.ParseError(
+                    f"Unable to decompress XZ at offset: 0x{data_offset:08x} with "
+                    f"error: {exception!s}"
+                )
 
         elif data_object.object_flags & self._OBJECT_COMPRESSED_FLAG_LZ4:
             uncompressed_size_map = self._GetDataTypeMap("uint32le")
@@ -154,7 +160,15 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
                     f"0x{data_offset:08x} with error: {exception!s}"
                 )
 
-            data = lz4_block.decompress(data[8:], uncompressed_size=uncompressed_size)
+            try:
+                data = lz4_block.decompress(
+                    data[8:], uncompressed_size=uncompressed_size
+                )
+            except (lz4_block.LZ4BlockError, ValueError) as exception:
+                raise errors.ParseError(
+                    f"Unable to decompress LZ4 at offset: 0x{data_offset:08x} with "
+                    f"error: {exception!s}"
+                )
 
         elif data_object.object_flags & self._OBJECT_COMPRESSED_FLAG_ZSTD:
             try:
@@ -272,6 +286,24 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
 
         return entry_object_offsets
 
+    @staticmethod
+    def _SplitFieldData(field_data):
+        """Splits journal field data into a key and value.
+
+        Args:
+          field_data (bytes): journal field data, which is "key=value" where the
+              value can contain arbitrary binary (non-UTF-8) data.
+
+        Returns:
+          tuple[str, str]: key and value decoded as UTF-8, with invalid bytes
+              replaced rather than raising.
+        """
+        key, _, value = field_data.partition(b"=")
+        return (
+            key.decode("utf-8", errors="replace"),
+            value.decode("utf-8", errors="replace"),
+        )
+
     def _ParseJournalEntry(self, file_object, file_offset):
         """Parses a journal entry.
 
@@ -321,9 +353,8 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
                     f"{self._maximum_journal_file_offset:d})"
                 )
 
-            event_data = self._ParseDataObject(file_object, entry_item.object_offset)
-            event_string = event_data.decode("utf-8")
-            key, value = event_string.split("=", 1)
+            field_data = self._ParseDataObject(file_object, entry_item.object_offset)
+            key, value = self._SplitFieldData(field_data)
             fields[key] = value
 
         return fields
@@ -391,7 +422,7 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
                     f"Unable to parse journal entry at offset: "
                     f"0x{entry_object_offset:08x} with error: {exception!s}"
                 )
-                return
+                continue
 
             date_time = dfdatetime_posix_time.PosixTimeInMicroseconds(
                 timestamp=fields["real_time"]

--- a/tests/parsers/systemd_journal.py
+++ b/tests/parsers/systemd_journal.py
@@ -58,8 +58,8 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
         )
         self.assertEqual(number_of_warnings, 0)
 
-        # A value with non-UTF-8 code points must decode with replacement characters
-        # and produce an extraction warning rather than silently replacing them.
+        # A key value pair containing invalid UTF-8 code points must decode with them
+        # escaped and produce an extraction warning.
         key, value = parser._ParseKeyValuePair(
             parser_mediator, b"MESSAGE=abc\xff\xfexyz"
         )
@@ -77,7 +77,6 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
         storage_writer = self._ParseFile(
             ["systemd", "journal", "system.journal"], parser
         )
-
         number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
             "event_data"
         )
@@ -101,7 +100,6 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
             "reporter": "systemd",
             "written_time": "2017-01-27T09:40:55.913258+00:00",
         }
-
         event_data = storage_writer.GetAttributeContainerByIndex("event_data", 0)
         self.CheckEventData(event_data, expected_event_values)
 
@@ -114,7 +112,6 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
             "reporter": "root",
             "written_time": "2017-02-06T16:24:32.564585+00:00",
         }
-
         event_data = storage_writer.GetAttributeContainerByIndex("event_data", 2098)
         self.CheckEventData(event_data, expected_event_values)
 
@@ -124,7 +121,6 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
         storage_writer = self._ParseFile(
             ["systemd", "journal", "system.journal.lz4"], parser
         )
-
         number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
             "event_data"
         )
@@ -148,14 +144,13 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
             "reporter": "systemd",
             "written_time": "2018-07-03T15:00:16.682340+00:00",
         }
-
         event_data = storage_writer.GetAttributeContainerByIndex("event_data", 0)
         self.CheckEventData(event_data, expected_event_values)
 
         # Test a LZ4 compressed data log entry.
-        # The text used in the test message was triplicated to make it long enough
-        # to trigger the LZ4 compression.
-        # Source: https://github.com/systemd/systemd/issues/6237
+        # The text used in the test message was trippled to make it long enough to
+        # trigger the LZ4 compression. Also see:
+        # https://github.com/systemd/systemd/issues/6237
         expected_body_parts = [" textual user names."]
         expected_body_parts.extend(
             (
@@ -176,7 +171,6 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
             "reporter": "test",
             "written_time": "2018-07-03T15:19:04.667807+00:00",
         }
-
         event_data = storage_writer.GetAttributeContainerByIndex("event_data", 84)
         self.CheckEventData(event_data, expected_event_values)
 
@@ -186,7 +180,6 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
         storage_writer = self._ParseFile(
             ["systemd", "journal", "user-1000.journal"], parser
         )
-
         number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
             "event_data"
         )
@@ -212,7 +205,6 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
             "reporter": "testapp",
             "written_time": "2023-09-26T07:42:46.445209+00:00",
         }
-
         event_data = storage_writer.GetAttributeContainerByIndex("event_data", 0)
         self.CheckEventData(event_data, expected_event_values)
 
@@ -228,15 +220,11 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
             ],
             parser,
         )
-
         number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
             "event_data"
         )
         self.assertEqual(number_of_event_data, 2211)
 
-        # The parser skips each corrupt entry and continues instead of aborting
-        # at the first one, so every corrupt entry in the unclean tail is
-        # reported rather than only the first.
         number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
             "extraction_warning"
         )
@@ -257,14 +245,12 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
             "reporter": "systemd-journald",
             "written_time": "2016-10-24T13:20:01.063423+00:00",
         }
-
         event_data = storage_writer.GetAttributeContainerByIndex("event_data", 0)
         self.CheckEventData(event_data, expected_event_values)
 
         generator = storage_writer.GetAttributeContainers(
             warnings.ExtractionWarning.CONTAINER_TYPE
         )
-
         test_warnings = list(generator)
         test_warning = test_warnings[0]
         self.assertIsNotNone(test_warning)
@@ -275,9 +261,8 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
         )
         self.assertEqual(test_warning.message, expected_message)
 
-        # The 46 warnings are 1 corrupt entry pointer plus 45 unused/zeroed
-        # objects in the unclean tail; check the breakdown and the last warning
-        # so the count is documented rather than an opaque magic number.
+        # The 46 warnings are 1 corrupt entry pointer plus 45 unused/zeroed objects in
+        # the unclean tail.
         unsupported_warnings = [
             warning
             for warning in test_warnings

--- a/tests/parsers/systemd_journal.py
+++ b/tests/parsers/systemd_journal.py
@@ -16,32 +16,6 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
 
     # pylint: disable=protected-access
 
-    def testSplitFieldData(self):
-        """Tests the _SplitFieldData function with text and binary values."""
-        parser = systemd_journal.SystemdJournalParser()
-        storage_writer = self._CreateStorageWriter()
-        parser_mediator = self._CreateParserMediator(storage_writer)
-
-        key, value = parser._SplitFieldData(parser_mediator, b"MESSAGE=hello world")
-        self.assertEqual(key, "MESSAGE")
-        self.assertEqual(value, "hello world")
-
-        number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
-            "extraction_warning"
-        )
-        self.assertEqual(number_of_warnings, 0)
-
-        # A value with non-UTF-8 bytes must decode with replacement characters
-        # and produce an extraction warning rather than silently replacing them.
-        key, value = parser._SplitFieldData(parser_mediator, b"MESSAGE=abc\xff\xfexyz")
-        self.assertEqual(key, "MESSAGE")
-        self.assertEqual(value, "abc" + chr(0xFFFD) * 2 + "xyz")
-
-        number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
-            "extraction_warning"
-        )
-        self.assertEqual(number_of_warnings, 1)
-
     def testParseDataObjectWithCorruptCompressedData(self):
         """Tests _ParseDataObject raises ParseError on corrupt compressed data."""
         parser = systemd_journal.SystemdJournalParser()
@@ -68,6 +42,34 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
         )
         with self.assertRaises(errors.ParseError):
             parser._ParseDataObject(file_object, 0)
+
+    def testParseKeyValuePair(self):
+        """Tests the _ParseKeyValuePair function with text and binary values."""
+        parser = systemd_journal.SystemdJournalParser()
+        storage_writer = self._CreateStorageWriter()
+        parser_mediator = self._CreateParserMediator(storage_writer)
+
+        key, value = parser._ParseKeyValuePair(parser_mediator, b"MESSAGE=hello world")
+        self.assertEqual(key, "MESSAGE")
+        self.assertEqual(value, "hello world")
+
+        number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+            "extraction_warning"
+        )
+        self.assertEqual(number_of_warnings, 0)
+
+        # A value with non-UTF-8 code points must decode with replacement characters
+        # and produce an extraction warning rather than silently replacing them.
+        key, value = parser._ParseKeyValuePair(
+            parser_mediator, b"MESSAGE=abc\xff\xfexyz"
+        )
+        self.assertEqual(key, "MESSAGE")
+        self.assertEqual(value, "abc\\xff\\xfexyz")
+
+        number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+            "extraction_warning"
+        )
+        self.assertEqual(number_of_warnings, 1)
 
     def testParse(self):
         """Tests the Parse function."""

--- a/tests/parsers/systemd_journal.py
+++ b/tests/parsers/systemd_journal.py
@@ -19,16 +19,28 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
     def testSplitFieldData(self):
         """Tests the _SplitFieldData function with text and binary values."""
         parser = systemd_journal.SystemdJournalParser()
+        storage_writer = self._CreateStorageWriter()
+        parser_mediator = self._CreateParserMediator(storage_writer)
 
-        key, value = parser._SplitFieldData(b"MESSAGE=hello world")
+        key, value = parser._SplitFieldData(parser_mediator, b"MESSAGE=hello world")
         self.assertEqual(key, "MESSAGE")
         self.assertEqual(value, "hello world")
 
+        number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+            "extraction_warning"
+        )
+        self.assertEqual(number_of_warnings, 0)
+
         # A value with non-UTF-8 bytes must decode with replacement characters
-        # rather than raising a UnicodeDecodeError.
-        key, value = parser._SplitFieldData(b"MESSAGE=abc\xff\xfexyz")
+        # and produce an extraction warning rather than silently replacing them.
+        key, value = parser._SplitFieldData(parser_mediator, b"MESSAGE=abc\xff\xfexyz")
         self.assertEqual(key, "MESSAGE")
         self.assertEqual(value, "abc" + chr(0xFFFD) * 2 + "xyz")
+
+        number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+            "extraction_warning"
+        )
+        self.assertEqual(number_of_warnings, 1)
 
     def testParseDataObjectWithCorruptCompressedData(self):
         """Tests _ParseDataObject raises ParseError on corrupt compressed data."""

--- a/tests/parsers/systemd_journal.py
+++ b/tests/parsers/systemd_journal.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Tests for the Systemd Journal parser."""
 
+import io
 import unittest
 
 from plaso.containers import warnings
+from plaso.lib import errors
 from plaso.parsers import systemd_journal
 
 from tests.parsers import test_lib
@@ -11,6 +13,49 @@ from tests.parsers import test_lib
 
 class SystemdJournalParserTest(test_lib.ParserTestCase):
     """Tests for the Systemd Journal parser."""
+
+    # pylint: disable=protected-access
+
+    def testSplitFieldData(self):
+        """Tests the _SplitFieldData function with text and binary values."""
+        parser = systemd_journal.SystemdJournalParser()
+
+        key, value = parser._SplitFieldData(b"MESSAGE=hello world")
+        self.assertEqual(key, "MESSAGE")
+        self.assertEqual(value, "hello world")
+
+        # A value with non-UTF-8 bytes must decode with replacement characters
+        # rather than raising a UnicodeDecodeError.
+        key, value = parser._SplitFieldData(b"MESSAGE=abc\xff\xfexyz")
+        self.assertEqual(key, "MESSAGE")
+        self.assertEqual(value, "abc" + chr(0xFFFD) * 2 + "xyz")
+
+    def testParseDataObjectWithCorruptCompressedData(self):
+        """Tests _ParseDataObject raises ParseError on corrupt compressed data."""
+        parser = systemd_journal.SystemdJournalParser()
+
+        def _data_object(flags, payload):
+            # A 64-byte DATA object header (object_type=1, object_flags=flags,
+            # 6 reserved bytes, data_size, then 6 unused uint64 fields) followed
+            # by a corrupt compressed payload.
+            header = (
+                bytes([1, flags])
+                + b"\x00" * 6
+                + (64 + len(payload)).to_bytes(8, "little")
+                + b"\x00" * 48
+            )
+            return io.BytesIO(header + payload)
+
+        file_object = _data_object(parser._OBJECT_COMPRESSED_FLAG_XZ, b"corrupt-xz")
+        with self.assertRaises(errors.ParseError):
+            parser._ParseDataObject(file_object, 0)
+
+        file_object = _data_object(
+            parser._OBJECT_COMPRESSED_FLAG_LZ4,
+            b"\x10\x00\x00\x00\x00\x00\x00\x00corrupt-lz4",
+        )
+        with self.assertRaises(errors.ParseError):
+            parser._ParseDataObject(file_object, 0)
 
     def testParse(self):
         """Tests the Parse function."""
@@ -175,10 +220,13 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
         )
         self.assertEqual(number_of_event_data, 2211)
 
+        # The parser skips each corrupt entry and continues instead of aborting
+        # at the first one, so every corrupt entry in the unclean tail is
+        # reported rather than only the first.
         number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
             "extraction_warning"
         )
-        self.assertEqual(number_of_warnings, 1)
+        self.assertEqual(number_of_warnings, 46)
 
         number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
             "recovery_warning"
@@ -212,6 +260,22 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
             "object offset should be after hash tables (0 < 2527472)"
         )
         self.assertEqual(test_warning.message, expected_message)
+
+        # The 46 warnings are 1 corrupt entry pointer plus 45 unused/zeroed
+        # objects in the unclean tail; check the breakdown and the last warning
+        # so the count is documented rather than an opaque magic number.
+        unsupported_warnings = [
+            warning
+            for warning in test_warnings
+            if "Unsupported object type: 0" in warning.message
+        ]
+        self.assertEqual(len(unsupported_warnings), 45)
+
+        expected_message = (
+            "Unable to parse journal entry at offset: 0x004287a0 with error: "
+            "Unsupported object type: 0"
+        )
+        self.assertEqual(test_warnings[-1].message, expected_message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Makes the systemd journal parser resilient to the damaged, rotated and unclean journals that matter most in forensics. Three related robustness fixes:

- **Continue past a corrupt entry instead of returning.** The entry loop in `ParseFileObject` did `return` on the first `ParseError`, abandoning every entry after the first unparsable one. It now does `continue`, matching systemd's reader guidance to skip corruption and recover as much surrounding data as possible.
- **Decode field data at the byte level.** `_ParseJournalEntry` did `event_data.decode("utf-8")` with no error handling; a non-UTF-8 field value (the on-disk format permits binary DATA payloads) raised an uncaught `UnicodeDecodeError` — a `ValueError`, so the surrounding `except errors.ParseError` never caught it. The split-and-decode is extracted into `_SplitFieldData`, which splits on the first `=` byte and decodes with `errors="replace"` (event-data values must be `str`).
- **Wrap XZ and LZ4 decompression** in try/except → `ParseError`, as ZSTD already was, so corrupt compressed data raises a `ParseError` instead of an uncaught library exception.

**Related issue:** fixes #5109

## Testing

- `testParseDirty` updated: the parser now reports all 46 corrupt entries in the unclean tail (1 corrupt entry pointer + 45 unused objects) instead of only the first; the event count (2211) and the first-warning message are unchanged. The 46 = 1 + 45 breakdown is asserted so the count is documented rather than magic.
- Added `testSplitFieldData` covering a text value and a non-UTF-8 value (→ U+FFFD replacement).
- Validated end-to-end against `journalctl`: a journal written by `systemd-journal-remote` with a `MESSAGE` containing non-UTF-8 bytes parses to a body with U+FFFD, matching `journalctl --output=json`'s byte-array rendering.
- Existing clean-journal tests (`testParse`, `testParseLZ4`, `testParseCompactZSTD`) unchanged and passing; Black + pylint clean.

## Open question for the reviewer

On the dirty-journal sample the extraction-warning count rises 1 → 46 because every corrupt tail entry is now surfaced rather than only the first. If that's too noisy, I'm happy to collapse a run of trailing `Unsupported object type: 0` entries into a single "reached corrupt tail" warning — let me know your preference.

## Checklist
- [x] No new dependencies are required or l2tdevtools has been updated.
- [x] Test data has a Plaso compatible license. (No new test data added.)
- [x] Reviewer assigned.
- [x] Automated checks (GitHub Actions, AppVeyor) pass.
