### PR TITLE
Added Linux IANA time zone name preprocessor

### DIFF
--- a/plaso/preprocessors/linux.py
+++ b/plaso/preprocessors/linux.py
@@ -217,6 +217,46 @@ class LinuxTimeZonePlugin(interface.FileEntryArtifactPreprocessorPlugin):
                 )
 
 
+class LinuxTimeZoneDebianPlugin(interface.FileArtifactPreprocessorPlugin):
+    """Linux time zone plugin for the /etc/timezone file.
+
+    The /etc/timezone file, used by Debian-based distributions, contains the
+    IANA time zone name, for example "Europe/Zurich". This is preferred over
+    the time zone abbreviation that LinuxTimeZonePlugin derives from a copied
+    /etc/localtime file, for example "CET", which is ambiguous. This plugin is
+    registered after LinuxTimeZonePlugin so that the IANA name, when present,
+    takes precedence.
+    """
+
+    ARTIFACT_DEFINITION_NAME = "LinuxTimezoneFile"
+
+    def _ParseFileData(self, mediator, file_object):
+        """Parses file content (data) for a time zone preprocessing attribute.
+
+        Args:
+          mediator (PreprocessMediator): mediates interactions between preprocess
+              plugins and other components, such as storage.
+          file_object (dfvfs.FileIO): file-like object that contains the artifact
+              value data.
+
+        Raises:
+          errors.PreProcessFail: if the preprocessing fails.
+        """
+        text_file_object = dfvfs_text_file.TextFile(file_object, encoding="utf-8")
+
+        time_zone = text_file_object.readline()
+        time_zone = time_zone.strip()
+
+        if time_zone:
+            try:
+                mediator.SetTimeZone(time_zone)
+            except ValueError:
+                mediator.ProducePreprocessingWarning(
+                    self.ARTIFACT_DEFINITION_NAME,
+                    f"Unable to set time zone: {time_zone:s} in knowledge base.",
+                )
+
+
 class LinuxUserAccountsPlugin(interface.FileArtifactPreprocessorPlugin):
     """The Linux user accounts plugin."""
 
@@ -333,6 +373,10 @@ manager.PreprocessPluginsManager.RegisterPlugins(
         LinuxStandardBaseReleasePlugin,
         LinuxSystemdOperatingSystemPlugin,
         LinuxTimeZonePlugin,
+        # LinuxTimeZoneDebianPlugin is registered after LinuxTimeZonePlugin so
+        # that the IANA time zone name from /etc/timezone takes precedence over
+        # the time zone abbreviation derived from a copied /etc/localtime file.
+        LinuxTimeZoneDebianPlugin,
         LinuxUserAccountsPlugin,
     ]
 )

--- a/test_data/artifacts/artifacts.yaml
+++ b/test_data/artifacts/artifacts.yaml
@@ -16,6 +16,13 @@ sources:
 labels: [System]
 supported_os: [Linux]
 ---
+name: LinuxTimezoneFile
+doc: Linux timezone file.
+sources:
+- type: FILE
+  attributes: {paths: ['/etc/timezone']}
+supported_os: [Linux]
+---
 name: LinuxPasswdFile
 doc: |
   Linux passwd file.

--- a/tests/preprocessors/linux.py
+++ b/tests/preprocessors/linux.py
@@ -4,9 +4,11 @@
 import unittest
 
 from dfvfs.helpers import fake_file_system_builder
+from dfvfs.helpers import file_system_searcher
 from dfvfs.path import fake_path_spec
 
 from plaso.preprocessors import linux
+from plaso.preprocessors import mediator
 
 from tests.preprocessors import test_lib
 
@@ -244,6 +246,99 @@ class LinuxTimeZonePluginTest(test_lib.ArtifactPreprocessorPluginTestCase):
         self.assertEqual(number_of_warnings, 1)
 
         self.assertIsNone(test_mediator.time_zone)
