### PR TITLE
Add scoped IPv6 support to IIS parser

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,7 +97,6 @@ linkcheck_ignore = [
     "https://docs.github.com/.*",
     "https://github.com/libyal/libsigscan/wiki/Internals#",
     "https://github.com/log2timeline/dfvfs/wiki#",
-    "https://open-source-dfir.slack.com/.*",
     "https://groups.google.com/forum/#",
     "https://developers.virustotal.com/reference#",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,7 @@ linkcheck_ignore = [
     "https://docs.github.com/.*",
     "https://github.com/libyal/libsigscan/wiki/Internals#",
     "https://github.com/log2timeline/dfvfs/wiki#",
+    "https://open-source-dfir.slack.com/.*",
     "https://groups.google.com/forum/#",
     "https://developers.virustotal.com/reference#",
 ]

--- a/plaso/parsers/text_plugins/iis.py
+++ b/plaso/parsers/text_plugins/iis.py
@@ -94,12 +94,18 @@ class WinIISTextPlugin(interface.TextPlugin):
     _FOUR_DIGITS = pyparsing.Word(pyparsing.nums, exact=4).set_parse_action(
         lambda tokens: int(tokens[0], 10)
     )
-
+    
+    # An IPv6 address can have a zone index suffix (RFC 4007), such as "%3" or
+    # "%eth0".
+    _IPV6_ZONE_INDEX = pyparsing.Combine(
+        pyparsing.Literal("%") + pyparsing.Word(pyparsing.alphanums + ".-_")
+    )
+    
     _IP_ADDRESS = (
         pyparsing.pyparsing_common.ipv4_address
         | pyparsing.Combine(
             pyparsing.pyparsing_common.ipv6_address
-            + pyparsing.Optional("%" + pyparsing.Word(pyparsing.alphanums + "_.-"))
+            + pyparsing.Optional(_IPV6_ZONE_INDEX)
         )
         | _BLANK
     )

--- a/plaso/parsers/text_plugins/iis.py
+++ b/plaso/parsers/text_plugins/iis.py
@@ -94,13 +94,13 @@ class WinIISTextPlugin(interface.TextPlugin):
     _FOUR_DIGITS = pyparsing.Word(pyparsing.nums, exact=4).set_parse_action(
         lambda tokens: int(tokens[0], 10)
     )
-    
+
     # An IPv6 address can have a zone index suffix (RFC 4007), such as "%3" or
     # "%eth0".
     _IPV6_ZONE_INDEX = pyparsing.Combine(
         pyparsing.Literal("%") + pyparsing.Word(pyparsing.alphanums + ".-_")
     )
-    
+
     _IP_ADDRESS = (
         pyparsing.pyparsing_common.ipv4_address
         | pyparsing.Combine(

--- a/plaso/parsers/text_plugins/iis.py
+++ b/plaso/parsers/text_plugins/iis.py
@@ -97,7 +97,10 @@ class WinIISTextPlugin(interface.TextPlugin):
 
     _IP_ADDRESS = (
         pyparsing.pyparsing_common.ipv4_address
-        | pyparsing.pyparsing_common.ipv6_address
+        | pyparsing.Combine(
+            pyparsing.pyparsing_common.ipv6_address
+            + pyparsing.Optional("%" + pyparsing.Word(pyparsing.alphanums + "_.-"))
+        )
         | _BLANK
     )
 

--- a/test_data/iis/iis10_edge_cases.log
+++ b/test_data/iis/iis10_edge_cases.log
@@ -17,3 +17,4 @@
 2022-01-01 00:01:24 ::1 POST /powershell clientApplication=ActiveMonitor;PSVersion=5.1.14393.4467 444  random/ranuser1 ::1 Microsoft+WinRM+Client - 200 0 0 15
 2022-01-01 00:01:24 ::1 POST /powershell clientApplication=ActiveMonitor;PSVersion=5.1.14393.4467 444  ranuser1@random ::1 Microsoft+WinRM+Client - 200 0 0 15
 2022-01-01 00:01:24 ::1 POST /powershell clientApplication=ActiveMonitor;PSVersion=5.1.14393.4467 444  random\ranuser1 ::1 Mozilla/5.0+(Linux;+Android+5.0;+SM-G900P+Build/LRX21T;+wv)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Version/4.0+Chrome/43.0.2357.121+Mobile+Safari/537.36+[FB_IAB/FB4A;FBAV/35.0.0.48.273;] - 200 0 0 15
+2022-01-01 00:01:24 fe80::1ff:fe23:4567:890a%3 POST /powershell clientApplication=ActiveMonitor;PSVersion=5.1.14393.4467 444 random\ranuser1 ::1 Microsoft+WinRM+Client - 200 0 0 15

--- a/tests/parsers/text_plugins/iis.py
+++ b/tests/parsers/text_plugins/iis.py
@@ -195,12 +195,19 @@ class WinIISTextPluginTest(test_lib.TextPluginTestCase):
         number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
             "event_data"
         )
-        self.assertEqual(number_of_event_data, 15)
+        self.assertEqual(number_of_event_data, 16)
 
         number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
             "extraction_warning"
         )
         self.assertEqual(number_of_warnings, 0)
+
+        expected_event_values = {
+            "dest_ip": "fe80::1ff:fe23:4567:890a%3",
+            "source_ip": "::1",
+        }
+        event_data = storage_writer.GetAttributeContainerByIndex("event_data", 15)
+        self.CheckEventData(event_data, expected_event_values)
 
         number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
             "recovery_warning"


### PR DESCRIPTION
## One line description of pull request

Add IIS parser support for IPv6 addresses containing a zone index.

## Description

Fixes #4903.

IIS logs can contain scoped IPv6 addresses such as `fe80::1ff:fe23:4567:890a%3`. The parser previously rejected the `%3` suffix and did not emit an event.

## Changes and testing

- Extend the IPv6 grammar with an optional zone index.
- Preserve the complete scoped address in `dest_ip`.
- Add an edge-case fixture and regression assertion.
- Ran `tests/parsers/text_plugins/iis.py` in the official Plaso container: 6 tests passed.

## Checklist:
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated.
* [x] Test data has a Plaso compatible license. If the test data was not authored by you (the contributor), make sure to mention its original source in ACKNOWLEDGEMENTS.
* [x] Reviewer assigned.
* [x] Automated checks (GitHub Actions, AppVeyor) pass.
