### PR TITLE
Extend syslog SSH record handling to current OpenSSH releases #5183

### DIFF
--- a/plaso/parsers/text_plugins/syslog.py
+++ b/plaso/parsers/text_plugins/syslog.py
@@ -155,15 +155,35 @@ class BaseSyslogTextPlugin(interface.TextPlugin):
 
     _CRON_MESSAGE = pyparsing.Group(_CRON_TASK_RUN).set_results_name("task_run")
 
+    # OpenSSH 9.8 split the server into a listener binary, sshd, and a per-session
+    # binary, sshd-session, which writes the authentication messages.
+    _SSHD_REPORTERS = frozenset(["sshd", "sshd-session"])
+
     _SSHD_AUTHENTICATION_METHOD = pyparsing.Keyword("password") | pyparsing.Keyword(
         "publickey"
     )
 
-    _SSHD_FINGER_PRINT = pyparsing.Combine(
-        pyparsing.Literal("RSA ") + pyparsing.Word(":" + pyparsing.hexnums)
+    # A key fingerprint consists of the key type followed by the digest, where the
+    # digest is either the hash name and a base64 value, such as
+    # "ED25519 SHA256:5xyQ+PG1Z3CIiShclJ2iNya5TOdKDgE/HrOXr21IdOo", or the older
+    # colon separated hexadecimal form, such as "RSA 00:aa:bb:cc". The default of
+    # the sshd_config FingerprintHash option is sha256.
+    # Note that the hexadecimal form is matched first, since the hash name and
+    # base64 pattern would otherwise match "00:aa" of "00:aa:bb:cc" and leave the
+    # remainder of the value unparsed.
+    _SSHD_FINGER_PRINT = pyparsing.Regex(
+        r"[A-Za-z0-9-]+ "
+        r"(?:[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2})+|[A-Za-z0-9]+:[A-Za-z0-9+/=]+)"
     ).set_results_name("fingerprint")
 
-    _SSH_USERNAME = pyparsing.Word(pyparsing.alphanums).set_results_name("username")
+    # A user name is determined by the text that precedes " from " since sshd
+    # logs the user name as provided by the client, which is not limited to the
+    # characters that useradd would accept.
+    _SSH_USERNAME = (
+        pyparsing.SkipTo(pyparsing.Literal("from"))
+        .set_parse_action(lambda tokens: tokens[0].strip())
+        .set_results_name("username")
+    )
 
     _SSH_IP_ADDRESS = (
         pyparsing.pyparsing_common.ipv4_address
@@ -181,6 +201,7 @@ class BaseSyslogTextPlugin(interface.TextPlugin):
         + _SSH_IP_ADDRESS.set_results_name("ip_address")
         + pyparsing.Literal("port")
         + _SSH_PORT
+        + pyparsing.Optional(pyparsing.Literal("ssh2").set_results_name("protocol"))
         + pyparsing.StringEnd()
     )
 
@@ -548,7 +569,7 @@ class SyslogTextPlugin(BaseSyslogTextPlugin):
         event_data = None
         if reporter == "CRON":
             event_data = self._ParseCronMessageBody(message_body)
-        elif reporter == "sshd":
+        elif reporter in self._SSHD_REPORTERS:
             event_data = self._ParseSshdMessageBody(message_body)
 
         if not event_data:
@@ -833,7 +854,7 @@ class TraditionalSyslogTextPlugin(
         event_data = None
         if reporter == "CRON":
             event_data = self._ParseCronMessageBody(message_body)
-        elif reporter == "sshd":
+        elif reporter in self._SSHD_REPORTERS:
             event_data = self._ParseSshdMessageBody(message_body)
 
         if not event_data:

--- a/test_data/syslog/syslog_sshd_session.log
+++ b/test_data/syslog/syslog_sshd_session.log
@@ -1,0 +1,8 @@
+Aug  2 11:41:04 localhost sshd-session[2470]: Failed password for svc-backup from 192.168.1.62 port 60203 ssh2
+Aug  2 11:41:08 localhost sshd-session[2473]: Failed password for john.doe from 192.168.1.62 port 60204 ssh2
+Aug  2 11:42:13 localhost sshd-session[2600]: Accepted password for svc-backup from 192.168.1.62 port 60214 ssh2
+Aug  2 11:42:15 localhost sshd-session[2655]: Accepted password for john.doe from 192.168.1.62 port 60215 ssh2
+Aug  2 11:42:16 localhost sshd-session[2711]: Accepted password for test_user from 192.168.1.62 port 60217 ssh2
+Aug  2 11:42:18 localhost sshd-session[2789]: Received disconnect from 192.168.1.62 port 60218:11: disconnected by user
+Aug  2 11:42:18 localhost sshd-session[2789]: Disconnected from user root 192.168.1.62 port 60218
+Aug  2 11:42:48 localhost sshd-session[2842]: Accepted publickey for root from 192.168.1.62 port 60220 ssh2: ED25519 SHA256:a79QfkCiaM8pEpw/wmP0Qfkl3ttsHxPlSKgqilMv9K8

--- a/tests/parsers/text_plugins/syslog.py
+++ b/tests/parsers/text_plugins/syslog.py
@@ -622,6 +622,117 @@ class TraditionalSyslogTextPluginTest(test_lib.TextPluginTestCase):
         event_data = storage_writer.GetAttributeContainerByIndex("event_data", 4)
         self.CheckEventData(event_data, expected_event_values)
 
+        expected_event_values = {
+            "authentication_method": "password",
+            "data_type": "syslog:ssh:failed_connection",
+            "ip_address": "188.124.3.41",
+            "last_written_time": "0000-03-11T22:55:32",
+            "port": "32889",
+            "protocol": "ssh2",
+            "username": "root",
+        }
+        event_data = storage_writer.GetAttributeContainerByIndex("event_data", 5)
+        self.CheckEventData(event_data, expected_event_values)
+
+        expected_event_values = {
+            "authentication_method": "publickey",
+            "data_type": "syslog:ssh:login",
+            "fingerprint": ("RSA SHA256:5xyQ+PG1Z3CIiShclJ2iNya5TOdKDgE/HrOXr21IdOo"),
+            "ip_address": "192.0.2.60",
+            "last_written_time": "0000-03-11T22:55:35",
+            "port": "59915",
+            "username": "fred",
+        }
+        event_data = storage_writer.GetAttributeContainerByIndex("event_data", 8)
+        self.CheckEventData(event_data, expected_event_values)
+
+    def testProcessSshdSession(self):
+        """Tests the Process function with a sshd-session syslog file."""
+        plugin = syslog.TraditionalSyslogTextPlugin()
+        storage_writer = self._ParseTextFileWithPlugin(
+            ["syslog", "syslog_sshd_session.log"], plugin
+        )
+        number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
+            "event_data"
+        )
+        self.assertEqual(number_of_event_data, 8)
+
+        number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+            "extraction_warning"
+        )
+        self.assertEqual(number_of_warnings, 0)
+
+        number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+            "recovery_warning"
+        )
+        self.assertEqual(number_of_warnings, 0)
+
+        expected_event_values = {
+            "authentication_method": "password",
+            "data_type": "syslog:ssh:failed_connection",
+            "ip_address": "192.168.1.62",
+            "last_written_time": "0000-08-02T11:41:04",
+            "port": "60203",
+            "protocol": "ssh2",
+            "reporter": "sshd-session",
+            "username": "svc-backup",
+        }
+        event_data = storage_writer.GetAttributeContainerByIndex("event_data", 0)
+        self.CheckEventData(event_data, expected_event_values)
+
+        expected_event_values = {
+            "data_type": "syslog:ssh:failed_connection",
+            "last_written_time": "0000-08-02T11:41:08",
+            "reporter": "sshd-session",
+            "username": "john.doe",
+        }
+        event_data = storage_writer.GetAttributeContainerByIndex("event_data", 1)
+        self.CheckEventData(event_data, expected_event_values)
+
+        expected_event_values = {
+            "data_type": "syslog:ssh:login",
+            "last_written_time": "0000-08-02T11:42:13",
+            "reporter": "sshd-session",
+            "username": "svc-backup",
+        }
+        event_data = storage_writer.GetAttributeContainerByIndex("event_data", 2)
+        self.CheckEventData(event_data, expected_event_values)
+
+        expected_event_values = {
+            "data_type": "syslog:ssh:login",
+            "last_written_time": "0000-08-02T11:42:16",
+            "reporter": "sshd-session",
+            "username": "test_user",
+        }
+        event_data = storage_writer.GetAttributeContainerByIndex("event_data", 4)
+        self.CheckEventData(event_data, expected_event_values)
+
+        # A message that the sshd structures do not define, which is retained as
+        # a syslog:line.
+        expected_event_values = {
+            "data_type": "syslog:line",
+            "last_written_time": "0000-08-02T11:42:18",
+            "reporter": "sshd-session",
+        }
+        event_data = storage_writer.GetAttributeContainerByIndex("event_data", 5)
+        self.CheckEventData(event_data, expected_event_values)
+
+        expected_event_values = {
+            "authentication_method": "publickey",
+            "data_type": "syslog:ssh:login",
+            "fingerprint": (
+                "ED25519 SHA256:a79QfkCiaM8pEpw/wmP0Qfkl3ttsHxPlSKgqilMv9K8"
+            ),
+            "ip_address": "192.168.1.62",
+            "last_written_time": "0000-08-02T11:42:48",
+            "port": "60220",
+            "protocol": "ssh2",
+            "reporter": "sshd-session",
+            "username": "root",
+        }
+        event_data = storage_writer.GetAttributeContainerByIndex("event_data", 7)
+        self.CheckEventData(event_data, expected_event_values)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Implements #5183.

