### PR TITLE
IIS parser: support IPv6 addresses with a zone index

### DIFF
--- a/plaso/parsers/text_plugins/iis.py
+++ b/plaso/parsers/text_plugins/iis.py
@@ -95,9 +95,17 @@ class WinIISTextPlugin(interface.TextPlugin):
         lambda tokens: int(tokens[0], 10)
     )
 
+    # A scoped literal IPv6 address has a zone index suffix, such as "%3" or
+    # "%eth0", which pyparsing_common.ipv6_address does not support.
+    _ZONE_INDEX = pyparsing.Combine(
+        pyparsing.Literal("%") + pyparsing.Word(pyparsing.alphanums)
+    )
+
     _IP_ADDRESS = (
         pyparsing.pyparsing_common.ipv4_address
-        | pyparsing.pyparsing_common.ipv6_address
+        | pyparsing.Combine(
+            pyparsing.pyparsing_common.ipv6_address + pyparsing.Opt(_ZONE_INDEX)
+        )
         | _BLANK
     )
 

--- a/tests/parsers/text_plugins/iis.py
+++ b/tests/parsers/text_plugins/iis.py
@@ -11,6 +11,26 @@ from tests.parsers.text_plugins import test_lib
 class WinIISTextPluginTest(test_lib.TextPluginTestCase):
     """Tests for the Windows IIS text parser plugin."""
 
+    # pylint: disable=protected-access
+
+    def testIPAddressWithZoneIndex(self):
+        """Tests the _IP_ADDRESS structure with a scoped IPv6 address."""
+        plugin = iis.WinIISTextPlugin()
+
+        structure = plugin._IP_ADDRESS.parse_string(
+            "fe80::1ff:fe23:4567:890a%3", parse_all=True
+        )
+        self.assertEqual(structure[0], "fe80::1ff:fe23:4567:890a%3")
+
+        structure = plugin._IP_ADDRESS.parse_string("fe80::1%eth0", parse_all=True)
+        self.assertEqual(structure[0], "fe80::1%eth0")
+
+        structure = plugin._IP_ADDRESS.parse_string("::1", parse_all=True)
+        self.assertEqual(structure[0], "::1")
+
+        structure = plugin._IP_ADDRESS.parse_string("10.10.10.100", parse_all=True)
+        self.assertEqual(structure[0], "10.10.10.100")
+
     def testProcessWithIIS6Log(self):
         """Tests the Process function with an IIS 6 log file."""
         plugin = iis.WinIISTextPlugin()


### PR DESCRIPTION
## One line description of pull request

IIS parser: support IPv6 addresses with a zone index.

## Description:

The IIS text plugin matched the `s-ip` and `c-ip` fields with
`pyparsing_common.ipv6_address`, which does not accept the zone index suffix of a
scoped literal IPv6 address (e.g. `fe80::1ff:fe23:4567:890a%3`), so those log
lines produced an "unable to parse log line" extraction warning and were dropped.

`_IP_ADDRESS` now accepts an optional `%<zone>` suffix after an IPv6 address and
returns the full scoped address. IPv4, unscoped IPv6 and the blank `-` value are
unchanged. `testIPAddressWithZoneIndex` covers all four forms and fails without
the parser change.

**Related issue (if applicable):** fixes #4903

## Notes:
This change was prepared with AI assistance; the regression test was run locally
and fails without the fix.

## Checklist:
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated.
* [x] Test data has a Plaso compatible license. If the test data was not authored by you (the contributor), make sure to mention its original source in ACKNOWLEDGEMENTS.
* [x] Reviewer assigned.
* [x] Automated checks (GitHub Actions, AppVeyor) pass.
