### PR TITLE
Added support for invalid user authentication failures to the syslog SSH parser #5183

### DIFF
--- a/plaso/data/formatters/generic.yaml
+++ b/plaso/data/formatters/generic.yaml
@@ -1030,8 +1030,13 @@ source: 'Log File'
 ---
 type: 'conditional'
 data_type: 'syslog:ssh:failed_connection'
+boolean_helpers:
+- input_attribute: 'is_invalid_user'
+  output_attribute: 'invalid_user_string'
+  value_if_true: 'invalid user'
 message:
 - 'Unsuccessful connection of user: {username} '
+- '({invalid_user_string}) '
 - 'from {ip_address}:'
 - '{port} '
 - 'using authentication method: {authentication_method} '

--- a/plaso/parsers/text_plugins/syslog.py
+++ b/plaso/parsers/text_plugins/syslog.py
@@ -120,9 +120,20 @@ class SyslogSSHLoginEventData(SyslogSSHEventData):
 
 
 class SyslogSSHFailedConnectionEventData(SyslogSSHEventData):
-    """SSH failed connection event data."""
+    """SSH failed connection event data.
+
+    Attributes:
+      is_invalid_user (bool): True if sshd wrote the user name as an invalid user,
+          which is a name that does not resolve to an account that is allowed to
+          log in.
+    """
 
     DATA_TYPE = "syslog:ssh:failed_connection"
+
+    def __init__(self):
+        """Initializes event data."""
+        super().__init__()
+        self.is_invalid_user = None
 
 
 class SyslogSSHOpenedConnectionEventData(SyslogSSHEventData):
@@ -192,10 +203,16 @@ class BaseSyslogTextPlugin(interface.TextPlugin):
 
     _SSH_PORT = pyparsing.Word(pyparsing.nums, max=5).set_results_name("port")
 
