### PR TITLE
Add ESXi log parser

### DIFF
--- a/docs/sources/user/Parsers-and-plugins.md
+++ b/docs/sources/user/Parsers-and-plugins.md
@@ -214,6 +214,7 @@ bitbucket_audit | Parser for Atlassian Bitbucket audit log (atlassian-bitbucket-
 confluence_access | Parser for Confluence access log (access.log) files.
 cri_log | Parser for Container Runtime Interface log files.
 dpkg | Parser for Debian package manager log (dpkg.log) files.
+esxi_log | Parser for VMware ESXi log files.
 gdrive_synclog | Parser for Google Drive Sync log files.
 googlelog | Parser for Google-formatted log files.
 ios_lockdownd | Parser for iOS lockdown daemon log.

--- a/docs/sources/user/Users-Guide.md
+++ b/docs/sources/user/Users-Guide.md
@@ -67,7 +67,7 @@ To follow announcements from the Plaso team or send in generic inquiries or
 discuss the tool:
 
 * subscribe to the [log2timeline-discuss](https://groups.google.com/forum/#!forum/log2timeline-discuss) mailing list.
-* join the Plaso channel part of the [open-source-dfir Slack community](https://open-source-dfir.slack.com/), more information can be found [here](https://github.com/open-source-dfir/slack).
+* join the Plaso channel in the open-source-dfir Slack community. See the [community joining instructions](https://github.com/open-source-dfir/slack) for details.
 
 Please be mindful of people's time:
 

--- a/plaso/data/formatters/generic.yaml
+++ b/plaso/data/formatters/generic.yaml
@@ -234,6 +234,21 @@ short_source: 'CRI'
 source: 'Container Runtime Interface Container Log'
 ---
 type: 'conditional'
+data_type: 'vmware:esxi:log:entry'
+message:
+- 'Component: {component}'
+- 'PID: {process_identifier}'
+- 'Severity: {severity}'
+- 'Hostname: {hostname}'
+- 'Priority: {syslog_priority}'
+- 'Message: {message_body}'
+short_message:
+- '{component}'
+- '{message_body}'
+short_source: 'ESXI'
+source: 'VMware ESXi Log'
+---
+type: 'conditional'
 data_type: 'cups:ipp:event'
 message:
 - 'Status: {status}'

--- a/plaso/data/timeliner.yaml
+++ b/plaso/data/timeliner.yaml
@@ -347,6 +347,12 @@ attribute_mappings:
   description: 'Content Modification Time'
 place_holder_event: true
 ---
+data_type: 'vmware:esxi:log:entry'
+attribute_mappings:
+- name: 'written_time'
+  description: 'Entry Written Time'
+place_holder_event: true
+---
 data_type: 'cups:ipp:event'
 attribute_mappings:
 - name: 'creation_time'

--- a/plaso/parsers/text_plugins/__init__.py
+++ b/plaso/parsers/text_plugins/__init__.py
@@ -13,6 +13,7 @@ from plaso.parsers.text_plugins import bitbucket_audit
 from plaso.parsers.text_plugins import confluence_access
 from plaso.parsers.text_plugins import cri
 from plaso.parsers.text_plugins import dpkg
+from plaso.parsers.text_plugins import esxi
 from plaso.parsers.text_plugins import gdrive_synclog
 from plaso.parsers.text_plugins import google_logging
 from plaso.parsers.text_plugins import iis

--- a/plaso/parsers/text_plugins/esxi.py
+++ b/plaso/parsers/text_plugins/esxi.py
@@ -1,9 +1,4 @@
-"""Text file parser plugin for VMware ESXi log files.
-
-Also see:
-  https://knowledge.broadcom.com/external/article/306962
-  https://github.com/strozfriedberg/qelp/blob/main/src/qelp/esxi_to_csv.py
-"""
+"""Text file parser plugin for VMware ESXi log files."""
 
 import re
 

--- a/plaso/parsers/text_plugins/esxi.py
+++ b/plaso/parsers/text_plugins/esxi.py
@@ -1,0 +1,208 @@
+"""Text file parser plugin for VMware ESXi log files.
+
+Also see:
+  https://knowledge.broadcom.com/external/article/306962
+  https://github.com/strozfriedberg/qelp/blob/main/src/qelp/esxi_to_csv.py
+"""
+
+import re
+
+from dfdatetime import time_elements
+
+import pyparsing
+
+from plaso.containers import events
+from plaso.lib import errors
+from plaso.parsers import text_parser
+from plaso.parsers.text_plugins import interface
+
+
+class ESXiLogEventData(events.EventData):
+    """VMware ESXi log event data.
+
+    Attributes:
+      component (str): component that generated the log entry.
+      hostname (str): hostname of the ESXi system.
+      message_body (str): message body.
+      process_identifier (str): process identifier.
+      severity (str): severity indicator.
+      syslog_priority (str): syslog priority value.
+      written_time (dfdatetime.DateTimeValues): date and time the log entry was
+          written.
+    """
+
+    DATA_TYPE = "vmware:esxi:log:entry"
+
+    def __init__(self):
+        """Initializes event data."""
+        super().__init__(data_type=self.DATA_TYPE)
+        self.component = None
+        self.hostname = None
+        self.message_body = None
+        self.process_identifier = None
+        self.severity = None
+        self.syslog_priority = None
+        self.written_time = None
+
+
+class ESXiLogTextPlugin(interface.TextPluginWithLineContinuation):
+    """Text file parser plugin for VMware ESXi log files."""
+
+    NAME = "esxi_log"
+    DATA_FORMAT = "VMware ESXi log file"
+
+    ENCODING = "utf-8"
+
+    _COMPONENTS = "auth|esxcli|hostd|rhttpproxy|shell|syslog|vmauthd|vmkernel|vobd|vpxa"
+    _DATE_TIME = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z"
+    _SEVERITY = r"\w+(?:\(\d+\))?"
+
+    # Legacy hostd line, for example:
+    # [2008-05-07 09:50:04.857 'SOAP' 2260 trivia] Received soap response
+    _LEGACY_HOSTD_LINE = pyparsing.Regex(
+        r"^\[(?P<date_time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)?) "
+        r"'(?P<component>[^']+)' (?P<process_identifier>\d+) "
+        r"(?P<severity>\w+)\]\s*(?P<message_body>.*)$",
+        flags=re.MULTILINE,
+    ) + pyparsing.Suppress(pyparsing.LineEnd())
+
+    # Remote syslog line, for example:
+    # <166>2019-05-21T19:27:32.479Z esxi.example Hostd: info hostd[123] ...
+    _REMOTE_SYSLOG_LINE = pyparsing.Regex(
+        rf"^<(?P<syslog_priority>\d+)>(?P<date_time>{_DATE_TIME}) "
+        rf"(?P<hostname>\S+) (?P<relay_component>\w+): "
+        rf"(?P<severity>{_SEVERITY}) (?P<component>{_COMPONENTS})"
+        r"(?:\[(?P<process_identifier>\d+)\])?[ :]\s*(?P<message_body>.*)$",
+        flags=re.IGNORECASE | re.MULTILINE,
+    ) + pyparsing.Suppress(pyparsing.LineEnd())
+
+    # Userworld line with severity, for example:
+    # 2021-01-04T16:02:17.168Z info hostd[123] ...
+    _USERWORLD_LINE = pyparsing.Regex(
+        rf"^(?P<date_time>{_DATE_TIME}) (?P<severity>{_SEVERITY}) "
+        rf"(?P<component>{_COMPONENTS})"
+        r"(?:\[(?P<process_identifier>\d+)\])?[ :]\s*(?P<message_body>.*)$",
+        flags=re.IGNORECASE | re.MULTILINE,
+    ) + pyparsing.Suppress(pyparsing.LineEnd())
+
+    # VMkernel and similar component line, for example:
+    # 2024-03-12T07:48:40.079Z In(182) vmkernel: ...
+    _KERNEL_LINE = pyparsing.Regex(
+        rf"^(?P<date_time>{_DATE_TIME}) (?P<severity>{_SEVERITY}) "
+        rf"(?P<component>{_COMPONENTS}):\s*(?P<message_body>.*)$",
+        flags=re.IGNORECASE | re.MULTILINE,
+    ) + pyparsing.Suppress(pyparsing.LineEnd())
+
+    # Shell line without severity, for example:
+    # 2024-12-12T01:44:43.728Z shell[123]: [root]: ls -la
+    _SHELL_LINE = pyparsing.Regex(
+        rf"^(?P<date_time>{_DATE_TIME}) (?P<component>shell)"
+        r"\[(?P<process_identifier>\d+)\]:\s*(?P<message_body>.*)$",
+        flags=re.IGNORECASE | re.MULTILINE,
+    ) + pyparsing.Suppress(pyparsing.LineEnd())
+
+    _LINE_STRUCTURES = [
+        ("legacy_hostd_line", _LEGACY_HOSTD_LINE),
+        ("remote_syslog_line", _REMOTE_SYSLOG_LINE),
+        ("userworld_line", _USERWORLD_LINE),
+        ("kernel_line", _KERNEL_LINE),
+        ("shell_line", _SHELL_LINE),
+    ]
+
+    VERIFICATION_GRAMMAR = (
+        _LEGACY_HOSTD_LINE
+        ^ _REMOTE_SYSLOG_LINE
+        ^ _USERWORLD_LINE
+        ^ _KERNEL_LINE
+        ^ _SHELL_LINE
+    )
+
+    def __init__(self):
+        """Initializes a text parser plugin."""
+        super().__init__()
+        self._event_data = None
+        self._message_body_lines = None
+
+    def _ParseFinalize(self, parser_mediator):
+        """Finalizes parsing.
+
+        Args:
+          parser_mediator (ParserMediator): parser mediator.
+        """
+        if self._event_data:
+            self._event_data.message_body = "\n".join(self._message_body_lines)
+            parser_mediator.ProduceEventData(self._event_data)
+
+        self._event_data = None
+        self._message_body_lines = None
+
+    def _ParseRecord(self, parser_mediator, key, structure):
+        """Parses a pyparsing structure.
+
+        Args:
+          parser_mediator (ParserMediator): parser mediator.
+          key (str): name of the parsed structure.
+          structure (pyparsing.ParseResults): tokens from a parsed log line.
+        """
+        if key == "_line_continuation":
+            if self._message_body_lines is not None:
+                self._message_body_lines.append(structure.strip())
+            return
+
+        if self._event_data:
+            self._event_data.message_body = "\n".join(self._message_body_lines)
+            parser_mediator.ProduceEventData(self._event_data)
+
+        date_time_string = self._GetValueFromStructure(structure, "date_time")
+        date_time = time_elements.TimeElementsInMicroseconds()
+        if key == "legacy_hostd_line":
+            date_time.CopyFromDateTimeString(date_time_string)
+            date_time.is_local_time = True
+        else:
+            date_time.CopyFromStringISO8601(date_time_string)
+
+        event_data = ESXiLogEventData()
+        event_data.component = self._GetValueFromStructure(structure, "component")
+        event_data.hostname = self._GetValueFromStructure(structure, "hostname")
+        event_data.process_identifier = self._GetValueFromStructure(
+            structure, "process_identifier"
+        )
+        event_data.severity = self._GetValueFromStructure(structure, "severity")
+        event_data.syslog_priority = self._GetValueFromStructure(
+            structure, "syslog_priority"
+        )
+        event_data.written_time = date_time
+
+        message_body = self._GetValueFromStructure(structure, "message_body")
+        self._event_data = event_data
+        self._message_body_lines = [message_body]
+
+    def CheckRequiredFormat(self, parser_mediator, text_reader):
+        """Checks if the log has the minimal structure required by the plugin.
+
+        Args:
+          parser_mediator (ParserMediator): parser mediator.
+          text_reader (EncodedTextReader): text reader.
+
+        Returns:
+          bool: True if this is the correct plugin, False otherwise.
+        """
+        try:
+            structure = self._VerifyString(text_reader.lines)
+        except errors.ParseError:
+            return False
+
+        date_time_string = self._GetValueFromStructure(structure, "date_time")
+        try:
+            date_time = time_elements.TimeElementsInMicroseconds()
+            if date_time_string.endswith("Z"):
+                date_time.CopyFromStringISO8601(date_time_string)
+            else:
+                date_time.CopyFromDateTimeString(date_time_string)
+        except ValueError:
+            return False
+
+        return True
+
+
+text_parser.TextLogParser.RegisterPlugin(ESXiLogTextPlugin)

--- a/test_data/esxi.log
+++ b/test_data/esxi.log
@@ -1,0 +1,11 @@
+2024-12-12T01:44:43.728Z shell[71435]: [root]: ls -la
+2024-03-12T07:48:40.079Z In(182) vmkernel: cpu21:2099003)<NMLX_ERR> attach failed
+2021-01-04T16:02:17.168Z info hostd[526501] [Originator@6876 sub=Libs user=root] New ERROR
+<166>2019-05-21T19:27:32.479Z esxi.example Hostd: info hostd[111111] [Originator@6876 user=root] logged out
+2024-12-12T01:45:05.064Z info auth[71470]: Session opened for user root
+2024-12-12T01:45:06.064Z info vobd[71471]: [UserLevelCorrelator] SSH access enabled
+2024-12-12T01:45:07.064Z info esxcli[71472]: system syslog mark --message=test
+2024-12-12T01:45:08.064Z info rhttpproxy[71473]: New proxy client
+2024-12-12T01:45:09.064Z info vpxa[71474]: Connected to hostd
+[2008-05-07 09:50:04.857 'SOAP' 2260 trivia] Received soap response
+POST /sdk HTTP/1.1

--- a/tests/parsers/text_plugins/esxi.py
+++ b/tests/parsers/text_plugins/esxi.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Tests for the VMware ESXi log text parser plugin."""
+
+import io
+import unittest
+
+from plaso.parsers import mediator as parsers_mediator
+from plaso.parsers import text_parser
+from plaso.parsers.text_plugins import esxi
+
+from tests.parsers.text_plugins import test_lib
+
+
+class ESXiLogTextPluginTest(test_lib.TextPluginTestCase):
+    """Tests for the VMware ESXi log text parser plugin."""
+
+    def testCheckRequiredFormat(self):
+        """Tests the CheckRequiredFormat method."""
+        plugin = esxi.ESXiLogTextPlugin()
+        parser_mediator = parsers_mediator.ParserMediator()
+
+        supported_lines = [
+            b"2024-12-12T01:44:43.728Z shell[71435]: [root]: ls -la\n",
+            b"2024-03-12T07:48:40.079Z In(182) vmkernel: message\n",
+            b"2021-01-04T16:02:17.168Z info hostd[526501] message\n",
+            b"<166>2019-05-21T19:27:32.479Z esxi.example Hostd: info "
+            b"hostd[111111] message\n",
+            b"[2008-05-07 09:50:04.857 'SOAP' 2260 trivia] message\n",
+        ]
+        for supported_line in supported_lines:
+            with self.subTest(supported_line=supported_line):
+                file_object = io.BytesIO(supported_line)
+                text_reader = text_parser.EncodedTextReader(file_object)
+                text_reader.ReadLines()
+
+                self.assertTrue(
+                    plugin.CheckRequiredFormat(parser_mediator, text_reader)
+                )
+
+        file_object = io.BytesIO(
+            b"2024-12-12T01:44:43.728Z example[71435]: not an ESXi log\n"
+        )
+        text_reader = text_parser.EncodedTextReader(file_object)
+        text_reader.ReadLines()
+
+        self.assertFalse(plugin.CheckRequiredFormat(parser_mediator, text_reader))
+
+    def testProcess(self):
+        """Tests the Process method."""
+        plugin = esxi.ESXiLogTextPlugin()
+        storage_writer = self._ParseTextFileWithPlugin(["esxi.log"], plugin)
+
+        number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
+            "event_data"
+        )
+        self.assertEqual(number_of_event_data, 10)
+
+        number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
+            "extraction_warning"
+        )
+        self.assertEqual(number_of_warnings, 0)
+
+        expected_event_values = {
+            "component": "shell",
+            "data_type": "vmware:esxi:log:entry",
+            "message_body": "[root]: ls -la",
+            "process_identifier": "71435",
+            "written_time": "2024-12-12T01:44:43.728000+00:00",
+        }
+        event_data = storage_writer.GetAttributeContainerByIndex("event_data", 0)
+        self.CheckEventData(event_data, expected_event_values)
+
+        expected_event_values = {
+            "component": "vmkernel",
+            "message_body": "cpu21:2099003)<NMLX_ERR> attach failed",
+            "severity": "In(182)",
+            "written_time": "2024-03-12T07:48:40.079000+00:00",
+        }
+        event_data = storage_writer.GetAttributeContainerByIndex("event_data", 1)
+        self.CheckEventData(event_data, expected_event_values)
+
+        expected_event_values = {
+            "component": "hostd",
+            "message_body": "[Originator@6876 sub=Libs user=root] New ERROR",
+            "process_identifier": "526501",
+            "severity": "info",
+        }
+        event_data = storage_writer.GetAttributeContainerByIndex("event_data", 2)
+        self.CheckEventData(event_data, expected_event_values)
+
+        expected_event_values = {
+            "component": "hostd",
+            "hostname": "esxi.example",
+            "process_identifier": "111111",
+            "severity": "info",
+            "syslog_priority": "166",
+        }
+        event_data = storage_writer.GetAttributeContainerByIndex("event_data", 3)
+        self.CheckEventData(event_data, expected_event_values)
+
+        expected_components = ["auth", "vobd", "esxcli", "rhttpproxy", "vpxa"]
+        for event_data_index, expected_component in enumerate(
+            expected_components, start=4
+        ):
+            event_data = storage_writer.GetAttributeContainerByIndex(
+                "event_data", event_data_index
+            )
+            self.assertEqual(event_data.component, expected_component)
+
+        expected_event_values = {
+            "component": "SOAP",
+            "message_body": "Received soap response\nPOST /sdk HTTP/1.1",
+            "process_identifier": "2260",
+            "severity": "trivia",
+            "written_time": "2008-05-07T09:50:04.857000",
+        }
+        event_data = storage_writer.GetAttributeContainerByIndex("event_data", 9)
+        self.CheckEventData(event_data, expected_event_values)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## One line description of pull request

Add a text parser plugin for modern and legacy VMware ESXi log formats.

## Description

This adds support for timeline extraction from VMware ESXi log files.

The parser supports:

- Modern ISO-8601-formatted ESXi log entries.
- Legacy bracketed `hostd` log entries.
- Remote-syslog-prefixed entries.
- Multiline log messages.
- Common ESXi components, including `auth`, `esxcli`, `hostd`,
  `rhttpproxy`, `shell`, `syslog`, `vmauthd`, `vmkernel`, `vobd`, and
  `vpxa`.

The following fields are extracted when available:

- Written time
- Component
- Process identifier
- Severity
- Hostname
- Syslog priority
- Message body

Format detection is restricted to known ESXi components to reduce false
positives.

This change also adds:

- Synthetic test data based on publicly documented ESXi log formats.
- Parser unit tests for supported and unsupported formats.
- Formatter and timeliner definitions.
- Parser registration and documentation.

The synthetic test data was created specifically for this change and
does not contain copied production data or sensitive information.

### Testing

```console
$ python tests/parsers/text_plugins/esxi.py
..
----------------------------------------------------------------------
Ran 2 tests

OK
```

```console
$ python tests/parsers/init_imports.py
..
----------------------------------------------------------------------
Ran 2 tests

OK
```

```console
$ python -m unittest discover -s tests/parsers/text_plugins -p '*.py'
...................................................................
----------------------------------------------------------------------
Ran 129 tests

OK
```

Black, docformatter, yamllint, pylint, and `git diff --check` also pass
locally.

**Related issue (if applicable):** Fixes #4972

## Notes

All contributions to Plaso undergo [code review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc).
This makes sure that the code has appropriate test coverage and conforms
with the [Plaso style guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine the code and may request changes.

## Checklist

- [x] No new dependencies are required.
- [x] Test data has a Plaso-compatible license. The synthetic test data
  was created specifically for this contribution.
- [x] Reviewer assigned.
- [x] Automated checks (GitHub Actions, AppVeyor) pass.