### PR TITLE
Fix false EOF in EncodedTextReader.ReadLine() caused by lines_size inflation

### DIFF
--- a/plaso/parsers/text_parser.py
+++ b/plaso/parsers/text_parser.py
@@ -53,7 +53,7 @@ class EncodedTextReader:
             self.ReadLines()
 
         line, _, self.lines = self.lines.partition("\n")
-        self.lines_size += len(line) + 1
+        self.lines_size -= len(line) + 1
         self.line_number += 1
 
         return line

--- a/tests/parsers/text_parser.py
+++ b/tests/parsers/text_parser.py
@@ -88,6 +88,55 @@ class EncodedTextReaderTest(test_lib.ParserTestCase):
         text_reader.SkipAhead(10)
         self.assertEqual(text_reader.lines, self._TEST_LINES[10:])
 
+    def testReadLineUpdatesLinesSize(self):
+        """Tests that ReadLine keeps lines_size in sync with the buffer."""
+        # Newline-terminated so every line consumed by ReadLine includes its
+        # newline, which makes lines_size == len(lines) hold exactly.
+        test_data = b"\n".join([b"first line", b"second line", b"third line"])
+        test_data = b"".join([test_data, b"\n"])
+
+        resolver_context = dfvfs_context.Context()
+
+        test_path_spec = fake_path_spec.FakePathSpec(location="/file.txt")
+        file_object = fake_file_io.FakeFile(resolver_context, test_path_spec, test_data)
+        file_object.Open()
+
+        text_reader = text_parser.EncodedTextReader(file_object)
+
+        text_reader.ReadLines()
+        while text_reader.lines:
+            text_reader.ReadLine()
+            self.assertEqual(text_reader.lines_size, len(text_reader.lines))
+
+    def testReadLineReadsEntireLargeFile(self):
+        """Tests that ReadLine reads a large file to its end.
+
+        Regression test: a file larger than the read buffer, consumed
+        line-by-line via ReadLine (the plugin reject path), must be read to
+        its end. Inflating lines_size in ReadLine used to stall the refill in
+        ReadLines and produce a false end-of-file.
+        """
+        number_of_lines = 25000
+        test_data = b"\n".join([b"x" * 48] * number_of_lines) + b"\n"
+
+        resolver_context = dfvfs_context.Context()
+
+        test_path_spec = fake_path_spec.FakePathSpec(location="/file.txt")
+        file_object = fake_file_io.FakeFile(resolver_context, test_path_spec, test_data)
+        file_object.Open()
+
+        text_reader = text_parser.EncodedTextReader(file_object)
+
+        number_of_read_lines = 0
+        text_reader.ReadLines()
+        while text_reader.lines:
+            text_reader.ReadLine()
+            text_reader.ReadLines()
+            number_of_read_lines += 1
+
+        self.assertEqual(number_of_read_lines, number_of_lines)
+        self.assertEqual(text_reader.get_offset(), len(test_data))
+
 
 class TextLogParserTest(test_lib.ParserTestCase):
     """Tests for the text log parser."""


### PR DESCRIPTION
Fixes #5175

## Problem

`EncodedTextReader.ReadLine()` removes a line from `self.lines` but **adds**
its length to `self.lines_size` instead of subtracting it:

```python
line, _, self.lines = self.lines.partition('\n')
self.lines_size += len(line) + 1   # should be -=
```

`ReadLines()` only refills the buffer while `self.lines_size < self.BUFFER_SIZE`
(65536). On the plugin reject path (`text_plugins/interface.py` calls
`ReadLine()` on every `ParseError`), each rejected line inflates the counter
instead of shrinking it. Once enough rejected lines push `lines_size` past the
threshold, `ReadLines()` stops refilling even though the real buffer has
drained, `while text_reader.lines:` goes false, and parsing halts at a silent
false end-of-file — dropping events on large logs that contain unparsable
lines. The documented `lines_size == len(lines)` invariant is violated after
the first rejected line. The success path is unaffected because it consumes via
`SkipAhead()`, which decrements the counter correctly.

## Fix

Change the single `+=` to `-=`, restoring the invariant. `lines_size` is
referenced only within `text_parser.py` (the refill gate and `SkipAhead`), so
the change is fully contained.

## Tests

Adds two regression tests to `tests/parsers/text_parser.py`:

- `testReadLineUpdatesLinesSize` — asserts `lines_size == len(lines)` after
  each `ReadLine()` across the buffer.
- `testReadLineReadsEntireLargeFile` — a file larger than the read buffer,
  consumed line-by-line via `ReadLine()`, must reach true EOF.

Both fail on the current code and pass with the fix.

| suite | with fix | without fix |
| --- | --- | --- |
| `tests/parsers/text_parser.py` | 7/7 pass | 2 new tests fail |
| `tests/parsers/text_plugins/` (114 tests) | 114/114 pass | 114/114 pass |

No existing test asserts on `lines_size`, which is why the regression went
undetected.

## Impact observed

Reported in #5175: `log2timeline --parsers text/apache_access` over a 3.3 GB
`access.log.1` (3,070,726 lines, ~52k sqlmap probe lines the grammar rejects)
stopped after 248,048 events with no error. A minimal reproduction stalls at
exactly one `_READ_BUFFER_SIZE` (1,048,576 bytes) before the fix and reads to
true EOF after it.