+    # sshd writes "invalid user" before the user name when the name does not
+    # resolve to an account that is allowed to log in, see auth_log in OpenSSH
+    # auth.c.
     _SSHD_FAILED_CONNECTION = (
         pyparsing.Literal("Failed")
         + _SSHD_AUTHENTICATION_METHOD.set_results_name("authentication_method")
         + pyparsing.Literal("for")
+        + pyparsing.Optional(
+            pyparsing.Literal("invalid user").set_results_name("invalid_user")
+        )
         + _SSH_USERNAME
         + pyparsing.Literal("from")
         + _SSH_IP_ADDRESS.set_results_name("ip_address")
@@ -293,6 +310,7 @@ class BaseSyslogTextPlugin(interface.TextPlugin):
 
         if key == "failed_connection":
             event_data = SyslogSSHFailedConnectionEventData()
+            event_data.is_invalid_user = structure.get("invalid_user") is not None
         elif key == "login":
             event_data = SyslogSSHLoginEventData()
         elif key == "opened_connection":

--- a/test_data/syslog/syslog_ssh.log
+++ b/test_data/syslog/syslog_ssh.log
@@ -7,3 +7,4 @@ Mar 11 22:55:32 ubuntu2015 sshd[3]:  Failed password for root from 188.124.3.41 
 Mar 11 22:55:33 ubuntu2015 sshd[3]:  Accepted publickey for fred from 192.0.2.60 port 60594 ssh2: RSA e8:31:68:c7:01:2d:25:20:36:8f:50:5d:f9:ee:70:4c
 Mar 11 22:55:34 ubuntu2015 sshd[3]:  Accepted publickey for fred from 192.0.2.60 port 20042 ssh2
 Mar 11 22:55:35 ubuntu2015 sshd[3]:  Accepted publickey for fred from 192.0.2.60 port 59915 ssh2: RSA SHA256:5xyQ+PG1Z3CIiShclJ2iNya5TOdKDgE/HrOXr21IdOo
+Jul 28 22:16:48 ubuntu24 sshd[2118]: Failed password for invalid user admin from 192.168.1.92 port 35932 ssh2

--- a/tests/parsers/text_plugins/syslog.py
+++ b/tests/parsers/text_plugins/syslog.py
@@ -573,7 +573,7 @@ class TraditionalSyslogTextPluginTest(test_lib.TextPluginTestCase):
         number_of_event_data = storage_writer.GetNumberOfAttributeContainers(
             "event_data"
         )
-        self.assertEqual(number_of_event_data, 9)
+        self.assertEqual(number_of_event_data, 10)
 
         number_of_warnings = storage_writer.GetNumberOfAttributeContainers(
             "extraction_warning"
@@ -626,6 +626,7 @@ class TraditionalSyslogTextPluginTest(test_lib.TextPluginTestCase):
             "authentication_method": "password",
             "data_type": "syslog:ssh:failed_connection",
             "ip_address": "188.124.3.41",
+            "is_invalid_user": False,
             "last_written_time": "0000-03-11T22:55:32",
             "port": "32889",
             "protocol": "ssh2",
@@ -644,6 +645,21 @@ class TraditionalSyslogTextPluginTest(test_lib.TextPluginTestCase):
             "username": "fred",
         }
         event_data = storage_writer.GetAttributeContainerByIndex("event_data", 8)
+        self.CheckEventData(event_data, expected_event_values)
+
+        # Unsuccessful authentication for a user name that does not resolve to an
+        # account, which sshd writes with "invalid user" before the name.
+        expected_event_values = {
+            "authentication_method": "password",
+            "data_type": "syslog:ssh:failed_connection",
+            "ip_address": "192.168.1.92",
+            "is_invalid_user": True,
+            "last_written_time": "0000-07-28T22:16:48",
+            "port": "35932",
+            "protocol": "ssh2",
+            "username": "admin",
+        }
+        event_data = storage_writer.GetAttributeContainerByIndex("event_data", 9)
         self.CheckEventData(event_data, expected_event_values)
 
     def testProcessSshdSession(self):


### PR DESCRIPTION
Follows #5193, for #5183 (question 2).

sshd writes `invalid user` before the user name of an unsuccessful authentication when the name
does not resolve to an account that is allowed to log in:

```
Failed password for invalid user admin from 192.168.1.92 port 35932 ssh2
```

The format string in `auth_log()` in OpenSSH
[`auth.c`](https://github.com/openssh/openssh-portable/blob/V_10_2_P1/auth.c#L294-L301) is
`"%s %s%s%s for %s%.100s from %.200s port %d ssh2%s%s"`, where the value before the name is
`"invalid user "` when the authentication context is not valid, and empty otherwise. The context is
not valid when `getpwnam()` does not find the name, and also when the account exists but
`allowed_user()` declines it, for example because it is locked or listed in `DenyUsers`. The 9.6p1
release has the same string.

Since #5193 the user name is the text preceding ` from `, so these records reach
`syslog:ssh:failed_connection` with the marker as part of the name: `username` holds
`invalid user admin`. This change matches the marker separately, so `username` holds the name as
the client sent it, and records the marker as a new attribute of `syslog:ssh:failed_connection`:

- `is_invalid_user` (bool): True if sshd wrote the user name as an invalid user.

The formatter adds `(invalid user)` after the name when it is set:
`Unsuccessful connection of user: admin (invalid user) from 192.168.1.92:35932 using authentication method: password ssh pid: 2118`

### Measured effect

The two `/var/log/auth.log` files measured in #5193, run through the syslog plugin. Event counts
per data type are unchanged; the change is to the `username` value of the records that carry the
marker.

| | `failed_connection` records | with the marker | `username` before | `username` after |
|---|---|---|---|---|
| Ubuntu 26.04, OpenSSH 10.2p1 | 6 | 2 | `invalid user admin`, `invalid user oracle` | `admin`, `oracle` |
| Ubuntu 24.04, OpenSSH 9.6p1 | 5 | 3 | `invalid user admin`, `invalid user oracle`, `invalid user postgres` | `admin`, `oracle`, `postgres` |

`is_invalid_user` is True on those five records and False on the other six.

### Backward compatibility

`is_invalid_user` is a new attribute on an existing data type; no attribute is removed or renamed
and no data type is added. The formatter only adds text when the attribute is True, so events in
existing storage files render as before. The timeliner entry is unchanged, since no timestamp is
involved, and the verification grammar is untouched, so the plugins claim exactly the same files.
Records without the marker parse as before; the existing assertions on them hold, and the one on
the `Failed password for root` record of `syslog_ssh.log` now also asserts the attribute is False.

### Test data

One record is appended to `test_data/syslog/syslog_ssh.log`: the `invalid user` record from the
Ubuntu 24.04 (OpenSSH 9.6p1) capture used for #5183, written in the timestamp format of that file.
`testProcessSshd` asserts on it.

## Checklist:
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated.
* [x] Test data has a Plaso compatible license. If the test data was not authored by you (the contributor), make sure to mention its original source in ACKNOWLEDGEMENTS.
* [x] Reviewer assigned.
* [x] Automated checks (GitHub Actions, AppVeyor) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
