### PR TITLE
Extend JSON output with fallback hostname and username

### DIFF
--- a/docs/sources/user/Output-and-formatting.md
+++ b/docs/sources/user/Output-and-formatting.md
@@ -81,12 +81,14 @@ Name | Description
 --- | ---
 display_name | Human readable representation of the path specification
 filename | The "filename" attribute if present in the event data. Will fallback to the filename derived from the event data stream path specification, if the option "--output-fallback-path" is enabled.
+hostname | The "hostname" attribute if present in the event data. Will fallback to the hostname derived by pre-processing, if the option "--output-fallback-hostname" is enabled. Omitted when no value can be resolved.
 inode | The "inode" attribute if present in the event data. Will fallback to the file system identifier (such as inode, MFT entry) derived from the event data stream path specification, if the option "--output-fallback-path" is enabled.
 message | The event message string as defined by the message formatter
 pathspec | JSON serialized path specification
 parser | Chain of parsers that generated the event.
 tag | The labels defined by event tags
 timestamp_desc | Indication of what the event time represents such as Creation Time or Program Execution Duration
+username | The "username" attribute if present in the event data. Will fallback to trying to resolve the username based on the "user_sid" attribute and user accounts derived by pre-processing. Omitted when no value can be resolved.
 
 ### Native (or "raw") Python runtime fields
 

--- a/plaso/output/shared_json.py
+++ b/plaso/output/shared_json.py
@@ -223,7 +223,7 @@ class SharedJSONOutputModule(text_file.TextFileOutputModule):
         # Use the output mediator to resolve hostname and username fields, similar to
         # dynamic output. In contrast to dynamic output do not default to "-"
         # placeholder.
-        
+
         hostname = output_mediator.GetHostname(event_data, default_hostname="")
         if hostname:
             field_values["hostname"] = hostname

--- a/plaso/output/shared_json.py
+++ b/plaso/output/shared_json.py
@@ -225,8 +225,16 @@ class SharedJSONOutputModule(text_file.TextFileOutputModule):
         # output is consistent with the dynamic output: events without their own
         # hostname/username attribute (for example filesystem events) then carry
         # the preprocessing-resolved value when --output_fallback_hostname is set.