OpenSSH 9.8 split the server into a listener binary, `sshd`, and a per-session binary,
`sshd-session`, which writes the authentication messages. This recognises both reporter names and
extends three of the sshd structures to the message forms current releases write.

### The per-session reporter name

`_SSHD_REPORTERS` holds both names and the dispatch in both plugins uses it. `sshd` is kept because
the listener still writes its own messages, such as `Server listening on 0.0.0.0 port 22.`

### Key fingerprints

The existing structure matches a key type followed by a colon separated hexadecimal digest, which is
the MD5 form. `sshd_config(5)` gives the default for `FingerprintHash` as `sha256`, so the value now
written is the hash name followed by base64, which can contain `+` and `/`. Both forms are matched.

Note the hexadecimal form is tried first: the hash name pattern would otherwise match `00:aa` of
`00:aa:bb:cc` and leave the remainder unparsed.

### The ssh2 suffix on unsuccessful authentication

`_SSHD_LOGIN` already expects `ssh2` after the port number. `_SSHD_FAILED_CONNECTION` ended at the
port, so it now accepts the same optional suffix. `test_data/syslog/syslog_ssh.log:6` is a record in
that form and has been in the repository since the file was added.

### User names

`_SSH_USERNAME` matched letters and digits. It is now determined by the text preceding ` from `,
since sshd logs the name as provided by the client, which is not limited to the characters
`useradd` accepts. Service and directory accounts commonly contain a hyphen, underscore or dot.

