### PR TITLE
Changes to Linux tagging rules to also match the sshd-session reporter #5183

### DIFF
--- a/plaso/data/tag_linux.txt
+++ b/plaso/data/tag_linux.txt
@@ -14,7 +14,7 @@ login
   data_type is 'linux:utmp:event' AND login_type == 7
   data_type is 'selinux:line' AND audit_type is 'LOGIN'
   reporter is 'login' AND (message_body contains 'logged in' OR message_body contains 'ROOT LOGIN' OR message_body contains 'session opened')
-  reporter is 'sshd' AND (message_body contains 'session opened' OR message_body contains 'Starting session')
+  (reporter is 'sshd' OR reporter is 'sshd-session') AND (message_body contains 'session opened' OR message_body contains 'Starting session')
   reporter is 'dovecot' AND message_body contains 'imap-login: Login:'
   reporter is 'postfix/submission/smtpd' AND message_body contains 'sasl_'
 
@@ -23,8 +23,8 @@ login_failed
   data_type is 'selinux:line' AND audit_type is 'ANOM_LOGIN_FAILURES'
   data_type is 'selinux:line' AND audit_type is 'USER_LOGIN' AND message_body contains 'res=failed'
   data_type is 'syslog:line' AND message_body contains 'pam_tally2'
-  (reporter is 'sshd' OR reporter is 'login' OR reporter is 'postfix/submission/smtpd' OR reporter is 'sudo') AND message_body contains 'uthentication fail'
-  reporter is 'sshd' AND (message_body contains 'Access denied for user' OR message_body contains 'not allowed because')
+  (reporter is 'sshd' OR reporter is 'sshd-session' OR reporter is 'login' OR reporter is 'postfix/submission/smtpd' OR reporter is 'sudo') AND message_body contains 'uthentication fail'
+  (reporter is 'sshd' OR reporter is 'sshd-session') AND (message_body contains 'Access denied for user' OR message_body contains 'not allowed because')
   (reporter is 'xscreensaver' or reporter is 'login') AND message_body contains 'FAILED LOGIN'
   reporter is 'su' and message_body contains 'DENIED'
   reporter is 'nologin'
@@ -60,7 +60,7 @@ logout
   # This will also flag dead gettys that init kills during shutdown/reboot (at least with SysV init)
   data_type is 'linux:utmp:event' AND login_type == 8 AND terminal != '' AND pid != 0
   reporter is 'login' AND message_body contains 'session closed'
-  reporter is 'sshd' AND (message_body contains 'session closed' OR message_body contains 'Close session')
+  (reporter is 'sshd' OR reporter is 'sshd-session') AND (message_body contains 'session closed' OR message_body contains 'Close session')
   reporter is 'systemd-logind' AND message_body contains 'logged out'
   reporter is 'dovecot' AND message_body contains 'Logged out'
   data_type is 'selinux:line' AND audit_type is 'USER_LOGOUT'

--- a/tests/data/tag_linux.py
+++ b/tests/data/tag_linux.py
@@ -122,11 +122,12 @@ class LinuxTaggingFileTest(test_lib.TaggingFileTestCase):
             syslog.SyslogLineEventData, attribute_values_per_name, ["login"]
         )
 
-        # Test: reporter is 'sshd' AND (message_body contains 'session opened' OR
+        # Test: (reporter is 'sshd' OR reporter is 'sshd-session') AND
+        #       (message_body contains 'session opened' OR
         #       message_body contains 'Starting session')
         attribute_values_per_name = {
             "message_body": ["session opened", "Starting session"],
-            "reporter": ["sshd"],
+            "reporter": ["sshd", "sshd-session"],
         }
         self._CheckTaggingRule(
             syslog.SyslogLineEventData, attribute_values_per_name, ["login"]
@@ -175,6 +176,7 @@ class LinuxTaggingFileTest(test_lib.TaggingFileTestCase):
         )
 
         # Test: (reporter is 'sshd' OR
