### PR TITLE
Correction for output mediator passed to WriteHeader #5184

### DIFF
--- a/config/end-to-end.ini
+++ b/config/end-to-end.ini
@@ -262,6 +262,13 @@ output_format=json_line
 reference_output_file=test_data/end_to_end/json_line.log
 source=test_data/psort_test.plaso
 
+[output_kml]
+case=analyze_and_output
+output_file=kml.log
+output_format=kml
+reference_output_file=test_data/end_to_end/kml.log
+source=test_data/psort_test.plaso
+
 [output_l2tcsv]
 case=analyze_and_output
 output_file=l2tcsv.log

--- a/plaso/multi_process/output_engine.py
+++ b/plaso/multi_process/output_engine.py
@@ -557,7 +557,7 @@ class OutputAndFormattingMultiProcessEngine(engine.MultiProcessEngine):
         self._output_mediator = self._CreateOutputMediator(
             storage_reader, processing_configuration
         )
-        output_module.WriteHeader(output_mediator)
+        output_module.WriteHeader(self._output_mediator)
 
         self._StartStatusUpdateThread()
 

--- a/test_data/end_to_end/kml.log
+++ b/test_data/end_to_end/kml.log
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><kml xmlns="http://www.opengis.net/kml/2.2"><Document></Document></kml>


### PR DESCRIPTION
Fixes #5184.

`ExportEvents` passed the `plaso.output.mediator` module to `WriteHeader` instead of
the `OutputMediator` it had just created, so `psort.py -o kml` failed with
`AttributeError: module 'plaso.output.mediator' has no attribute 'encoding'`.

Also adds the end-to-end test for the `kml` output format, modelled on
`output_rawpy`.

A note on the reference output: `KMLOutputModule.WriteFieldValues` returns early for
events without latitude and longitude, and `test_data/psort_test.plaso` has no
geolocation data, so `test_data/end_to_end/kml.log` is the header and footer only:

```
<?xml version="1.0" encoding="utf-8"?><kml xmlns="http://www.opengis.net/kml/2.2"><Document></Document></kml>
```

That covers the defect, since it is in `WriteHeader`. It does not cover the placemark
path in `WriteFieldValues`, and there is currently no clean way to: `android_airtag`
appears to be the only parser that populates `latitude` and `longitude`, and the
AirGuard `beacon` table it reads stores latitude in the column named `longitude` and
longitude in the column named `latitude`
([reference](https://thebinaryhick.blog/2022/01/08/androids-airtags-oof/)). The plugin
does not compensate for that, so a placemark reference generated from
`test_data/android/attd_db` would record reversed coordinates. Noted for the record,
not addressed here.

Verified with the full end-to-end suite on Ubuntu 26.04, exit 0, including the new
`output_kml` case.
