### PR TITLE
Add Tier 1 fields to systemd journal event data

### DIFF
--- a/plaso/data/timeliner.yaml
+++ b/plaso/data/timeliner.yaml
@@ -1440,6 +1440,8 @@ data_type: 'systemd:journal'
 attribute_mappings:
 - name: 'written_time'
   description: 'Content Modification Time'
+- name: 'recorded_time'
+  description: 'Recorded Time'
 place_holder_event: true
 ---
 # TODO: prefix data_type with 'windows:registry:'.

--- a/plaso/parsers/systemd_journal.py
+++ b/plaso/parsers/systemd_journal.py
@@ -15,15 +15,81 @@ from plaso.lib import specification
 from plaso.parsers import interface
 from plaso.parsers import manager
 
+# Syslog severity and facility label tables, mirroring the ones in
+# plaso/parsers/text_plugins/syslog.py. In the journal the PRIORITY and
+# SYSLOG_FACILITY fields are stored as plain decimal strings (0-7 and 0-23
+# respectively per systemd.journal-fields(7)) that index directly into these
+# tables; the RFC 3164 priority-byte decomposition used for text syslog does not
+# apply here. These are unvalidated "user" fields, so their values are
+# bounds-checked before use.
+_SYSLOG_SEVERITY = [
+    "EMERG",
+    "ALERT",
+    "CRIT",
+    "ERR",
+    "WARNING",
+    "NOTICE",
+    "INFO",
+    "DEBUG",
+]
+
+_SYSLOG_FACILITY = [
+    "kernel message",
+    "user-level message",
+    "mail system",
+    "system daemons",
+    "security/authorization messages",
+    "messages generated internally by syslogd",
+    "line printer subsystem",
+    "network news subsystem",
+    "UUCP subsystem",
+    "clock daemon",
+    "security/authorization messages",
+    "FTP daemon",
+    "NTP subsystem",
+    "log audit",
+    "log alert",
+    "clock daemon",
+    "local use 0",
+    "local use 1",
+    "local use 2",
+    "local use 3",
+    "local use 4",
+    "local use 5",
+    "local use 6",
+    "local use 7",
+]
+
 
 class SystemdJournalEventData(events.EventData):
     """Systemd journal event data.
 
     Attributes:
+      audit_login_identifier (str): login user identifier (audit loginuid) of
+          the process that logged the entry.
+      boot_identifier (str): identifier of the boot the entry was logged in.
+      command_line (str): command line of the process that logged the entry.
+      executable (str): path of the executable of the process that logged the
+          entry.
+      facility (str): syslog facility.
+      group_identifier (str): group identifier (GID) of the process that logged
+          the entry.
       hostname (str): hostname.
+      machine_identifier (str): identifier of the machine the entry was logged
+          on.
       message_body (str): message body.
-      pid (int): process identifier (PID).
+      pid (str): process identifier (PID).
+      process_name (str): name of the process that logged the entry.
+      recorded_time (dfdatetime.DateTimeValues): date and time the log entry
+          was recorded (received) by journald on the originating host.
       reporter (str): reporter.
+      selinux_context (str): SELinux security context of the process that logged
+          the entry.
+      severity (str): syslog severity.
+      systemd_unit (str): systemd unit of the process that logged the entry.
+      transport (str): how the entry was received by the journal.
+      user_identifier (str): user identifier (UID) of the process that logged
+          the entry.
       written_time (dfdatetime.DateTimeValues): date and time the log entry
           was written.
     """
@@ -33,10 +99,24 @@ class SystemdJournalEventData(events.EventData):
     def __init__(self):
         """Initializes event data."""
         super().__init__(data_type=self.DATA_TYPE)
+        self.audit_login_identifier = None
+        self.boot_identifier = None
+        self.command_line = None
+        self.executable = None
+        self.facility = None
+        self.group_identifier = None
         self.hostname = None
+        self.machine_identifier = None
         self.message_body = None
         self.pid = None
+        self.process_name = None
+        self.recorded_time = None
         self.reporter = None
+        self.selinux_context = None
+        self.severity = None
+        self.systemd_unit = None
+        self.transport = None
+        self.user_identifier = None
         self.written_time = None
 
 
@@ -286,6 +366,32 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
 
         return entry_object_offsets
 