+        #        reporter is 'sshd-session' OR
         #        reporter is 'login' OR
         #        reporter is 'postfix/submission/smtpd' OR
         #        reporter is 'sudo') AND
@@ -185,7 +187,24 @@ class LinuxTaggingFileTest(test_lib.TaggingFileTestCase):
                 "authentication failure",
                 "Authentication failure",
             ],
-            "reporter": ["login", "postfix/submission/smtpd", "sshd", "sudo"],
+            "reporter": [
+                "login",
+                "postfix/submission/smtpd",
+                "sshd",
+                "sshd-session",
+                "sudo",
+            ],
+        }
+        self._CheckTaggingRule(
+            syslog.SyslogLineEventData, attribute_values_per_name, ["login_failed"]
+        )
+
+        # Test: (reporter is 'sshd' OR reporter is 'sshd-session') AND
+        #       (message_body contains 'Access denied for user' OR
+        #       message_body contains 'not allowed because')
+        attribute_values_per_name = {
+            "message_body": ["Access denied for user", "not allowed because"],
+            "reporter": ["sshd", "sshd-session"],
         }
         self._CheckTaggingRule(
             syslog.SyslogLineEventData, attribute_values_per_name, ["login_failed"]
@@ -355,11 +374,12 @@ class LinuxTaggingFileTest(test_lib.TaggingFileTestCase):
             syslog.SyslogLineEventData, attribute_values_per_name, ["logout"]
         )
 
-        # Test: reporter is 'sshd' AND (message_body contains 'session closed' OR
+        # Test: (reporter is 'sshd' OR reporter is 'sshd-session') AND
+        #       (message_body contains 'session closed' OR
         #       message_body contains 'Close session')
         attribute_values_per_name = {
             "message_body": ["Close session", "session closed"],
-            "reporter": ["sshd"],
+            "reporter": ["sshd", "sshd-session"],
         }
         self._CheckTaggingRule(
             syslog.SyslogLineEventData, attribute_values_per_name, ["logout"]


### PR DESCRIPTION
Follows #5193, for #5183.

OpenSSH 9.8 split the server into a listener binary, `sshd`, and a per-session binary,
`sshd-session`, which writes the session and authentication messages. #5193 recognises both names
in the syslog plugins. In that change I expected the four rules in `plaso/data/tag_linux.txt` that
select on a reporter of `sshd` to apply again as a result. They select on the reporter value stored
on the event, which is the name as logged, so the rules need the per-session name as well. This
adds it to the four rules:

| Label | Message text the rule selects on |
|---|---|
| `login` | `session opened`, `Starting session` |
| `login_failed` | `uthentication fail` |
| `login_failed` | `Access denied for user`, `not allowed because` |
| `logout` | `session closed`, `Close session` |

`tests/data/tag_linux.py` now covers both reporter names for each rule. The third rule had no test;
one is added.

### Measured effect

Events extracted by the syslog plugin from the two `/var/log/auth.log` files measured in #5193,
tagged with `tag_linux.txt`:

| | Label | before | after |
|---|---|---|---|
| Ubuntu 26.04, OpenSSH 10.2p1 | `login` | 5 | 245 |
| | `login_failed` | 8 | 14 |
| | `logout` | 241 | 479 |
| Ubuntu 24.04, OpenSSH 9.6p1 | `login` | 18 | 18 |
| | `login_failed` | 6 | 6 |
| | `logout` | 32 | 32 |

The additional events on the 26.04 host are all `sshd-session` records: 240 `session opened`, 6
`authentication failure` and 238 `session closed`. The 24.04 host, where the reporter is `sshd`, is
unchanged, as are the other labels on both hosts.

### Backward compatibility

Only the four rules are extended; each still matches everything it matched before. No parser, data
type or attribute is involved.

## Checklist:
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated.
* [x] Test data has a Plaso compatible license. If the test data was not authored by you (the contributor), make sure to mention its original source in ACKNOWLEDGEMENTS.
* [x] Reviewer assigned.
* [x] Automated checks (GitHub Actions, AppVeyor) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