-        field_values["hostname"] = output_mediator.GetHostname(event_data)
-        field_values["username"] = output_mediator.GetUsername(event_data)
+        # Only a resolved, non-placeholder value is added, so records are not
+        # bloated with "-" when nothing can be resolved, and a value the event
+        # already carries is never replaced by the placeholder.
+        hostname = output_mediator.GetHostname(event_data, default_hostname="")
+        if hostname:
+            field_values["hostname"] = hostname
+
+        username = output_mediator.GetUsername(event_data, default_username="")
+        if username:
+            field_values["username"] = username
 
         if event_tag:
             event_tag_values = {

--- a/plaso/output/shared_json.py
+++ b/plaso/output/shared_json.py
@@ -220,6 +220,14 @@ class SharedJSONOutputModule(text_file.TextFileOutputModule):
         field_values["message"] = self._field_formatting_helper.GetFormattedField(
             output_mediator, "message", event, event_data, event_data_stream, event_tag
         )
+
+        # Resolve hostname and username through the output mediator, so JSON
+        # output is consistent with the dynamic output: events without their own
+        # hostname/username attribute (for example filesystem events) then carry
+        # the preprocessing-resolved value when --output_fallback_hostname is set.
+        field_values["hostname"] = output_mediator.GetHostname(event_data)
+        field_values["username"] = output_mediator.GetUsername(event_data)
+
         if event_tag:
             event_tag_values = {
                 "__container_type__": "event_tag",

--- a/plaso/output/shared_json.py
+++ b/plaso/output/shared_json.py
@@ -220,14 +220,10 @@ class SharedJSONOutputModule(text_file.TextFileOutputModule):
         field_values["message"] = self._field_formatting_helper.GetFormattedField(
             output_mediator, "message", event, event_data, event_data_stream, event_tag
         )
-
-        # Resolve hostname and username through the output mediator, so JSON
-        # output is consistent with the dynamic output: events without their own
-        # hostname/username attribute (for example filesystem events) then carry
-        # the preprocessing-resolved value when --output_fallback_hostname is set.
-        # Only a resolved, non-placeholder value is added, so records are not
-        # bloated with "-" when nothing can be resolved, and a value the event
-        # already carries is never replaced by the placeholder.
+        # Use the output mediator to resolve hostname and username fields, similar to
+        # dynamic output. In contrast to dynamic output do not default to "-"
+        # placeholder.
+        
         hostname = output_mediator.GetHostname(event_data, default_hostname="")
         if hostname:
             field_values["hostname"] = hostname

--- a/tests/output/shared_json.py
+++ b/tests/output/shared_json.py
@@ -8,8 +8,11 @@ import unittest
 from dfvfs.lib import definitions as dfvfs_definitions
 from dfvfs.path import factory as path_spec_factory
 
+from plaso.containers import artifacts
 from plaso.lib import definitions
+from plaso.output import mediator
 from plaso.output import shared_json
+from plaso.storage.fake import writer as fake_writer
 
 from tests import test_lib as shared_test_lib
 from tests.containers import test_lib as containers_test_lib
@@ -108,6 +111,49 @@ class SharedJSONOutputModuleTest(test_lib.OutputModuleTestCase):
             output_mediator, event, event_data, event_data_stream, None
         )
         self.assertEqual(field_values, expected_field_values)
+
+    def testGetFieldValuesWithFallbackHostname(self):
+        """Tests the GetFieldValues function with a fallback hostname."""
+        system_configuration = artifacts.SystemConfigurationArtifact()
+        system_configuration.hostname = artifacts.HostnameArtifact(name="myhost")
+
+        storage_writer = fake_writer.FakeStorageWriter()
+        storage_writer.Open()
+
+        try:
+            storage_writer.AddAttributeContainer(system_configuration)
+
+            output_mediator = mediator.OutputMediator(
+                storage_writer, use_fallback_hostname=True
+            )
+
+            formatters_directory_path = self._GetTestFilePath(["formatters"])
+            output_mediator.ReadMessageFormattersFromDirectory(
+                formatters_directory_path
+            )
+
+            output_module = shared_json.SharedJSONOutputModule()
+
+            event, event_data, event_data_stream = (
+                containers_test_lib.CreateEventFromValues(self._TEST_EVENTS[0])
+            )
+
+            # An event without its own hostname or username: the preprocessing
+            # resolved hostname is used as a fallback, and the username stays
+            # unresolved and is therefore omitted rather than padded.
+            event_data.hostname = None
+            event_data.username = None
+
+            field_values = output_module.GetFieldValues(
+                output_mediator, event, event_data, event_data_stream, None
+            )
+            self.assertEqual(field_values["hostname"], "myhost")
+            # The username cannot be resolved, so it is omitted rather than
+            # padded with the "-" placeholder.
+            self.assertNotEqual(field_values.get("username"), "-")
+
+        finally:
+            storage_writer.Close()
 
 
 if __name__ == "__main__":

--- a/tests/output/shared_json.py
+++ b/tests/output/shared_json.py
@@ -144,7 +144,7 @@ class SharedJSONOutputModuleTest(test_lib.OutputModuleTestCase):
             # The preprocessing resolved hostname is used as a fallback, and
             # the username stays unresolved. It is omitted rather substituted
             # with a placeholder.
-            
+
             self.assertEqual(field_values["hostname"], "myhost")
             self.assertNotIn("username", field_values)
 

--- a/tests/output/shared_json.py
+++ b/tests/output/shared_json.py
@@ -126,31 +126,27 @@ class SharedJSONOutputModuleTest(test_lib.OutputModuleTestCase):
             output_mediator = mediator.OutputMediator(
                 storage_writer, use_fallback_hostname=True
             )
-
             formatters_directory_path = self._GetTestFilePath(["formatters"])
             output_mediator.ReadMessageFormattersFromDirectory(
                 formatters_directory_path
             )
-
             output_module = shared_json.SharedJSONOutputModule()
 
             event, event_data, event_data_stream = (
                 containers_test_lib.CreateEventFromValues(self._TEST_EVENTS[0])
             )
-
-            # An event without its own hostname or username: the preprocessing
-            # resolved hostname is used as a fallback, and the username stays
-            # unresolved and is therefore omitted rather than padded.
             event_data.hostname = None
             event_data.username = None
 
             field_values = output_module.GetFieldValues(
                 output_mediator, event, event_data, event_data_stream, None
             )
+            # The preprocessing resolved hostname is used as a fallback, and
+            # the username stays unresolved. It is omitted rather substituted
+            # with a placeholder.
+            
             self.assertEqual(field_values["hostname"], "myhost")
-            # The username cannot be resolved, so it is omitted rather than
-            # padded with the "-" placeholder.
-            self.assertNotEqual(field_values.get("username"), "-")
+            self.assertNotIn("username", field_values)
 
         finally:
             storage_writer.Close()


### PR DESCRIPTION
## One line description of pull request

Resolve hostname and username in JSON output like the dynamic output.

## Description:

The `dynamic` output resolves `hostname`/`username` through the output mediator (`GetHostname`/`GetUsername`), so with `--output_fallback_hostname` every event — including filesystem events with no `hostname` attribute of their own — gets the preprocessing-resolved value (registry ComputerName / `/etc/hostname`, from `system_configuration`).

The JSON output (`json_line`, `json`) did not call the mediator in `SharedJSONOutputModule.GetFieldValues`, so those events carried no hostname even though the storage held a resolved `system_configuration.hostname`. This resolves both fields there, making JSON output consistent with `dynamic`. `GetHostname`/`GetUsername` return the event's own value when present, so events that already carry a `hostname`/`username` (syslog, utmp, …) are unchanged; only events lacking one gain the fallback.

Verified on a freely-licensed public image — the **DFRWS 2021 Challenge** Raspberry Pi microSD (`2_Raspberry_Pi_mSD`, host `octopi`), from Digital Corpora (https://digitalcorpora.s3.amazonaws.com/corpora/dfrws/challenge-2021/2_Raspberry_Pi_mSD.zip): `dynamic --output_fallback_hostname` resolves `hostname=octopi` on all ~346k events including `fs:stat`, while `json_line --output_fallback_hostname` leaves those host-less despite the `.plaso` holding `system_configuration.hostname = octopi`.

**Related issue (if applicable):** fixes #5195

## Notes:

Existing `tests/output/shared_json.py::testGetFieldValues` exercises an event that already carries `hostname`/`username`, which is unchanged by this patch. Happy to add a test case covering the `--output_fallback_hostname` fallback path for an event without its own hostname — pointers to the preferred fixture/setup welcome.

## Checklist:
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated.
* [x] Test data has a Plaso compatible license. This PR adds no test data; the reproduction/validation image is the publicly released DFRWS 2021 Challenge Raspberry Pi image from Digital Corpora (https://digitalcorpora.s3.amazonaws.com/corpora/dfrws/challenge-2021/2_Raspberry_Pi_mSD.zip).
* [x] Reviewer assigned.
* [x] Automated checks (GitHub Actions, AppVeyor) pass.