### PR TITLE
Fix crashes in pinfo related to warning 

### DIFF
--- a/plaso/cli/pinfo_tool.py
+++ b/plaso/cli/pinfo_tool.py
@@ -1520,7 +1520,7 @@ class PinfoTool(tools.CLITool, tool_options.StorageFileOptions):
         for key, count_container in sorted(warnings_by_path_spec.items()):
             if write_comma:
                 self._output_writer.Write(", ")
-
+            key = key.replace('\n', '\\n')
             self._output_writer.Write(
                 f'"{key:s}": {count_container.number_of_events:d}'
             )

--- a/plaso/cli/pinfo_tool.py
+++ b/plaso/cli/pinfo_tool.py
@@ -1520,7 +1520,7 @@ class PinfoTool(tools.CLITool, tool_options.StorageFileOptions):
         for key, count_container in sorted(warnings_by_path_spec.items()):
             if write_comma:
                 self._output_writer.Write(", ")
-            key = key.replace('\n', '\\n')
+            key = key.replace("\n", "\\n")
             self._output_writer.Write(
                 f'"{key:s}": {count_container.number_of_events:d}'
             )

--- a/plaso/cli/tools.py
+++ b/plaso/cli/tools.py
@@ -159,7 +159,7 @@ class CLITool:
         return "\n".join(
             [
                 line.translate(definitions.NON_PRINTABLE_CHARACTER_TRANSLATION_TABLE)
-                for line in path_spec.comparable.split("\n")
+                for line in path_spec.comparable.split("\n") if line
             ]
         )
 

--- a/plaso/cli/tools.py
+++ b/plaso/cli/tools.py
@@ -159,7 +159,8 @@ class CLITool:
         return "\n".join(
             [
                 line.translate(definitions.NON_PRINTABLE_CHARACTER_TRANSLATION_TABLE)
-                for line in path_spec.comparable.split("\n") if line
+                for line in path_spec.comparable.split("\n")
+                if line
             ]
         )
 

--- a/plaso/containers/counts.py
+++ b/plaso/containers/counts.py
@@ -1,4 +1,5 @@
 """Count related attribute container definitions."""
+
 from functools import total_ordering
 
 from acstore.containers import interface

--- a/plaso/containers/counts.py
+++ b/plaso/containers/counts.py
@@ -1,4 +1,5 @@
 """Count related attribute container definitions."""
+from functools import total_ordering
 
 from acstore.containers import interface
 from acstore.containers import manager
@@ -78,8 +79,7 @@ class ParserCount(interface.AttributeContainer):
         super().__init__()
         self.name = name
         self.number_of_events = number_of_events
-
-
+@total_ordering
 class WarningCount(interface.AttributeContainer):
     """Warning count attribute container.
 
@@ -101,6 +101,19 @@ class WarningCount(interface.AttributeContainer):
         """
         super().__init__()
         self.number_of_events = number_of_events
