### PR TITLE
Changes to handle equal sign and blank lines in Linux release preprocessors

### DIFF
--- a/plaso/preprocessors/linux.py
+++ b/plaso/preprocessors/linux.py
@@ -121,9 +121,9 @@ class LinuxStandardBaseReleasePlugin(interface.FileArtifactPreprocessorPlugin):
         product_values = {}
         for line in text_file_object.readlines():
             line = line.strip()
-            if line.startswith("#"):
+            if line.startswith("#") or "=" not in line:
                 continue
-            key, value = line.split("=")
+            key, _, value = line.partition("=")
             key = key.strip().upper()
             value = value.strip().strip('"')
             product_values[key] = value
@@ -160,7 +160,7 @@ class LinuxSystemdOperatingSystemPlugin(interface.FileArtifactPreprocessorPlugin
             if "=" not in line:
                 continue
 
-            key, value = line.split("=")
+            key, _, value = line.partition("=")
             key = key.upper()
             value = value.strip('"')
             product_values[key] = value

--- a/tests/preprocessors/linux.py
+++ b/tests/preprocessors/linux.py
@@ -80,10 +80,14 @@ class LinuxStandardBaseReleasePluginTest(test_lib.ArtifactPreprocessorPluginTest
     """Tests for the Linux standard base (LSB) release plugin."""
 
     _FILE_DATA = b"""\
+# Distribution release information.
 DISTRIB_CODENAME=trusty
 DISTRIB_DESCRIPTION="Ubuntu 14.04 LTS"
 DISTRIB_ID=Ubuntu
-DISTRIB_RELEASE=14.04"""
+DISTRIB_RELEASE=14.04
+
+DISTRIB_NOTE=key=value=pair
+"""
 
     def testParseFileData(self):
         """Tests the _ParseFileData function."""
@@ -123,6 +127,9 @@ class LinuxSystemdOperatingSystemPluginTest(
         b"PRIVACY_POLICY_URL=https://fedoraproject.org/wiki/Legal:PrivacyPolicy\n"
         b'VARIANT="Workstation Edition"\n'
         b"VARIANT_ID=workstation\n"
+        b"# Documentation references.\n"
+        b"\n"
+        b'DOCUMENTATION_URL="https://docs.fedoraproject.org/?lang=en"\n'
     )
 
     def testParseFileData(self):


### PR DESCRIPTION
## Description

`LinuxStandardBaseReleasePlugin` (`/etc/lsb-release`) and `LinuxSystemdOperatingSystemPlugin` (`/etc/os-release`) split `KEY=VALUE` lines with `line.split("=")`, which raises an uncaught `ValueError` on a blank / `=`-less line (LSB) or on any value containing `=` (os-release — which the freedesktop os-release specification explicitly permits). The error is caught by neither the plugin's `Collect` (catches only `PreProcessFail`) nor `PreprocessPluginsManager.CollectFromFileSystem` (catches only `(OSError, PreProcessFail)`), so it propagates and aborts preprocessing.

Fix: split on the first `=` with `str.partition("=")` and skip blank / comment lines.

**Related issue:** fixes #5110

## Testing

Extended the LSB and os-release preprocessor fixtures with a blank line, a comment line, and a value containing `=`; both assert no exception and the correct `operating_system_product`. (The pre-fix code raises `ValueError` on these inputs.) Black + pylint clean.

## Checklist
- [x] No new dependencies are required or l2tdevtools has been updated.
- [x] Test data has a Plaso compatible license. (No new test data added; inline byte fixtures only.)
- [x] Reviewer assigned.
- [ ] Automated checks (GitHub Actions, AppVeyor) pass.
