### PR TITLE
Changes to improve code readability

### DIFF
--- a/plaso/cli/helpers/opensearch_ts_output.py
+++ b/plaso/cli/helpers/opensearch_ts_output.py
@@ -56,7 +56,7 @@ class OpenSearchTimesketchOutputArgumentsHelper(interface.ArgumentsHelper):
             output_module, opensearch_ts.OpenSearchTimesketchOutputModule
         ):
             raise errors.BadConfigObject(
-                "Output module is not an instance of OpenSearchsearchOutputModule"
+                "Output module is not an instance of OpenSearchTimesketchOutputModule"
             )
 
         opensearch_output.OpenSearchOutputArgumentsHelper.ParseOptions(

--- a/plaso/formatters/msiecf.py
+++ b/plaso/formatters/msiecf.py
@@ -24,7 +24,7 @@ class MSIECFCachedPathFormatterHelper(interface.CustomEventFormatterHelper):
             event_values["cached_file_path"] = cached_file_path
 
 
-class MSIECFHTTPHeadersventFormatterHelper(interface.CustomEventFormatterHelper):
+class MSIECFHTTPHeadersEventFormatterHelper(interface.CustomEventFormatterHelper):
     """MSIE cache file HTTP headers formatter helper."""
 
     IDENTIFIER = "msiecf_http_headers"
@@ -42,5 +42,5 @@ class MSIECFHTTPHeadersventFormatterHelper(interface.CustomEventFormatterHelper)
 
 
 manager.FormattersManager.RegisterEventFormatterHelpers(
-    [MSIECFCachedPathFormatterHelper, MSIECFHTTPHeadersventFormatterHelper]
+    [MSIECFCachedPathFormatterHelper, MSIECFHTTPHeadersEventFormatterHelper]
 )


### PR DESCRIPTION
## Summary

fix: 2 improvements across 2 files

## Problem

**Severity**: `Low` | **File**: `plaso/formatters/msiecf.py:L30`

The class name 'MSIECFHTTPHeadersventFormatterHelper' is missing an 'E' in the word 'Event', making it 'vent'. This is likely a typo and reduces code readability.

## Solution

Rename the class to 'MSIECFHTTPHeadersEventFormatterHelper'.

## Changes

- `plaso/formatters/msiecf.py` (modified)
- `plaso/cli/helpers/opensearch_ts_output.py` (modified)