### PR TITLE
Changes to the analysis engine to determine the total number of events #5210

### DIFF
--- a/plaso/multi_process/analysis_engine.py
+++ b/plaso/multi_process/analysis_engine.py
@@ -653,6 +653,7 @@ class AnalysisMultiProcessEngine(task_engine.TaskMultiProcessEngine):
 
         self._event_labels_counter = collections.Counter()
 
+        total_number_of_events = 0
         if storage_writer.HasAttributeContainers("parser_count"):
             parsers_counter = {
                 parser_count.name: parser_count.number_of_events
@@ -661,11 +662,6 @@ class AnalysisMultiProcessEngine(task_engine.TaskMultiProcessEngine):
                 )
             }
             total_number_of_events = parsers_counter["total"]
-
-        else:
-            total_number_of_events = 0
-            for stored_session in storage_writer.GetSessions():
-                total_number_of_events += stored_session.parsers_counter["total"]
 
         self._events_status.total_number_of_events = total_number_of_events
 

--- a/tests/multi_process/analysis_engine.py
+++ b/tests/multi_process/analysis_engine.py
@@ -130,6 +130,54 @@ class AnalysisEngineMultiProcessEngineTest(test_lib.MultiProcessingTestCase):
             finally:
                 storage_writer.Close()
 
+    def testAnalyzeEventsWithoutParserCount(self):
+        """Tests the AnalyzeEvents function on a storage file without counts."""
+        test_tagging_file_path = self._GetTestFilePath(["tagging_file", "valid.txt"])
+        self._SkipIfPathNotExists(test_tagging_file_path)
+
+        session = sessions.Session()
+
+        data_location = ""
+
+        analysis_plugin = tagging.TaggingAnalysisPlugin()
+        analysis_plugin.SetAndLoadTagFile(test_tagging_file_path)
+
+        analysis_plugins = {"tagging": analysis_plugin}
+
+        configuration = configurations.ProcessingConfiguration()
+        test_engine = analysis_engine.AnalysisMultiProcessEngine()
+
+        with shared_test_lib.TempDirectory() as temp_directory:
+            temp_file = os.path.join(temp_directory, "storage.plaso")
+
+            storage_writer = storage_factory.StorageFactory.CreateStorageWriter(
+                definitions.DEFAULT_STORAGE_FORMAT
+            )
+
+            storage_writer.Open(path=temp_file)
+
+            try:
+                # A storage file of an extraction that generated no events has no
+                # parser count attribute containers.
+                storage_writer.AddAttributeContainer(session)
+
+                has_parser_count = storage_writer.HasAttributeContainers("parser_count")
+                self.assertFalse(has_parser_count)
+
+                test_engine.AnalyzeEvents(
+                    session,
+                    storage_writer,
+                    data_location,
+                    analysis_plugins,
+                    configuration,
+                    storage_file_path=temp_directory,
+                )
+
+                self.assertEqual(test_engine._events_status.total_number_of_events, 0)
+
+            finally:
+                storage_writer.Close()
+
     def testAnalyzeEventsWithEventFilter(self):
         """Tests the AnalyzeEvents function with an event filter."""
         test_file_path = self._GetTestFilePath(["psort_test.plaso"])


### PR DESCRIPTION
Implements #5210.

`AnalyzeEvents` determined the total number of events from the `parsers_counter`
attribute of a session when a storage file has no `parser_count` attribute containers.
`Session` carried that attribute until 818154965, "Deprecated use of SessionStart and
SessionCompletion #3880 (#4544)", which moved the counts into `parser_count` attribute
containers, so that path raised an `AttributeError`:

```
  File "plaso/multi_process/analysis_engine.py", line 668, in AnalyzeEvents
    total_number_of_events += stored_session.parsers_counter["total"]
AttributeError: 'Session' object has no attribute 'parsers_counter'
```

The total number of events is now determined the same way as in the output and
formatting engine (`plaso/multi_process/output_engine.py:605-614`): it starts at 0 and
the `parser_count` containers are read when they are present.

```python
total_number_of_events = 0
if storage_writer.HasAttributeContainers("parser_count"):
    parsers_counter = {
        parser_count.name: parser_count.number_of_events
        for parser_count in storage_writer.GetAttributeContainers("parser_count")
    }
    total_number_of_events = parsers_counter["total"]
```

### Effect

An extraction that generates no events writes a session but no `parser_count`
containers, which is the state that reached the removed branch:

```bash
mkdir /tmp/emptydir
python3 -m plaso.scripts.log2timeline --unattended --status-view none \
    --parsers=bencode --storage-file empty.plaso /tmp/emptydir
python3 -m plaso.scripts.psort --status-view none --analysis tagging \
    --tagging-file plaso/data/tag_linux.txt -o null empty.plaso
```

| | before | after |
|---|---|---|
| `psort --analysis` | exit 1, `AttributeError` | exit 0 |
| `psort` without `--analysis` | exit 0 | exit 0 |

### Backward compatibility

A storage file that has `parser_count` containers takes the same path as before and its
total is unchanged; `psort` without `--analysis` is not affected either way. No
attribute container, data type or attribute is added, removed or renamed.
`GetSessions` (`plaso/storage/reader.py:179`) has no remaining caller in the engines; it
is left in place as part of the storage reader interface.

### Tests

`testAnalyzeEventsWithoutParserCount` analyses a storage file that holds a session and
no `parser_count` containers, and asserts the total number of events is 0. It fails on
current main with the traceback above.

`tests/multi_process/analysis_engine.py` and `tests/multi_process/output_engine.py`
pass unmodified otherwise.

## Checklist:
* [x] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated.
* [x] Test data has a Plaso compatible license. If the test data was not authored by you (the contributor), make sure to mention its original source in ACKNOWLEDGEMENTS.
* [x] Reviewer assigned.
* [x] Automated checks (GitHub Actions, AppVeyor) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