+    def _GetSyslogLabel(self, value, labels):
+        """Retrieves a syslog label for a numeric journal field value.
+
+        The journal PRIORITY and SYSLOG_FACILITY fields are client-supplied and
+        not validated by journald, so they can be absent, out of range, or
+        non-numeric (for example applications that store a textual facility). In
+        those cases no label is returned rather than raising or guessing.
+
+        Args:
+          value (str): decimal journal field value, or None.
+          labels (list[str]): label table indexed by the numeric field value.
+
+        Returns:
+          str: label, or None if the value is missing, non-numeric or out of
+              range.
+        """
+        try:
+            index = int(value)
+        except (TypeError, ValueError):
+            return None
+
+        if 0 <= index < len(labels):
+            return labels[index]
+
+        return None
+
     def _ParseKeyValuePair(self, parser_mediator, field_data):
         """Parses a key value pair.
 
@@ -448,10 +554,49 @@ class SystemdJournalParser(interface.FileObjectParser, dtfabric_helper.DtFabricH
             )
             event_data = SystemdJournalEventData()
 
+            event_data.audit_login_identifier = fields.get("_AUDIT_LOGINUID")
+            event_data.boot_identifier = fields.get("_BOOT_ID")
+            event_data.command_line = fields.get("_CMDLINE")
+            event_data.executable = fields.get("_EXE")
+            event_data.facility = self._GetSyslogLabel(
+                fields.get("SYSLOG_FACILITY"), _SYSLOG_FACILITY
+            )
+            event_data.group_identifier = fields.get("_GID")
             event_data.hostname = fields.get("_HOSTNAME")
+            event_data.machine_identifier = fields.get("_MACHINE_ID")
             event_data.message_body = fields.get("MESSAGE")
-            event_data.reporter = fields.get("SYSLOG_IDENTIFIER")
+            event_data.process_name = fields.get("_COMM")
+            # Fall back to the trusted _COMM when SYSLOG_IDENTIFIER is absent.
+            event_data.reporter = fields.get("SYSLOG_IDENTIFIER") or fields.get("_COMM")
+            event_data.selinux_context = fields.get("_SELINUX_CONTEXT")
+            event_data.severity = self._GetSyslogLabel(
+                fields.get("PRIORITY"), _SYSLOG_SEVERITY
+            )
+            event_data.systemd_unit = fields.get("_SYSTEMD_UNIT")
+            event_data.transport = fields.get("_TRANSPORT")
+            event_data.user_identifier = fields.get("_UID")
             event_data.written_time = date_time
+
+            # _SOURCE_REALTIME_TIMESTAMP is the earliest trusted (event) time of
+            # the message on the originating host, whereas written_time
+            # (__REALTIME_TIMESTAMP) is journald's reception time; for journals
+            # relayed via systemd-journal-remote the latter is the collection
+            # time on the central host, so the two diverge. It is a trusted
+            # field and should be numeric microseconds, so a malformed value is
+            # surfaced rather than dropped.
+            source_realtime = fields.get("_SOURCE_REALTIME_TIMESTAMP")
+            if source_realtime:
+                try:
+                    event_data.recorded_time = (
+                        dfdatetime_posix_time.PosixTimeInMicroseconds(
+                            timestamp=int(source_realtime)
+                        )
+                    )
+                except ValueError:
+                    parser_mediator.ProduceExtractionWarning(
+                        f"Unable to parse source realtime timestamp: "
+                        f"{source_realtime:s}"
+                    )
 
             if event_data.reporter and event_data.reporter != "kernel":
                 event_data.pid = fields.get("_PID", fields.get("SYSLOG_PID"))

--- a/tests/parsers/systemd_journal.py
+++ b/tests/parsers/systemd_journal.py
@@ -94,10 +94,22 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
 
         expected_event_values = {
             "data_type": "systemd:journal",
+            "boot_identifier": "493676ee7ee04cff9afb308244ef893c",
+            "command_line": "/sbin/init splash",
+            "executable": "/lib/systemd/systemd",
+            "facility": "system daemons",
+            "group_identifier": "0",
             "hostname": "test-VirtualBox",
+            "machine_identifier": "a447b9eff9fe40a890e8e376e92a4ede",
             "message_body": "Started User Manager for UID 1000.",
             "pid": "1",
+            "process_name": "systemd",
+            "recorded_time": "2017-01-27T09:40:55.855726+00:00",
             "reporter": "systemd",
+            "severity": "INFO",
+            "systemd_unit": "init.scope",
+            "transport": "journal",
+            "user_identifier": "0",
             "written_time": "2017-01-27T09:40:55.913258+00:00",
         }
         event_data = storage_writer.GetAttributeContainerByIndex("event_data", 0)
@@ -106,10 +118,19 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
         # Test a XZ compressed data log entry.
         expected_event_values = {
             "data_type": "systemd:journal",
+            "boot_identifier": "493676ee7ee04cff9afb308244ef893c",
+            "facility": "user-level message",
+            "group_identifier": "0",
             "hostname": "test-VirtualBox",
+            "machine_identifier": "a447b9eff9fe40a890e8e376e92a4ede",
             "message_body": "a" * 692,
             "pid": "22921",
+            "process_name": "logger",
+            "recorded_time": "2017-02-06T16:24:32.562231+00:00",
             "reporter": "root",
+            "severity": "NOTICE",
+            "transport": "syslog",
+            "user_identifier": "0",
             "written_time": "2017-02-06T16:24:32.564585+00:00",
         }
         event_data = storage_writer.GetAttributeContainerByIndex("event_data", 2098)
@@ -138,13 +159,47 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
 
         expected_event_values = {
             "data_type": "systemd:journal",
+            "audit_login_identifier": "1000",
+            "boot_identifier": "02e8c96371d240b7b3934b11b08a120e",
+            "command_line": "/lib/systemd/systemd --user",
+            "executable": "/lib/systemd/systemd",
+            "facility": "system daemons",
+            "group_identifier": "1000",
             "hostname": "testlol",
+            "machine_identifier": "cf624987d3b145a79c35ae3874368fc7",
             "message_body": "Reached target Paths.",
             "pid": "822",
+            "process_name": "systemd",
+            "recorded_time": "2018-07-03T15:00:16.679635+00:00",
             "reporter": "systemd",
+            "severity": "INFO",
+            "systemd_unit": "user@1000.service",
+            "transport": "journal",
+            "user_identifier": "1000",
             "written_time": "2018-07-03T15:00:16.682340+00:00",
         }
         event_data = storage_writer.GetAttributeContainerByIndex("event_data", 0)
+        self.CheckEventData(event_data, expected_event_values)
+
+        # Test the reporter fallback to _COMM when SYSLOG_IDENTIFIER is absent.
+        # This entry has no SYSLOG_IDENTIFIER, so reporter (and the pid, which is
+        # only set for non-kernel reporters) are derived from the trusted _COMM.
+        expected_event_values = {
+            "data_type": "systemd:journal",
+            "audit_login_identifier": "1000",
+            "facility": None,
+            "hostname": "testlol",
+            "pid": "1485",
+            "process_name": "indicator-sound",
+            "recorded_time": "2018-07-03T15:00:21.873337+00:00",
+            "reporter": "indicator-sound",
+            "severity": "WARNING",
+            "systemd_unit": "user@1000.service",
+            "transport": "journal",
+            "user_identifier": "1000",
+            "written_time": "2018-07-03T15:00:21.875704+00:00",
+        }
+        event_data = storage_writer.GetAttributeContainerByIndex("event_data", 39)
         self.CheckEventData(event_data, expected_event_values)
 
         # Test a LZ4 compressed data log entry.
@@ -165,10 +220,18 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
 
         expected_event_values = {
             "data_type": "systemd:journal",
+            "boot_identifier": "02e8c96371d240b7b3934b11b08a120e",
+            "facility": "user-level message",
+            "group_identifier": "1000",
             "hostname": "testlol",
+            "machine_identifier": "cf624987d3b145a79c35ae3874368fc7",
             "message_body": expected_message_body,
             "pid": "34757",
+            "recorded_time": "2018-07-03T15:19:04.664754+00:00",
             "reporter": "test",
+            "severity": "NOTICE",
+            "transport": "syslog",
+            "user_identifier": "1000",
             "written_time": "2018-07-03T15:19:04.667807+00:00",
         }
         event_data = storage_writer.GetAttributeContainerByIndex("event_data", 84)
@@ -197,12 +260,24 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
 
         large_string = "A" * 512
 
+        # This journal was generated on stdout transport: it has no
+        # SYSLOG_FACILITY (facility stays None) and no _SOURCE_REALTIME_TIMESTAMP
+        # (recorded_time stays None).
         expected_event_values = {
             "data_type": "systemd:journal",
+            "boot_identifier": "7dd8f8967ea94fec9efa46beed3d2a71",
+            "facility": None,
+            "group_identifier": "1000",
             "hostname": "DESKTOP-QCDE2BT",
+            "machine_identifier": "9e4a892d275848e797b10057152ae1bf",
             "message_body": f"Some large string: {large_string:s}",
             "pid": "197",
+            "process_name": "cat",
+            "recorded_time": None,
             "reporter": "testapp",
+            "severity": "INFO",
+            "transport": "stdout",
+            "user_identifier": "1000",
             "written_time": "2023-09-26T07:42:46.445209+00:00",
         }
         event_data = storage_writer.GetAttributeContainerByIndex("event_data", 0)
@@ -237,12 +312,23 @@ class SystemdJournalParserTest(test_lib.ParserTestCase):
 
         expected_event_values = {
             "data_type": "systemd:journal",
+            "boot_identifier": "978fdbbbe8ab4f1d834efb2899083415",
+            "command_line": "/lib/systemd/systemd-journald",
+            "executable": "/lib/systemd/systemd-journald",
+            "facility": "system daemons",
+            "group_identifier": "0",
             "hostname": "test-VirtualBox",
+            "machine_identifier": "49cd46492584496585e147de34ed5816",
             "message_body": (
                 "Runtime journal (/run/log/journal/) is 1.2M, max 9.9M, 8.6M " "free."
             ),
             "pid": "569",
+            "process_name": "systemd-journal",
             "reporter": "systemd-journald",
+            "severity": "INFO",
+            "systemd_unit": "systemd-journald.service",
+            "transport": "driver",
+            "user_identifier": "0",
             "written_time": "2016-10-24T13:20:01.063423+00:00",
         }
         event_data = storage_writer.GetAttributeContainerByIndex("event_data", 0)


### PR DESCRIPTION
## Summary

Implements the **Tier 1** field set from the design proposal in #5118, which you
approved ("Please feel free to go ahead ... Let's start with tier 1 and assess
what the volume of additional events is"). Built on the now-merged #5113
binary-safe field decode.

The `systemd_journal` parser previously surfaced only 5 attributes and discarded
the rest. This adds 14 attributes, most of them trusted (`_`-prefixed) fields
that journald adds itself and that the logging process cannot forge.

## New attributes

| attribute | journal field |
|---|---|
| `user_identifier` | `_UID` |
| `group_identifier` | `_GID` |
| `process_name` | `_COMM` |
| `executable` | `_EXE` |
| `command_line` | `_CMDLINE` |
| `systemd_unit` | `_SYSTEMD_UNIT` |
| `boot_identifier` | `_BOOT_ID` |
| `machine_identifier` | `_MACHINE_ID` |
| `transport` | `_TRANSPORT` |
| `audit_login_identifier` | `_AUDIT_LOGINUID` |
| `selinux_context` | `_SELINUX_CONTEXT` |
| `severity` | `PRIORITY` (→ syslog label) |
| `facility` | `SYSLOG_FACILITY` (→ syslog label) |
| `recorded_time` | `_SOURCE_REALTIME_TIMESTAMP` |

Also: `reporter` falls back to the trusted `_COMM` when `SYSLOG_IDENTIFIER` is
absent, and the `pid` docstring is corrected (`int` → `str`).

## Volume of additional events

The only new attribute that generates timeline events is `recorded_time`. Across
the four test journals (4,398 entries) it adds **3,177** events on top of the
4,398 `written_time` events → **7,575 total, +72.2%** — only for entries that
carry `_SOURCE_REALTIME_TIMESTAMP` (measured with log2timeline + pinfo).

## Notes / decisions

- **severity / facility as labels**, matching `syslog:line`, for cross-parser
  parity. Per `systemd.journal-fields(7)` `PRIORITY` is 0–7 and `SYSLOG_FACILITY`
  0–23, indexed directly (no RFC 3164 `>>3` / `&7`). These are *unvalidated* user
  fields — the samples contain e.g. `SYSLOG_FACILITY=DHCP4` (NetworkManager) — so
  values are bounds-checked and non-numeric ones yield `None` silently rather
  than flooding extraction warnings.
- The severity/facility label tables mirror the ones in
  `text_plugins/syslog.py`; glad to switch to importing them instead of the local
  copies if you prefer reuse.
- **recorded_time** is a distinct second timestamp (source/event time) alongside
  `written_time` (reception/collection time); for `systemd-journal-remote`
  relayed journals the two diverge.
- **selinux_context** is mapped but absent from the current test samples
  (generated on an AppArmor host), so it ships without a value assertion — happy
  to add one if a SELinux sample is contributed.

## Backward compatibility

New attributes default to `None`; acstore does not serialize `None`, so entries
that do not populate a field are byte-for-byte unchanged (no event-identity /
dedup-hash change, no storage bloat). No attribute is renamed or removed.

## Testing

Expected values are derived from `journalctl --output=json` ground truth over the
existing test journals — no new test data. Verified locally:
`tests.parsers.systemd_journal`, `tests.engine.timeliner` +
`tests.engine.yaml_timeliner_file`, pylint / black / docformatter / yamllint,
`tests.cli.psteal_tool`, and the end-to-end suite (clean — no over-claim, no
psort crash).