+
+    def _is_valid_operand(self, other):
+        return hasattr(other, "number_of_events")
+
+    def __eq__(self, other):
+        if not self._is_valid_operand(other):
+            return NotImplemented
+        return self.number_of_events == other.number_of_events
+
+    def __lt__(self, other):
+        if not self._is_valid_operand(other):
+            return NotImplemented
+        return self.number_of_events < other.number_of_events
 
 
 manager.AttributeContainersManager.RegisterAttributeContainers(

--- a/plaso/containers/counts.py
+++ b/plaso/containers/counts.py
@@ -80,6 +80,7 @@ class ParserCount(interface.AttributeContainer):
         self.name = name
         self.number_of_events = number_of_events
 
+
 @total_ordering
 class WarningCount(interface.AttributeContainer):
     """Warning count attribute container.

--- a/plaso/containers/counts.py
+++ b/plaso/containers/counts.py
@@ -79,6 +79,7 @@ class ParserCount(interface.AttributeContainer):
         super().__init__()
         self.name = name
         self.number_of_events = number_of_events
+
 @total_ordering
 class WarningCount(interface.AttributeContainer):
     """Warning count attribute container.

--- a/plaso/multi_process/extraction_engine.py
+++ b/plaso/multi_process/extraction_engine.py
@@ -709,7 +709,7 @@ class ExtractionMultiProcessEngine(task_engine.TaskMultiProcessEngine):
         Raises:
           RuntimeError: when storage writer is not set.
         """
-        warning = warnings.ExtractionWarning(message=message, path_spec=path_spec)
+        warning = warnings.ExtractionWarning(message=message, parser_chain="extraction_engine", path_spec=path_spec)
         storage_writer.AddAttributeContainer(warning)
 
         if path_spec:

--- a/plaso/multi_process/extraction_engine.py
+++ b/plaso/multi_process/extraction_engine.py
@@ -709,7 +709,9 @@ class ExtractionMultiProcessEngine(task_engine.TaskMultiProcessEngine):
         Raises:
           RuntimeError: when storage writer is not set.
         """
-        warning = warnings.ExtractionWarning(message=message, parser_chain="extraction_engine", path_spec=path_spec)
+        warning = warnings.ExtractionWarning(
+            message=message, parser_chain="extraction_engine", path_spec=path_spec
+        )
         storage_writer.AddAttributeContainer(warning)
 
         if path_spec:

--- a/plaso/parsers/plist.py
+++ b/plaso/parsers/plist.py
@@ -176,6 +176,7 @@ class PlistParser(interface.FileObjectParser):
                         f"plugin: {plugin_name:s} unable to parse plist file with "
                         f"error: {exception!s}"
                     )
+                    required_format = None
 
             finally:
                 parser_mediator.SampleFormatCheckStopTiming(profiling_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=77.0.3", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77.0.3", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION

## One line description of pull request

Fix multiple little issues related to warning that create crashes when pinfo is used on storage files with some warning raised during processing.

## Description:


* Allows comparison between WarningCount instance to prevent crash with text/markdown output. Text/mardown output use a Counter with WarningCount inside, but no comparison operator were defined between WarningCount, thus making the code crash when using the Counter.most_common function that need to sort Counter object. In addition similar issue will occur if some other Counter methore are used, e.g Counter.total (__add__ is undefined)
* Fix `unable to process path specification with error: local variable 'required_format' referenced before assignment` in plist plugin. (it's more that I had the issue under my eyes will debugging so I fix it) : assign variable that was only defined in the try part of a try catch.
* Fix json output formation : strip '\n' add the end of the path_spec, and escape '\n' when rendering json.
* Define a parser chain in multiprocess extraction engine. As the parse chain was None, this cause crash when using pinfo (unsupported operator between None and string +, and fail to format the value as a string. Cf. [pinfo_tool.py#L1520](https://github.com/log2timeline/plaso/blob/09266eff829982ecdecda743df90eda59bd43626/plaso/cli/pinfo_tool.py#L1520)). It's looks like than in single process mode, no warning is generated.

## Notes:

Also bumped the minimal setuptools supported version to [77,](https://setuptools.pypa.io/en/stable/history.html#v77-0-0) which is the one that introduce support to license as string, as defined in the project.tom. Using a version below cause an error (and by error, I means impossible to run any test, a setup tool crash).


Regarding test I'm not sure how it would be the more maintainable.
1st option is to generate a plaso storage file with some warning and add some test based on this file. But this may cause issue when storage format change
2nd option is to dynamically generate a plaso storage file with some warnings, but the test may start to fail it these warning are fixed. Furthermore there is no end2end to for psort, but it may be in the scope of this PR to add support for pinfo e2e test and prevent future similar errors.


Do you have any preference?

## Checklist:
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated.
* [x] Test data has a Plaso compatible license. If the test data was not authored by you (the contributor), make sure to mention its original source in ACKNOWLEDGEMENTS.
* [x] Reviewer assigned.
* [ ] Automated checks (GitHub Actions, AppVeyor) pass.