+
+
+class LinuxTimeZoneDebianPluginTest(test_lib.ArtifactPreprocessorPluginTestCase):
+    """Tests for the Linux Debian time zone plugin."""
+
+    def testParseFileData(self):
+        """Tests the _ParseFileData function on an /etc/timezone file."""
+        file_system_builder = fake_file_system_builder.FakeFileSystemBuilder()
+        file_system_builder.AddFile("/etc/timezone", b"Europe/Zurich\n")
+
+        mount_point = fake_path_spec.FakePathSpec(location="/")
+
+        storage_writer = self._CreateTestStorageWriter()
+
+        plugin = linux.LinuxTimeZoneDebianPlugin()
+        test_mediator = self._RunPreprocessorPluginOnFileSystem(
+            file_system_builder.file_system, mount_point, storage_writer, plugin
+        )
+
+        number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+            "preprocessing_warning"
+        )
+        self.assertEqual(number_of_warnings, 0)
+
+        self.assertEqual(test_mediator.time_zone.zone, "Europe/Zurich")
+
+    def testParseFileDataWithBogusTimeZone(self):
+        """Tests the _ParseFileData function with an unsupported time zone."""
+        file_system_builder = fake_file_system_builder.FakeFileSystemBuilder()
+        file_system_builder.AddFile("/etc/timezone", b"Bogus/Zone\n")
+
+        mount_point = fake_path_spec.FakePathSpec(location="/")
+
+        storage_writer = self._CreateTestStorageWriter()
+
+        plugin = linux.LinuxTimeZoneDebianPlugin()
+        test_mediator = self._RunPreprocessorPluginOnFileSystem(
+            file_system_builder.file_system, mount_point, storage_writer, plugin
+        )
+
+        number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+            "preprocessing_warning"
+        )
+        self.assertEqual(number_of_warnings, 1)
+
+        self.assertIsNone(test_mediator.time_zone)
+
+    def testTimeZoneFileTakesPrecedenceOverLocalTime(self):
+        """Tests that /etc/timezone overrides the /etc/localtime abbreviation."""
+        test_file_path = self._GetTestFilePath(["localtime.tzif"])
+        self._SkipIfPathNotExists(test_file_path)
+
+        file_system_builder = fake_file_system_builder.FakeFileSystemBuilder()
+        file_system_builder.AddFileReadData("/etc/localtime", test_file_path)
+        file_system_builder.AddFile("/etc/timezone", b"Europe/Zurich\n")
+
+        mount_point = fake_path_spec.FakePathSpec(location="/")
+
+        storage_writer = self._CreateTestStorageWriter()
+
+        # The two plugins are run on a shared mediator in the same order they are
+        # registered in linux.py: LinuxTimeZonePlugin first derives the "CET"
+        # abbreviation from the copied /etc/localtime file, then
+        # LinuxTimeZoneDebianPlugin overrides it with the IANA name read from
+        # /etc/timezone.
+        test_mediator = mediator.PreprocessMediator(storage_writer)
+        searcher = file_system_searcher.FileSystemSearcher(
+            file_system_builder.file_system, mount_point
+        )
+
+        local_time_plugin = linux.LinuxTimeZonePlugin()
+        local_time_definition = self._artifacts_registry.GetDefinitionByName(
+            local_time_plugin.ARTIFACT_DEFINITION_NAME
+        )
+        local_time_plugin.Collect(
+            test_mediator,
+            local_time_definition,
+            searcher,
+            file_system_builder.file_system,
+        )
+        self.assertEqual(test_mediator.time_zone.zone, "CET")
+
+        debian_plugin = linux.LinuxTimeZoneDebianPlugin()
+        debian_definition = self._artifacts_registry.GetDefinitionByName(
+            debian_plugin.ARTIFACT_DEFINITION_NAME
+        )
+        debian_plugin.Collect(
+            test_mediator,
+            debian_definition,
+            searcher,
+            file_system_builder.file_system,
+        )
+        self.assertEqual(test_mediator.time_zone.zone, "Europe/Zurich")
 
 
 class LinuxUserAccountsPluginTest(test_lib.ArtifactPreprocessorPluginTestCase):


### PR DESCRIPTION
## One line description of pull request

Recover the IANA time zone name from `/etc/timezone` on Debian-based systems.

## Description:

When `/etc/localtime` is a copy of a zoneinfo file rather than a symbolic link,
`LinuxTimeZonePlugin` can only derive an ambiguous time zone **abbreviation**
(for example `CET`) instead of the IANA name (for example `Europe/Zurich`). The
abbreviation is imprecise, is taken as of a hard-coded winter date, and for most
abbreviations is not a usable zone name (falling back to UTC).

This change adds `LinuxTimeZoneDebianPlugin`, which reads the IANA name from the
Debian `/etc/timezone` file (via the existing `LinuxTimezoneFile` artifact). It is
registered **after** `LinuxTimeZonePlugin` so the IANA name takes precedence when
present, while the `/etc/localtime` abbreviation remains the fallback. The
`LinuxTimezoneFile` artifact definition is also vendored into the test artifacts
fixture so the plugin resolves during testing.

Unit tests cover IANA recovery from `/etc/timezone`, an unsupported value
(produces a preprocessing warning), and precedence over a copied `/etc/localtime`
(`CET` → `Europe/Zurich`). No new binary test data is introduced.

RHEL/CentOS (`/etc/sysconfig/clock`) is intentionally out of scope: the
`artifacts` project has no definition for that file, so it would require an
upstream artifact definition and a dependency bump first.

**Related issue (if applicable):** fixes #5116

## Notes:
All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).

## Checklist:
* [x] No new dependencies are required (uses the existing `LinuxTimezoneFile` artifact).
* [x] Test data has a Plaso compatible license. No new binary test data; only inline bytes, the existing `localtime.tzif`, and a self-authored artifact definition.
* [x] Reviewer assigned.
* [ ] Automated checks (GitHub Actions, AppVeyor) pass.