### Measured effect

Two `/var/log/auth.log` files from hosts either side of the OpenSSH 9.8 change, run through
`log2timeline.py` and `pinfo.py`:

| | before | after |
|---|---|---|
| Ubuntu 26.04, OpenSSH 10.2p1 | `syslog:line` 3,406 · `syslog:ssh:*` 0 | `syslog:line` 3,160 · `login` 240 · `failed_connection` 6 |
| Ubuntu 24.04, OpenSSH 9.6p1 | `syslog:line` 242 · `login` 1 | `syslog:line` 221 · `login` 17 · `failed_connection` 5 |

**Total event count is unchanged** in both cases, 3,409 and 246. No new timeline events are
produced; records that previously took the `syslog:line` path now take the SSH one.

Four tagging rules in `plaso/data/tag_linux.txt` that look for a reporter of `sshd` also apply again
on hosts running the current release.

### Backward compatibility

No attribute is removed or renamed and no new data type is added; the three existing SSH data types
are reused, so their formatter and timeliner entries are unchanged. The colon separated hexadecimal
fingerprint form and the unsuffixed unsuccessful form both still parse, and
`tests/parsers/text_plugins/syslog.py` asserts on records of each.

The verification grammar is untouched, so the plugins claim exactly the same files.

### Test data

`test_data/syslog/syslog_sshd_session.log` — eight records from a Fedora 44 host running OpenSSH
10.2p1, covering the per-session reporter, a base64 fingerprint, user names containing a hyphen, a
dot and an underscore, unsuccessful authentication with the `ssh2` suffix, and two messages the
structures do not define, which are retained as `syslog:line`.

`testProcessSshd` now also asserts on the two records of `syslog_ssh.log` described above, which
were counted but not previously inspected.

### Points left open in #5183

These are the questions from the issue. I have taken the smallest option in each case and am happy
to change any of them.

- **The fingerprint attribute** is kept as a single value, matching how it is stored today, rather
  than splitting out the key type and hash name.
- **Unsuccessful authentication for accounts that do not exist**, written as `Failed password for
  invalid user …`, is not covered here; it fits with the group of messages I offered to raise
  separately.
- **The reporter name** is handled by an alternation rather than by normalising the name first,
  since normalising would change how every reporter is dispatched.
- **No extraction warning** is produced when an SSH message does not match. On the hosts I measured,
  around 40% of the messages are ones the structures do not define at all, so a warning for each
  would be a large volume for something that is not an error.

## Checklist:
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated.
* [x] Test data has a Plaso compatible license. If the test data was not authored by you (the contributor), make sure to mention its original source in ACKNOWLEDGEMENTS.
* [x] Reviewer assigned.
* [x] Automated checks (GitHub Actions, AppVeyor) pass.
