### PR TITLE
Correction to storage profiler write sample data size #5191

### DIFF
--- a/plaso/storage/sqlite/sqlite_file.py
+++ b/plaso/storage/sqlite/sqlite_file.py
@@ -302,9 +302,10 @@ class SQLiteStorageFile(sqlite_store.SQLiteAttributeContainerStore):
 
             if self.compression_format == definitions.COMPRESSION_FORMAT_ZLIB:
                 compressed_data = zlib.compress(serialized_data)
-                serialized_data = sqlite3.Binary(compressed_data)
+                column_value = sqlite3.Binary(compressed_data)
             else:
-                compressed_data = ""
+                compressed_data = b""
+                column_value = serialized_data
 
             if self._storage_profiler:
                 self._storage_profiler.Sample(
@@ -316,7 +317,7 @@ class SQLiteStorageFile(sqlite_store.SQLiteAttributeContainerStore):
                 )
 
             column_names = ["_data"]
-            values = [serialized_data]
+            values = [column_value]
 
             self._CacheAttributeContainerForWrite(
                 container.CONTAINER_TYPE, column_names, values

--- a/tests/storage/sqlite/sqlite_file.py
+++ b/tests/storage/sqlite/sqlite_file.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 """Tests for the SQLite-based storage."""
 
+import csv
+import gzip
 import os
 import unittest
 
 from plaso.containers import events
+from plaso.engine import configurations
+from plaso.engine import profilers
 from plaso.lib import definitions
 from plaso.storage.sqlite import sqlite_file
 
@@ -282,6 +286,43 @@ class SQLiteStorageFileTest(test_lib.StorageTestCase):
 
             finally:
                 test_store.Close()
+
+    def testWriteNewAttributeContainerWithStorageProfiler(self):
+        """Tests the _WriteNewAttributeContainer function with a storage profiler."""
+        event_data = events.EventData()
+        event_data.data_type = "test:event_data"
+        event_data.body = "test" * 256
+
+        profiling_configuration = configurations.ProfilingConfiguration()
+
+        with shared_test_lib.TempDirectory() as temp_directory:
+            profiling_configuration.directory = temp_directory
+
+            test_profiler = profilers.StorageProfiler("test", profiling_configuration)
+            test_profiler.Start()
+
+            test_path = os.path.join(temp_directory, "plaso.sqlite")
+            test_store = sqlite_file.SQLiteStorageFile()
+            test_store.SetStorageProfiler(test_profiler)
+            test_store.Open(path=test_path, read_only=False)
+
+            try:
+                test_store._WriteNewAttributeContainer(event_data)
+            finally:
+                test_store.Close()
+                test_profiler.Stop()
+
+            sample_path = os.path.join(temp_directory, "storage-test.csv.gz")
+            with gzip.open(sample_path, "rt", encoding="utf-8") as file_object:
+                rows = list(csv.reader(file_object, delimiter="\t"))
+
+        write_rows = [row for row in rows if row[1] == "write_new"]
+        self.assertEqual(len(write_rows), 1)
+
+        data_size = int(write_rows[0][5])
+        compressed_data_size = int(write_rows[0][6])
+
+        self.assertGreater(data_size, compressed_data_size)
 
     def testAddAttributeContainer(self):
         """Tests the AddAttributeContainer function."""


### PR DESCRIPTION
Fixes #5191.

`_WriteNewAttributeContainer` rebound `serialized_data` to the compressed blob before
sampling it, so the storage profiler's `write_new` samples carried the compressed
length in both the `Data size` and the `Compressed data size` column. The value bound
for the `_data` column is now a separate name, leaving `serialized_data` holding the
serialized container when the sample is taken.

| | Data size | Compressed data size |
| --- | --- | --- |
| before | 107 | 107 |
| after | 1266 | 107 |

`compressed_data` in the non-compressed branch is also `b""` now, matching
`_CreateAttributeContainerFromRow`.

Storage file contents are unchanged — the compressed blob is still what is written to
the `_data` column, and the read path was already correct.

`tests/storage/sqlite/sqlite_file.py` had no case that attached a storage profiler.
`testWriteNewAttributeContainerWithStorageProfiler` writes an `event_data` container
through a real `StorageProfiler`, reads back the `storage-*.csv.gz` sample file, and
asserts the data size exceeds the compressed data size. It fails on the parent commit
with `AssertionError: 89 not greater than 89`.

Verified: 57 tests in `tests/storage`, 44 in the storage and profiler modules, and the
30 CLI tool tests in `tests/cli/{psteal,psort,log2timeline}_tool.py`. `pylint` and
`black` clean on both files. The one CLI failure,
`log2timeline_tool.testExtractEventsFromSourcesOnBDEImage`, reproduces identically on
the unmodified parent commit and passes when run on its own — a local environment
issue, not related to this change.

## Backward compatibility

None affected. The change is confined to which value the profiler samples; the stored
data, the storage format, and the profiler's CSV schema are all unchanged.
